### PR TITLE
Add dynamic filter option updates on main page

### DIFF
--- a/price_manager/core/templates/main/includes/dynamic_filters.html
+++ b/price_manager/core/templates/main/includes/dynamic_filters.html
@@ -1,0 +1,20 @@
+<div class="row mt-3">
+  <div class="form-group">
+    <label for="{{ filter_form.supplier.id_for_label }}">{{ filter_form.supplier.label }}</label>
+    {{ filter_form.supplier }}
+  </div>
+</div>
+
+<div class="row mt-3">
+  <div class="form-group">
+    <label for="{{ filter_form.manufacturer.id_for_label }}">{{ filter_form.manufacturer.label }}</label>
+    {{ filter_form.manufacturer }}
+  </div>
+</div>
+
+<div class="row mt-3">
+  <div class="form-group">
+    <label for="{{ filter_form.category.id_for_label }}">{{ filter_form.category.label }}</label>
+    {% include 'includes/category_tree_filter.html' with field=filter_form.category category_tree=category_tree selected_categories=selected_categories %}
+  </div>
+</div>

--- a/price_manager/core/templates/main/main.html
+++ b/price_manager/core/templates/main/main.html
@@ -27,21 +27,36 @@
 <div class="row">
   <div class="col-md-4 card mt-5">
     <h2>Фильтры</h2>
-    <form method="get" class="form">
-      {{filter.form.media}}
-      {% for item in filter.form %}
+    <form method="get" class="form" id="main-filter-form">
+      {{ filter_form.media }}
+
       <div class="row mt-3">
         <div class="form-group">
-            <label for="{{ item.id_for_label }}"> {{item.label}} </label>
-            {% if item.name == 'category' %}
-              {% include 'includes/category_tree_filter.html' with field=item category_tree=category_tree selected_categories=selected_categories %}
-            {% else %}
-              {{ item }}
-            {% endif %}
+          <label for="{{ filter_form.search.id_for_label }}">{{ filter_form.search.label }}</label>
+          {{ filter_form.search }}
         </div>
       </div>
-      {% endfor %}
-      
+
+      <div class="row mt-3">
+        <div class="form-group">
+          <label for="{{ filter_form.anti_search.id_for_label }}">{{ filter_form.anti_search.label }}</label>
+          {{ filter_form.anti_search }}
+        </div>
+      </div>
+
+      {% if filter_form.available %}
+      <div class="row mt-3">
+        <div class="form-group">
+          <label for="{{ filter_form.available.id_for_label }}">{{ filter_form.available.label }}</label>
+          {{ filter_form.available }}
+        </div>
+      </div>
+      {% endif %}
+
+      <div id="dynamic-filter-options">
+        {% include 'main/includes/dynamic_filters.html' %}
+      </div>
+
       <div class="row mt-3">
           <div class="col-12">
               <button type="submit" class="btn btn-primary">
@@ -77,24 +92,32 @@
     evt.detail.headers['X-CSRFToken'] = '{{ csrf_token }}';
   });
 
