### PR TITLE
Wrap advanced filters in accordion

### DIFF
--- a/price_manager/core/templates/main/includes/dynamic_filters.html
+++ b/price_manager/core/templates/main/includes/dynamic_filters.html
@@ -1,0 +1,5 @@
+{% include 'main/includes/filter_field.html' with field=filter_form.supplier container_id='supplier-filter-container' header_id='supplier-filter-header' collapse_id='supplier-filter-collapse' accordion_parent_id='main-filter-accordion' hx_swap_oob=True %}
+
+{% include 'main/includes/filter_field.html' with field=filter_form.manufacturer container_id='manufacturer-filter-container' header_id='manufacturer-filter-header' collapse_id='manufacturer-filter-collapse' accordion_parent_id='main-filter-accordion' hx_swap_oob=True %}
+
+{% include 'main/includes/filter_field.html' with field=filter_form.category container_id='category-filter-container' header_id='category-filter-header' collapse_id='category-filter-collapse' accordion_parent_id='main-filter-accordion' is_category=True category_tree=category_tree selected_categories=selected_categories hx_swap_oob=True %}

--- a/price_manager/core/templates/main/includes/filter_field.html
+++ b/price_manager/core/templates/main/includes/filter_field.html
@@ -1,0 +1,27 @@
+<div id="{{ container_id }}" class="accordion-item"{% if hx_swap_oob %} hx-swap-oob="true"{% endif %}>
+  <h2 class="accordion-header" id="{{ header_id }}">
+    <button
+        class="accordion-button collapsed"
+        type="button"
+        data-bs-toggle="collapse"
+        data-bs-target="#{{ collapse_id }}"
+        aria-expanded="false"
+        aria-controls="{{ collapse_id }}">
+      {{ field.label }}
+    </button>
+  </h2>
+  <div
+      id="{{ collapse_id }}"
+      class="accordion-collapse collapse"
+      aria-labelledby="{{ header_id }}"
+      {% if accordion_parent_id %}data-bs-parent="#{{ accordion_parent_id }}"{% endif %}>
+    <div class="accordion-body">
+      {% if not is_category %}
+        <label for="{{ field.id_for_label }}" class="form-label visually-hidden">{{ field.label }}</label>
+        {{ field }}
+      {% else %}
+        {% include 'includes/category_tree_filter.html' with field=field category_tree=category_tree selected_categories=selected_categories %}
+      {% endif %}
+    </div>
+  </div>
+</div>

--- a/price_manager/core/templates/main/main.html
+++ b/price_manager/core/templates/main/main.html
@@ -27,21 +27,42 @@
 <div class="row">
   <div class="col-md-4 card mt-5">
     <h2>Фильтры</h2>
-    <form method="get" class="form">
-      {{filter.form.media}}
-      {% for item in filter.form %}
+    <form method="get" class="form" id="main-filter-form">
+      {{ filter_form.media }}
+
+      <div id="filters-update-sink" class="d-none"></div>
+
       <div class="row mt-3">
         <div class="form-group">
-            <label for="{{ item.id_for_label }}"> {{item.label}} </label>
-            {% if item.name == 'category' %}
-              {% include 'includes/category_tree_filter.html' with field=item category_tree=category_tree selected_categories=selected_categories %}
-            {% else %}
-              {{ item }}
-            {% endif %}
+          <label for="{{ filter_form.search.id_for_label }}">{{ filter_form.search.label }}</label>
+          {{ filter_form.search }}
         </div>
       </div>
