### PR TITLE
Add available supplier and manufacturer info to main filter

### DIFF
--- a/price_manager/core/templates/main/main.html
+++ b/price_manager/core/templates/main/main.html
@@ -43,6 +43,28 @@
         </div>
         {%endfor%}
 
+        {% if available_suppliers %}
+        <div class="mt-4">
+          <h6 class="mb-2">Доступные поставщики ({{ available_suppliers|length }})</h6>
+          <div class="d-flex flex-wrap gap-2">
+            {% for supplier in available_suppliers %}
+            <span class="badge text-bg-light border text-wrap">{{ supplier }}</span>
+            {% endfor %}
+          </div>
+        </div>
+        {% endif %}
+
+        {% if available_manufacturers %}
+        <div class="mt-4">
+          <h6 class="mb-2">Доступные производители ({{ available_manufacturers|length }})</h6>
+          <div class="d-flex flex-wrap gap-2">
+            {% for manufacturer in available_manufacturers %}
+            <span class="badge text-bg-light border text-wrap">{{ manufacturer }}</span>
+            {% endfor %}
+          </div>
+        </div>
+        {% endif %}
+
         <!-- Кнопки -->
         <div class=" d-flex gap-2 mt-5">
           <button type="submit" class="btn btn-primary">

--- a/price_manager/core/views.py
+++ b/price_manager/core/views.py
@@ -68,6 +68,21 @@ class MainPage(SingleTableMixin, FilterView):
   template_name = 'main/main.html'
   def get_table(self, **kwargs):
     return super().get_table(**kwargs, request=self.request)
+  def get_context_data(self, **kwargs):
+    context = super().get_context_data(**kwargs)
+    queryset = context.get('filter').qs if context.get('filter') else MainProduct.objects.none()
+    context['available_suppliers'] = list(
+      queryset.order_by('supplier__name')
+              .values_list('supplier__name', flat=True)
+              .distinct()
+    )
+    context['available_manufacturers'] = list(
+      queryset.filter(manufacturer__isnull=False)
+              .order_by('manufacturer__name')
+              .values_list('manufacturer__name', flat=True)
+              .distinct()
+    )
+    return context
 
 # Обработка поставщика
 


### PR DESCRIPTION
## Summary
- enrich main page filter context with the names of suppliers and manufacturers found in the filtered dataset
- render the available supplier and manufacturer lists in the filter card to give users quick visibility

## Testing
- python price_manager/manage.py test *(fails: database server is not running in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cffce9d998832d9845781551de3b0b