### PR TITLE
Show available suppliers and manufacturers in main filter

### DIFF
--- a/price_manager/core/models.py
+++ b/price_manager/core/models.py
@@ -193,7 +193,7 @@ class PriceManager(models.Model):
   def __str__(self):
     return self.name
    
-MP_TABLE_FIELDS = ['article', 'category', 'supplier', 'name', 'manufacturer','prime_cost', 'stock', 'available']
+MP_TABLE_FIELDS = ['article', 'supplier', 'name', 'manufacturer','prime_cost', 'stock']
 MP_CHARS = ['sku', 'article', 'name']
 MP_FKS = ['supplier', 'category', 'discount', 'manufacturer', 'price_manager']
 MP_DECIMALS = ['weight', 'length', 'width', 'depth']

--- a/price_manager/core/templates/main/includes/dynamic_filters.html
+++ b/price_manager/core/templates/main/includes/dynamic_filters.html
@@ -1,6 +1,6 @@
 
-{% include 'main/includes/filter_field.html' with field=filter_form.supplier container_id='supplier-filter-container' collapse_id='supplier-filter-collapse' hx_swap_oob=True %}
+{% include 'main/includes/filter_field.html' with field=filter_form.supplier container_id='supplier-filter-container' collapse_id='supplier-filter-collapse' hx_swap_oob=True available_options=available_suppliers available_options_label='Доступные поставщики' %}
 
-{% include 'main/includes/filter_field.html' with field=filter_form.manufacturer container_id='manufacturer-filter-container' collapse_id='manufacturer-filter-collapse' hx_swap_oob=True %}
+{% include 'main/includes/filter_field.html' with field=filter_form.manufacturer container_id='manufacturer-filter-container' collapse_id='manufacturer-filter-collapse' hx_swap_oob=True available_options=available_manufacturers available_options_label='Доступные производители' %}
 
-{% include 'main/includes/filter_field.html' with field=filter_form.category container_id='category-filter-container' collapse_id='category-filter-collapse' is_category=True category_tree=category_tree selected_categories=selected_categories hx_swap_oob=True %}
+{% include 'main/includes/filter_field.html' with field=filter_form.category container_id='category-filter-container' collapse_id='category-filter-collapse' is_category=True category_tree=category_tree selected_categories=selected_categories available_options=None hx_swap_oob=True %}

--- a/price_manager/core/templates/main/includes/dynamic_filters.html
+++ b/price_manager/core/templates/main/includes/dynamic_filters.html
@@ -1,6 +1,6 @@
 
-{% include 'main/includes/filter_field.html' with field=filter_form.supplier container_id='supplier-filter-container' collapse_id='supplier-filter-collapse' hx_swap_oob=True available_options=available_suppliers available_options_label='Доступные поставщики' %}
+{% include 'main/includes/filter_field.html' with field=filter_form.supplier container_id='supplier-filter-container' collapse_id='supplier-filter-collapse' hx_swap_oob=True available_options=available_suppliers available_options_label='Доступные поставщики' collapsible=False %}
 
-{% include 'main/includes/filter_field.html' with field=filter_form.manufacturer container_id='manufacturer-filter-container' collapse_id='manufacturer-filter-collapse' hx_swap_oob=True available_options=available_manufacturers available_options_label='Доступные производители' %}
+{% include 'main/includes/filter_field.html' with field=filter_form.manufacturer container_id='manufacturer-filter-container' collapse_id='manufacturer-filter-collapse' hx_swap_oob=True available_options=available_manufacturers available_options_label='Доступные производители' collapsible=False %}
 
-{% include 'main/includes/filter_field.html' with field=filter_form.category container_id='category-filter-container' collapse_id='category-filter-collapse' is_category=True category_tree=category_tree selected_categories=selected_categories available_options=None hx_swap_oob=True %}
+{% include 'main/includes/filter_field.html' with field=filter_form.category container_id='category-filter-container' collapse_id='category-filter-collapse' is_category=True category_tree=category_tree selected_categories=selected_categories available_options=None hx_swap_oob=True collapsible=False %}

