### PR TITLE
Show available suppliers and manufacturers in main filter

### DIFF
--- a/price_manager/core/templates/main/main.html
+++ b/price_manager/core/templates/main/main.html
@@ -33,6 +33,28 @@
       <form method="get" class="card p-3 shadow-sm">
         <h5 class="mb-3">Фильтры</h5>
 
+        <div class="mb-3">
+          <h6 class="fw-semibold">Доступные поставщики</h6>
+          <ul class="list-unstyled small mb-0">
+            {% for supplier in available_suppliers %}
+              <li>{{ supplier.name }}</li>
+            {% empty %}
+              <li class="text-muted">Нет доступных поставщиков</li>
+            {% endfor %}
+          </ul>
+        </div>
+
+        <div class="mb-4">
+          <h6 class="fw-semibold">Доступные производители</h6>
+          <ul class="list-unstyled small mb-0">
+            {% for manufacturer in available_manufacturers %}
+              <li>{{ manufacturer.name }}</li>
+            {% empty %}
+              <li class="text-muted">Нет доступных производителей</li>
+            {% endfor %}
+          </ul>
+        </div>
+
         <!-- Поиск по всем полям -->
         {% for item in filter.form %}
         <div class="container">

--- a/price_manager/core/views.py
+++ b/price_manager/core/views.py
@@ -68,6 +68,15 @@ class MainPage(SingleTableMixin, FilterView):
   template_name = 'main/main.html'
   def get_table(self, **kwargs):
     return super().get_table(**kwargs, request=self.request)
+  def get_context_data(self, **kwargs):
+    context = super().get_context_data(**kwargs)
+    context['available_suppliers'] = Supplier.objects.filter(
+        mainproduct__available=True
+    ).distinct().order_by('name')
+    context['available_manufacturers'] = Manufacturer.objects.filter(
+        mainproduct__available=True
+    ).distinct().order_by('name')
+    return context
 
 # Обработка поставщика
 


### PR DESCRIPTION
## Summary
- add queryset context to expose available suppliers and manufacturers on the main page
- render the new supplier and manufacturer lists in the filter panel

## Testing
- `python price_manager/manage.py test` *(fails: database connection to localhost:5432 refused)*

------
https://chatgpt.com/codex/tasks/task_e_68cffce9d998832d9845781551de3b0b