-      {% endfor %}
-      
+
+      <div class="row mt-3">
+        <div class="form-group">
+          <label for="{{ filter_form.anti_search.id_for_label }}">{{ filter_form.anti_search.label }}</label>
+          {{ filter_form.anti_search }}
+        </div>
+      </div>
+
+      {% if filter_form.available %}
+      <div class="row mt-3">
+        <div class="form-group">
+          <label for="{{ filter_form.available.id_for_label }}">{{ filter_form.available.label }}</label>
+          {{ filter_form.available }}
+        </div>
+      </div>
+      {% endif %}
+
+      <div class="accordion mt-3" id="main-filter-accordion">
+        {% include 'main/includes/filter_field.html' with field=filter_form.supplier container_id='supplier-filter-container' header_id='supplier-filter-header' collapse_id='supplier-filter-collapse' accordion_parent_id='main-filter-accordion' %}
+
+        {% include 'main/includes/filter_field.html' with field=filter_form.manufacturer container_id='manufacturer-filter-container' header_id='manufacturer-filter-header' collapse_id='manufacturer-filter-collapse' accordion_parent_id='main-filter-accordion' %}
+
+        {% include 'main/includes/filter_field.html' with field=filter_form.category container_id='category-filter-container' header_id='category-filter-header' collapse_id='category-filter-collapse' accordion_parent_id='main-filter-accordion' is_category=True category_tree=category_tree selected_categories=selected_categories %}
+      </div>
+
       <div class="row mt-3">
           <div class="col-12">
               <button type="submit" class="btn btn-primary">
@@ -77,24 +98,45 @@
     evt.detail.headers['X-CSRFToken'] = '{{ csrf_token }}';
   });
 
-  document.addEventListener('DOMContentLoaded', () => {
-    const enhanceSelect = (selector) => {
-      const element = window.jQuery ? window.jQuery(selector) : null;
-      if (element && element.length && element.select2) {
-        element.select2({
-          width: '100%',
-          placeholder: element.data('placeholder') || '',
-          allowClear: true,
-          language: {
-            noResults: () => 'Ничего не найдено',
-            searching: () => 'Поиск…'
-          }
-        });
-      }
-    };
+  const enhanceSelect = (selector) => {
+    const element = window.jQuery ? window.jQuery(selector) : null;
+    if (element && element.length && element.select2) {
+      element.select2({
+        width: '100%',
+        placeholder: element.data('placeholder') || '',
+        allowClear: true,
+        language: {
+          noResults: () => 'Ничего не найдено',
+          searching: () => 'Поиск…'
+        }
+      });
+    }
+  };
 
+  const initDynamicFilters = () => {
     enhanceSelect('#id_supplier');
     enhanceSelect('#id_manufacturer');
+  };
+
+  document.addEventListener('DOMContentLoaded', initDynamicFilters);
+
+  const shouldEnhance = (target) => {
+    if (!target) {
+      return false;
+    }
+    return ['supplier-filter-container', 'manufacturer-filter-container'].includes(target.id);
+  };
+
+  document.body.addEventListener('htmx:afterSwap', (event) => {
+    if (event.target && event.target.id === 'filters-update-sink') {
+      initDynamicFilters();
+    }
+  });
+
+  document.body.addEventListener('htmx:oobAfterSwap', (event) => {
+    if (shouldEnhance(event.detail && event.detail.target)) {
+      initDynamicFilters();
+    }
   });
 </script>
 {% endblock %}

--- a/price_manager/price_manager/urls.py
+++ b/price_manager/price_manager/urls.py
@@ -9,6 +9,7 @@ urlpatterns = [
     path('admin/', admin.site.urls),
 
     path('', views.MainPage.as_view(), name='main'),
+    path('main/filter-options/', views.MainFilterOptionsView.as_view(), name='main-filter-options'),
     
     path('supplier/', views.SupplierList.as_view(), name='supplier'),
     path('supplier/<int:id>/', views.SupplierDetail.as_view(), name='supplier-detail'),


### PR DESCRIPTION
## Summary
- wrap supplier, manufacturer, and category filter sections in a shared accordion container on the main page
- render the accordion-capable filter partial with collapse metadata for both the initial page and dynamic HTMX updates
- keep the original inputs accessible by adding visually hidden labels inside the accordion body for select fields

## Testing
- `python price_manager/manage.py test` *(fails: ModuleNotFoundError: No module named 'dal')*

------
https://chatgpt.com/codex/tasks/task_e_68cfd8eb5d1c832d8bf343268132950e