--- a/price_manager/core/templates/main/includes/filter_field.html
+++ b/price_manager/core/templates/main/includes/filter_field.html
@@ -1,5 +1,5 @@
 
-{% with field_value=field.value %}
+{% with field_value=field.value options=available_options label=available_options_label %}
 <div id="{{ container_id }}" class="filter-toggle-section mt-3"{% if hx_swap_oob %} hx-swap-oob="true"{% endif %}>
   <div class="d-flex justify-content-between align-items-center">
     <span class="fw-semibold">{{ field.label }}</span>
@@ -22,6 +22,22 @@
       {{ field }}
     {% else %}
       {% include 'includes/category_tree_filter.html' with field=field category_tree=category_tree selected_categories=selected_categories %}
+    {% endif %}
+    {% if options is not None %}
+      <div class="mt-3">
+        {% if options %}
+          <div class="small text-muted mb-1">
+            {{ label|default:'Доступные значения' }} ({{ options|length }}):
+          </div>
+          <div class="d-flex flex-wrap gap-1">
+            {% for option in options %}
+              <span class="badge bg-light text-dark border text-wrap">{{ option.name }}</span>
+            {% endfor %}
+          </div>
+        {% else %}
+          <div class="small text-muted">{{ label|default:'Доступные значения' }}: отсутствуют</div>
+        {% endif %}
+      </div>
     {% endif %}
   </div>
 </div>

--- a/price_manager/core/templates/main/includes/filter_field.html
+++ b/price_manager/core/templates/main/includes/filter_field.html
@@ -1,22 +1,24 @@
 
-{% with field_value=field.value options=available_options label=available_options_label %}
+{% with field_value=field.value options=available_options label=available_options_label collapsible=collapsible|default:True %}
 <div id="{{ container_id }}" class="filter-toggle-section mt-3"{% if hx_swap_oob %} hx-swap-oob="true"{% endif %}>
   <div class="d-flex justify-content-between align-items-center">
     <span class="fw-semibold">{{ field.label }}</span>
-    <button
-        class="btn btn-sm btn-outline-secondary"
-        type="button"
-        data-bs-toggle="collapse"
-        data-bs-target="#{{ collapse_id }}"
-        aria-expanded="{% if field_value %}true{% else %}false{% endif %}"
-        aria-controls="{{ collapse_id }}"
-        data-filter-toggle="button"
-        data-expanded-text="Скрыть"
-        data-collapsed-text="Показать">
-      {% if field_value %}Скрыть{% else %}Показать{% endif %}
-    </button>
+    {% if collapsible %}
+      <button
+          class="btn btn-sm btn-outline-secondary"
+          type="button"
+          data-bs-toggle="collapse"
+          data-bs-target="#{{ collapse_id }}"
+          aria-expanded="{% if field_value %}true{% else %}false{% endif %}"
+          aria-controls="{{ collapse_id }}"
+          data-filter-toggle="button"
+          data-expanded-text="Скрыть"
+          data-collapsed-text="Показать">
+        {% if field_value %}Скрыть{% else %}Показать{% endif %}
+      </button>
+    {% endif %}
   </div>
-  <div id="{{ collapse_id }}" class="collapse{% if field_value %} show{% endif %} mt-2">
+  <div id="{{ collapse_id }}" class="mt-2{% if collapsible %} collapse{% if field_value %} show{% endif %}{% endif %}">
     {% if not is_category %}
       <label for="{{ field.id_for_label }}" class="form-label">{{ field.label }}</label>
       {{ field }}

--- a/price_manager/core/templates/main/main.html
+++ b/price_manager/core/templates/main/main.html
@@ -56,11 +56,11 @@
       </div>
       {% endif %}
 
-      {% include 'main/includes/filter_field.html' with field=filter_form.supplier container_id='supplier-filter-container' collapse_id='supplier-filter-collapse' %}
+      {% include 'main/includes/filter_field.html' with field=filter_form.supplier container_id='supplier-filter-container' collapse_id='supplier-filter-collapse' available_options=available_suppliers available_options_label='Доступные поставщики' %}
 