-  document.addEventListener('DOMContentLoaded', () => {
-    const enhanceSelect = (selector) => {
-      const element = window.jQuery ? window.jQuery(selector) : null;
-      if (element && element.length && element.select2) {
-        element.select2({
-          width: '100%',
-          placeholder: element.data('placeholder') || '',
-          allowClear: true,
-          language: {
-            noResults: () => 'Ничего не найдено',
-            searching: () => 'Поиск…'
-          }
-        });
-      }
-    };
+  const enhanceSelect = (selector) => {
+    const element = window.jQuery ? window.jQuery(selector) : null;
+    if (element && element.length && element.select2) {
+      element.select2({
+        width: '100%',
+        placeholder: element.data('placeholder') || '',
+        allowClear: true,
+        language: {
+          noResults: () => 'Ничего не найдено',
+          searching: () => 'Поиск…'
+        }
+      });
+    }
+  };
 
+  const initDynamicFilters = () => {
     enhanceSelect('#id_supplier');
     enhanceSelect('#id_manufacturer');
+  };
+
+  document.addEventListener('DOMContentLoaded', initDynamicFilters);
+
+  document.body.addEventListener('htmx:afterSwap', (event) => {
+    if (event.target && event.target.id === 'dynamic-filter-options') {
+      initDynamicFilters();
+    }
   });
 </script>
 {% endblock %}

--- a/price_manager/core/views.py
+++ b/price_manager/core/views.py
@@ -72,36 +72,154 @@ def toggle_basket(request, pk):
     )
     return HttpResponse(html)
 
+def build_category_tree(categories):
+  children_map = defaultdict(list)
+  for category in categories:
+    children_map[category.parent_id].append(category)
+  for siblings in children_map.values():
+    siblings.sort(key=lambda item: item.name.lower())
+  def build_nodes(parent_id):
+    nodes = []
+    for category in children_map.get(parent_id, []):
+      nodes.append({
+          'category': category,
+          'children': build_nodes(category.id)
+      })
+    return nodes
+  return build_nodes(None)
+
+
+def _collect_int_values(values):
+  result = set()
+  for value in values:
+    try:
+      result.add(int(value))
+    except (TypeError, ValueError):
+      continue
+  return result
+
+
+def _expand_category_ids_with_ancestors(category_ids):
+  expanded_ids = set(category_ids)
+  to_process = {category_id for category_id in expanded_ids if category_id is not None}
+  while to_process:
+    parents = set(
+        Category.objects
+        .filter(id__in=to_process)
+        .values_list('parent_id', flat=True)
+    )
+    parents.discard(None)
+    new_ids = parents - expanded_ids
+    if not new_ids:
+      break
+    expanded_ids.update(new_ids)
+    to_process = new_ids
+  expanded_ids.discard(None)
+  return expanded_ids
+
+
+def _get_search_filtered_queryset(request):
+  filter_data = request.GET.copy()
+  for field in ('category', 'supplier', 'manufacturer'):
+    filter_data.pop(field, None)
+  filter_data.pop('page', None)
+  filterset = MainProductFilter(data=filter_data, queryset=MainProduct.objects.all())
+  return filterset.qs
+
+
+def get_main_filter_context(request):
+  filterset = MainProductFilter(data=request.GET or None, queryset=MainProduct.objects.all())
+  filter_form = filterset.form
+
+  queryset = _get_search_filtered_queryset(request)
+
+  selected_supplier_ids = _collect_int_values(request.GET.getlist('supplier'))
+  selected_manufacturer_ids = _collect_int_values(request.GET.getlist('manufacturer'))
+  selected_category_ids = _collect_int_values(request.GET.getlist('category'))
+
+  supplier_ids = set(queryset.values_list('supplier_id', flat=True))
+  supplier_ids.discard(None)
+  supplier_ids.update(selected_supplier_ids)
+
+  manufacturer_ids = set(queryset.values_list('manufacturer_id', flat=True))
+  manufacturer_ids.discard(None)
+  manufacturer_ids.update(selected_manufacturer_ids)
+
+  category_ids = set(queryset.values_list('category_id', flat=True))
+  category_ids.discard(None)
+  category_ids.update(selected_category_ids)
+  category_ids = _expand_category_ids_with_ancestors(category_ids)
+
+  supplier_queryset = Supplier.objects.filter(id__in=supplier_ids).order_by('name') if supplier_ids else Supplier.objects.none()
+  manufacturer_queryset = Manufacturer.objects.filter(id__in=manufacturer_ids).order_by('name') if manufacturer_ids else Manufacturer.objects.none()
+  category_queryset = Category.objects.filter(id__in=category_ids).select_related('parent') if category_ids else Category.objects.none()
+
+  filter_form.fields['supplier'].queryset = supplier_queryset
+  filter_form.fields['manufacturer'].queryset = manufacturer_queryset
+  filter_form.fields['category'].queryset = category_queryset
+
+  selected_categories = {str(value) for value in request.GET.getlist('category') if value}
+
+  category_tree = build_category_tree(list(category_queryset))
+
+  return {
+      'filter_form': filter_form,
+      'category_tree': category_tree,
+      'selected_categories': selected_categories,
+  }
+
+
 class MainPage(SingleTableMixin, FilterView):
   model = MainProduct
   filterset_class = MainProductFilter
   table_class = MainProductListTable
   template_name = 'main/main.html'
+
   def get_table(self, **kwargs):
     return super().get_table(**kwargs, request=self.request)
+
   def get_context_data(self, **kwargs):
     context = super().get_context_data(**kwargs)
-    category_field = context['filter'].form['category']
-    category_list = list(category_field.field.queryset.select_related('parent'))
-    context['category_tree'] = self._build_category_tree(category_list)
-    selected_categories = category_field.value() or []
-    context['selected_categories'] = {str(value) for value in selected_categories}
+    filter_context = get_main_filter_context(self.request)
+    context.update(filter_context)
+
+    filter_form = filter_context['filter_form']
+    dynamic_url = reverse('main-filter-options')
+    hx_attrs = {
+        'hx-get': dynamic_url,
+        'hx-target': '#dynamic-filter-options',
+        'hx-include': '#main-filter-form',
+    }
+
+    search_field = filter_form.fields['search']
+    search_field.widget.attrs.update({
+        **hx_attrs,
+        'hx-trigger': 'keyup changed delay:500ms',
+        'autocomplete': 'off',
+    })
+
+    anti_search_field = filter_form.fields['anti_search']
+    anti_search_field.widget.attrs.update({
+        **hx_attrs,
+        'hx-trigger': 'keyup changed delay:500ms',
+        'autocomplete': 'off',
+    })
+
+    if 'available' in filter_form.fields:
+      filter_form.fields['available'].widget.attrs.update({
+          **hx_attrs,
+          'hx-trigger': 'change',
+      })
+
     return context
-  def _build_category_tree(self, categories):
-    children_map = defaultdict(list)
-    for category in categories:
-      children_map[category.parent_id].append(category)
-    for siblings in children_map.values():
-      siblings.sort(key=lambda item: item.name.lower())
-    def build_nodes(parent_id):
-      nodes = []
-      for category in children_map.get(parent_id, []):
-        nodes.append({
-            'category': category,
-            'children': build_nodes(category.id)
-        })
-      return nodes
-    return build_nodes(None)
+
+
+class MainFilterOptionsView(View):
+  template_name = 'main/includes/dynamic_filters.html'
+
+  def get(self, request, *args, **kwargs):
+    context = get_main_filter_context(request)
+    return render(request, self.template_name, context)
 
 # Обработка поставщика
 

--- a/price_manager/price_manager/urls.py
+++ b/price_manager/price_manager/urls.py
@@ -9,6 +9,7 @@ urlpatterns = [
     path('admin/', admin.site.urls),
 
     path('', views.MainPage.as_view(), name='main'),
+    path('main/filter-options/', views.MainFilterOptionsView.as_view(), name='main-filter-options'),
     
     path('supplier/', views.SupplierList.as_view(), name='supplier'),
     path('supplier/<int:id>/', views.SupplierDetail.as_view(), name='supplier-detail'),


### PR DESCRIPTION
## Summary
- add helper utilities to compute filtered supplier, manufacturer, and category options for the main page filters
- render filter inputs explicitly and introduce an HTMX endpoint to refresh available options dynamically
- ensure Select2 widgets are re-initialised after HTMX swaps and expose the new endpoint via project URLs

## Testing
- `python price_manager/manage.py test` *(fails: ModuleNotFoundError: No module named 'dal')*


------
https://chatgpt.com/codex/tasks/task_e_68cfd8eb5d1c832d8bf343268132950e