### PR TITLE
Switch supplier/manufacturer filters to select2 multi-select

### DIFF
--- a/price_manager/core/filters.py
+++ b/price_manager/core/filters.py
@@ -9,12 +9,26 @@ class MainProductFilter(FilterSet):
         queryset=Category.objects.all(),
         widget=forms.CheckboxSelectMultiple
     )
-  supplier = filters.ModelMultipleChoiceFilter(field_name='supplier',
-                                               queryset=Supplier.objects.all(),
-                                               widget=forms.CheckboxSelectMultiple)
-  manufacturer = filters.ModelMultipleChoiceFilter(field_name='manufacturer',
-                                               queryset=Manufacturer.objects.all(),
-                                               widget=forms.CheckboxSelectMultiple)
+  supplier = filters.ModelMultipleChoiceFilter(
+      field_name='supplier',
+      queryset=Supplier.objects.all(),
+      widget=forms.SelectMultiple(
+          attrs={
+              'class': 'form-select select2',
+              'data-placeholder': 'Выберите поставщиков'
+          }
+      )
+  )
+  manufacturer = filters.ModelMultipleChoiceFilter(
+      field_name='manufacturer',
+      queryset=Manufacturer.objects.all(),
+      widget=forms.SelectMultiple(
+          attrs={
+              'class': 'form-select select2',
+              'data-placeholder': 'Выберите производителей'
+          }
+      )
+  )
   class Meta:
     model = MainProduct
     fields = ['search', 'anti_search', 'supplier', 'category', 'manufacturer', 'available']

--- a/price_manager/core/templates/main/main.html
+++ b/price_manager/core/templates/main/main.html
@@ -76,5 +76,25 @@
   document.body.addEventListener('htmx:configRequest', (evt) => {
     evt.detail.headers['X-CSRFToken'] = '{{ csrf_token }}';
   });
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const enhanceSelect = (selector) => {
+      const element = window.jQuery ? window.jQuery(selector) : null;
+      if (element && element.length && element.select2) {
+        element.select2({
+          width: '100%',
+          placeholder: element.data('placeholder') || '',
+          allowClear: true,
+          language: {
+            noResults: () => 'Ничего не найдено',
+            searching: () => 'Поиск…'
+          }
+        });
+      }
+    };
+
+    enhanceSelect('#id_supplier');
+    enhanceSelect('#id_manufacturer');
+  });
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- replace supplier and manufacturer checkbox filters with searchable Select2 multi-selects on the main page
- initialize Select2 on the main page to support search, localisation, and clearing selections

## Testing
- python manage.py check *(fails: missing dependency django-autocomplete-light is unavailable in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfd4836b60832da39b9f7c9d43df19