-      {% include 'main/includes/filter_field.html' with field=filter_form.manufacturer container_id='manufacturer-filter-container' collapse_id='manufacturer-filter-collapse' %}
+      {% include 'main/includes/filter_field.html' with field=filter_form.manufacturer container_id='manufacturer-filter-container' collapse_id='manufacturer-filter-collapse' available_options=available_manufacturers available_options_label='Доступные производители' %}
 
-      {% include 'main/includes/filter_field.html' with field=filter_form.category container_id='category-filter-container' collapse_id='category-filter-collapse' is_category=True category_tree=category_tree selected_categories=selected_categories %}
+      {% include 'main/includes/filter_field.html' with field=filter_form.category container_id='category-filter-container' collapse_id='category-filter-collapse' is_category=True category_tree=category_tree selected_categories=selected_categories available_options=None %}
 
 
       <div class="row mt-3">

--- a/price_manager/core/templates/main/main.html
+++ b/price_manager/core/templates/main/main.html
@@ -21,38 +21,89 @@
     .hover-wrapper:focus .hover-card {
       display: block;
     }
+
+    .main-page-layout {
+      padding-right: 360px;
+    }
+
+    .filter-panel {
+      position: fixed;
+      top: 96px;
+      right: 32px;
+      width: 320px;
+      max-height: calc(100vh - 128px);
+      overflow-y: auto;
+      z-index: 1030;
+    }
+
+    .filter-panel form {
+      padding-bottom: 1rem;
+    }
+
+    .filter-panel .form-group + .form-group {
+      margin-top: 1rem;
+    }
+
+    .table-area {
+      margin-top: 2rem;
+    }
+
+    @media (max-width: 991.98px) {
+      .main-page-layout {
+        padding-right: 0;
+      }
+
+      .filter-panel {
+        position: static;
+        width: 100%;
+        max-height: none;
+        margin-top: 1.5rem;
+        right: auto;
+      }
+
+      .table-area {
+        margin-top: 1.5rem;
+      }
+    }
 {% endblock %}
 
 {% block body %}
-<div class="row">
-  <div class="col-md-4 card mt-5">
-    <h2>Фильтры</h2>
+<div class="container-fluid main-page-layout">
+  <div class="table-area mb-5">
+    <h1 class="mb-4">Главный прайс</h1>
+
+    {% load export_url from django_tables2 %}
+
+    <div class="table-responsive card p-3 shadow-sm overflow-visible">
+      {% load django_tables2 %}
+      {% render_table table %}
+    </div>
+  </div>
+</div>
+
+<div class="filter-panel card shadow-sm">
+  <div class="card-body">
+    <h2 class="h4">Фильтры</h2>
     <form method="get" class="form" id="main-filter-form">
       {{ filter_form.media }}
 
       <div id="filters-update-sink" class="d-none"></div>
 
-      <div class="row mt-3">
-        <div class="form-group">
-          <label for="{{ filter_form.search.id_for_label }}">{{ filter_form.search.label }}</label>
-          {{ filter_form.search }}
-        </div>
+      <div class="form-group mt-3">
+        <label for="{{ filter_form.search.id_for_label }}">{{ filter_form.search.label }}</label>
+        {{ filter_form.search }}
       </div>
 
-      <div class="row mt-3">
-        <div class="form-group">
-          <label for="{{ filter_form.anti_search.id_for_label }}">{{ filter_form.anti_search.label }}</label>
-          {{ filter_form.anti_search }}
-        </div>
+      <div class="form-group mt-3">
+        <label for="{{ filter_form.anti_search.id_for_label }}">{{ filter_form.anti_search.label }}</label>
+        {{ filter_form.anti_search }}
       </div>
 
 
       {% if filter_form.available %}
-      <div class="row mt-3">
-        <div class="form-group">
-          <label for="{{ filter_form.available.id_for_label }}">{{ filter_form.available.label }}</label>
-          {{ filter_form.available }}
-        </div>
+      <div class="form-group mt-3">
+        <label for="{{ filter_form.available.id_for_label }}">{{ filter_form.available.label }}</label>
+        {{ filter_form.available }}
       </div>
       {% endif %}
 
