### PR TITLE
Display category filter as tree on main page

### DIFF
--- a/price_manager/core/filters.py
+++ b/price_manager/core/filters.py
@@ -1,21 +1,13 @@
 from django_filters import filters, FilterSet
 from .models import *
 from django import forms
-from dal import autocomplete
 
 class MainProductFilter(FilterSet):
   search = filters.CharFilter(method='search_method', label='Поиск')
   anti_search = filters.CharFilter(method='anti_search_method', label='Исключения')
   category = filters.ModelMultipleChoiceFilter(
         queryset=Category.objects.all(),
-        widget=autocomplete.ModelSelect2Multiple(
-            url='category-autocomplete',
-            attrs={
-              'class':'form-control select2-multiple',
-              'data-placeholder': 'Выберите категории...',
-              'data-minimum-input-length': 2,
-            }
-        )
+        widget=forms.CheckboxSelectMultiple
     )
   supplier = filters.ModelMultipleChoiceFilter(field_name='supplier',
                                                queryset=Supplier.objects.all(),

--- a/price_manager/core/templates/includes/category_tree_filter.html
+++ b/price_manager/core/templates/includes/category_tree_filter.html
@@ -1,0 +1,9 @@
+<div class="category-tree">
+  <ul class="list-unstyled">
+    {% for node in category_tree %}
+      {% include 'includes/category_tree_node.html' with node=node field=field selected_categories=selected_categories %}
+    {% empty %}
+      <li class="text-muted">Нет доступных категорий</li>
+    {% endfor %}
+  </ul>
+</div>

--- a/price_manager/core/templates/includes/category_tree_node.html
+++ b/price_manager/core/templates/includes/category_tree_node.html
@@ -1,0 +1,20 @@
+<li>
+  <div class="form-check">
+    <input
+        class="form-check-input"
+        type="checkbox"
+        name="{{ field.html_name }}"
+        value="{{ node.category.pk }}"
+        id="{{ field.auto_id }}_{{ node.category.pk }}"
+        {% if node.category.pk|stringformat:'s' in selected_categories %}checked{% endif %}
+    >
+    <label class="form-check-label" for="{{ field.auto_id }}_{{ node.category.pk }}">{{ node.category.name }}</label>
+  </div>
+  {% if node.children %}
+    <ul class="list-unstyled ms-3">
+      {% for child in node.children %}
+        {% include 'includes/category_tree_node.html' with node=child field=field selected_categories=selected_categories %}
+      {% endfor %}
+    </ul>
+  {% endif %}
+</li>

--- a/price_manager/core/templates/main/main.html
+++ b/price_manager/core/templates/main/main.html
@@ -33,7 +33,11 @@
       <div class="row mt-3">
         <div class="form-group">
             <label for="{{ item.id_for_label }}"> {{item.label}} </label>
-            {{ item }}
+            {% if item.name == 'category' %}
+              {% include 'includes/category_tree_filter.html' with field=item category_tree=category_tree selected_categories=selected_categories %}
+            {% else %}
+              {{ item }}
+            {% endif %}
         </div>
       </div>
       {% endfor %}


### PR DESCRIPTION
## Summary
- replace the category filter widget on the main page with a checkbox-based tree view
- build the category hierarchy in the `MainPage` view so the template can render nested categories
- add reusable includes to display the hierarchical category checkboxes in the filter form

## Testing
- python manage.py check *(fails: database connection to localhost:5432 is refused in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfce7710c0832da4e824163190586e