@@ -63,31 +114,15 @@
       {% include 'main/includes/filter_field.html' with field=filter_form.category container_id='category-filter-container' collapse_id='category-filter-collapse' is_category=True category_tree=category_tree selected_categories=selected_categories available_options=None collapsible=False %}
 
 
-      <div class="row mt-3">
-          <div class="col-12">
-              <button type="submit" class="btn btn-primary">
-                🔍 Искать
-              </button>
-              <a href="{% url 'main-product-sync'%}" class="btn btn-success">
-                <i class="bi bi-recycle"></i> Обновить
-              </a>
-          </div>
+      <div class="mt-4 d-flex gap-2">
+          <button type="submit" class="btn btn-primary flex-grow-1">
+            🔍 Искать
+          </button>
+          <a href="{% url 'main-product-sync'%}" class="btn btn-success">
+            <i class="bi bi-recycle"></i> Обновить
+          </a>
       </div>
     </form>
-  </div>
-  <div class="container-fluid mt-4 mb-5 col-md-8">
-    <h1 class="mb-4">Главный прайс</h1>
-    
-      <!-- Таблица -->
-      <div class="col-md-12 mb-5">
-        {% load export_url from django_tables2 %}
-    
-        <div class="table-responsive card p-3 shadow-sm overflow-visible">
-          {% load django_tables2 %}
-          {% render_table table %}
-        </div>
-      </div>
-    </div>
   </div>
 </div>
 {% endblock %}

--- a/price_manager/core/templates/main/main.html
+++ b/price_manager/core/templates/main/main.html
@@ -56,11 +56,11 @@
       </div>
       {% endif %}
 
-      {% include 'main/includes/filter_field.html' with field=filter_form.supplier container_id='supplier-filter-container' collapse_id='supplier-filter-collapse' available_options=available_suppliers available_options_label='Доступные поставщики' %}
+      {% include 'main/includes/filter_field.html' with field=filter_form.supplier container_id='supplier-filter-container' collapse_id='supplier-filter-collapse' available_options=available_suppliers available_options_label='Доступные поставщики' collapsible=False %}
 
-      {% include 'main/includes/filter_field.html' with field=filter_form.manufacturer container_id='manufacturer-filter-container' collapse_id='manufacturer-filter-collapse' available_options=available_manufacturers available_options_label='Доступные производители' %}
+      {% include 'main/includes/filter_field.html' with field=filter_form.manufacturer container_id='manufacturer-filter-container' collapse_id='manufacturer-filter-collapse' available_options=available_manufacturers available_options_label='Доступные производители' collapsible=False %}
 
-      {% include 'main/includes/filter_field.html' with field=filter_form.category container_id='category-filter-container' collapse_id='category-filter-collapse' is_category=True category_tree=category_tree selected_categories=selected_categories available_options=None %}
+      {% include 'main/includes/filter_field.html' with field=filter_form.category container_id='category-filter-container' collapse_id='category-filter-collapse' is_category=True category_tree=category_tree selected_categories=selected_categories available_options=None collapsible=False %}
 
 
       <div class="row mt-3">

--- a/price_manager/core/views.py
+++ b/price_manager/core/views.py
@@ -158,6 +158,9 @@ def get_main_filter_context(request):
   filter_form.fields['manufacturer'].queryset = manufacturer_queryset
   filter_form.fields['category'].queryset = category_queryset
 
+  available_suppliers = list(supplier_queryset)
+  available_manufacturers = list(manufacturer_queryset)
+
   selected_categories = {str(value) for value in request.GET.getlist('category') if value}
 
   category_tree = build_category_tree(list(category_queryset))
@@ -166,6 +169,8 @@ def get_main_filter_context(request):
       'filter_form': filter_form,
       'category_tree': category_tree,
       'selected_categories': selected_categories,
+      'available_suppliers': available_suppliers,
+      'available_manufacturers': available_manufacturers,
   }
 
 


### PR DESCRIPTION
## Summary
- provide supplier and manufacturer availability lists in the main filter context
- render the available suppliers and manufacturers in both the static and HTMX filter templates

## Testing
- python manage.py check *(fails: ModuleNotFoundError: No module named 'dal')*

------
https://chatgpt.com/codex/tasks/task_e_68d004ff4c08832d95913193572b6cc7