### PR TITLE
Auto refresh main table when filters change

### DIFF
--- a/price_manager/core/templates/main/includes/dynamic_filters.html
+++ b/price_manager/core/templates/main/includes/dynamic_filters.html
@@ -1,6 +1,6 @@
 
-{% include 'main/includes/filter_field.html' with field=filter_form.supplier container_id='supplier-filter-container' collapse_id='supplier-filter-collapse' hx_swap_oob=True %}
+{% include 'main/includes/filter_field.html' with field=filter_form.supplier container_id='supplier-filter-container' collapse_id='supplier-filter-collapse' hx_swap_oob=True available_options=available_suppliers available_options_label='Доступные поставщики' collapsible=False %}
 
-{% include 'main/includes/filter_field.html' with field=filter_form.manufacturer container_id='manufacturer-filter-container' collapse_id='manufacturer-filter-collapse' hx_swap_oob=True %}
+{% include 'main/includes/filter_field.html' with field=filter_form.manufacturer container_id='manufacturer-filter-container' collapse_id='manufacturer-filter-collapse' hx_swap_oob=True available_options=available_manufacturers available_options_label='Доступные производители' collapsible=False %}
 
-{% include 'main/includes/filter_field.html' with field=filter_form.category container_id='category-filter-container' collapse_id='category-filter-collapse' is_category=True category_tree=category_tree selected_categories=selected_categories hx_swap_oob=True %}
+{% include 'main/includes/filter_field.html' with field=filter_form.category container_id='category-filter-container' collapse_id='category-filter-collapse' is_category=True category_tree=category_tree selected_categories=selected_categories available_options=None hx_swap_oob=True collapsible=False %}

--- a/price_manager/core/templates/main/includes/filter_field.html
+++ b/price_manager/core/templates/main/includes/filter_field.html
@@ -1,27 +1,45 @@
 
-{% with field_value=field.value %}
+{% with field_value=field.value options=available_options label=available_options_label collapsible=collapsible|default:True %}
 <div id="{{ container_id }}" class="filter-toggle-section mt-3"{% if hx_swap_oob %} hx-swap-oob="true"{% endif %}>
   <div class="d-flex justify-content-between align-items-center">
     <span class="fw-semibold">{{ field.label }}</span>
-    <button
-        class="btn btn-sm btn-outline-secondary"
-        type="button"
-        data-bs-toggle="collapse"
-        data-bs-target="#{{ collapse_id }}"
-        aria-expanded="{% if field_value %}true{% else %}false{% endif %}"
-        aria-controls="{{ collapse_id }}"
-        data-filter-toggle="button"
-        data-expanded-text="Скрыть"
-        data-collapsed-text="Показать">
-      {% if field_value %}Скрыть{% else %}Показать{% endif %}
-    </button>
+    {% if collapsible %}
+      <button
+          class="btn btn-sm btn-outline-secondary"
+          type="button"
+          data-bs-toggle="collapse"
+          data-bs-target="#{{ collapse_id }}"
+          aria-expanded="{% if field_value %}true{% else %}false{% endif %}"
+          aria-controls="{{ collapse_id }}"
+          data-filter-toggle="button"
+          data-expanded-text="Скрыть"
+          data-collapsed-text="Показать">
+        {% if field_value %}Скрыть{% else %}Показать{% endif %}
+      </button>
+    {% endif %}
   </div>
-  <div id="{{ collapse_id }}" class="collapse{% if field_value %} show{% endif %} mt-2">
+  <div id="{{ collapse_id }}" class="mt-2{% if collapsible %} collapse{% if field_value %} show{% endif %}{% endif %}">
     {% if not is_category %}
       <label for="{{ field.id_for_label }}" class="form-label">{{ field.label }}</label>
       {{ field }}
     {% else %}
       {% include 'includes/category_tree_filter.html' with field=field category_tree=category_tree selected_categories=selected_categories %}
+    {% endif %}
+    {% if options is not None %}
+      <div class="mt-3">
+        {% if options %}
+          <div class="small text-muted mb-1">
+            {{ label|default:'Доступные значения' }} ({{ options|length }}):
+          </div>
+          <div class="d-flex flex-wrap gap-1">
+            {% for option in options %}
+              <span class="badge bg-light text-dark border text-wrap">{{ option.name }}</span>
+            {% endfor %}
+          </div>
+        {% else %}
+          <div class="small text-muted">{{ label|default:'Доступные значения' }}: отсутствуют</div>
+        {% endif %}
+      </div>
     {% endif %}
   </div>
 </div>

--- a/price_manager/core/templates/main/includes/table.html
+++ b/price_manager/core/templates/main/includes/table.html
@@ -1,0 +1,10 @@
+{% load export_url from django_tables2 %}
+{% load django_tables2 %}
+
+<div id="main-table-container" class="table-area mb-5">
+  <h1 class="mb-4">Главный прайс</h1>
+
+  <div class="table-responsive card p-3 shadow-sm overflow-visible">
+    {% render_table table %}
+  </div>
+</div>

--- a/price_manager/core/templates/main/main.html
+++ b/price_manager/core/templates/main/main.html
@@ -21,73 +21,99 @@
     .hover-wrapper:focus .hover-card {
       display: block;
     }
+
+    .main-page-layout {
+      padding-right: 360px;
+    }
+
+    .filter-panel {
+      position: fixed;
+      top: 96px;
+      right: 32px;
+      width: 320px;
+      max-height: calc(100vh - 128px);
+      overflow-y: auto;
+      z-index: 1030;
+    }
+
+    .filter-panel form {
+      padding-bottom: 1rem;
+    }
+
+    .filter-panel .form-group + .form-group {
+      margin-top: 1rem;
+    }
+
+    .table-area {
+      margin-top: 2rem;
+    }
+
+    @media (max-width: 991.98px) {
+      .main-page-layout {
+        padding-right: 0;
+      }
+
+      .filter-panel {
+        position: static;
+        width: 100%;
+        max-height: none;
+        margin-top: 1.5rem;
+        right: auto;
+      }
+
+      .table-area {
+        margin-top: 1.5rem;
+      }
+    }
 {% endblock %}
 
 {% block body %}
-<div class="row">
-  <div class="col-md-4 card mt-5">
-    <h2>Фильтры</h2>
+<div class="container-fluid main-page-layout">
+  {% include 'main/includes/table.html' %}
+</div>
+
+<div class="filter-panel card shadow-sm">
+  <div class="card-body">
+    <h2 class="h4">Фильтры</h2>
     <form method="get" class="form" id="main-filter-form">
       {{ filter_form.media }}
 
       <div id="filters-update-sink" class="d-none"></div>
 
-      <div class="row mt-3">
-        <div class="form-group">
-          <label for="{{ filter_form.search.id_for_label }}">{{ filter_form.search.label }}</label>
-          {{ filter_form.search }}
-        </div>
+      <div class="form-group mt-3">
+        <label for="{{ filter_form.search.id_for_label }}">{{ filter_form.search.label }}</label>
+        {{ filter_form.search }}
       </div>
 
-      <div class="row mt-3">
-        <div class="form-group">
-          <label for="{{ filter_form.anti_search.id_for_label }}">{{ filter_form.anti_search.label }}</label>
-          {{ filter_form.anti_search }}
-        </div>
+      <div class="form-group mt-3">
+        <label for="{{ filter_form.anti_search.id_for_label }}">{{ filter_form.anti_search.label }}</label>
+        {{ filter_form.anti_search }}
       </div>
 
 
       {% if filter_form.available %}
-      <div class="row mt-3">
-        <div class="form-group">
-          <label for="{{ filter_form.available.id_for_label }}">{{ filter_form.available.label }}</label>
-          {{ filter_form.available }}
-        </div>
+      <div class="form-group mt-3">
+        <label for="{{ filter_form.available.id_for_label }}">{{ filter_form.available.label }}</label>
+        {{ filter_form.available }}
       </div>
       {% endif %}
 
-      {% include 'main/includes/filter_field.html' with field=filter_form.supplier container_id='supplier-filter-container' collapse_id='supplier-filter-collapse' %}
+      {% include 'main/includes/filter_field.html' with field=filter_form.supplier container_id='supplier-filter-container' collapse_id='supplier-filter-collapse' available_options=available_suppliers available_options_label='Доступные поставщики' collapsible=False %}
 
-      {% include 'main/includes/filter_field.html' with field=filter_form.manufacturer container_id='manufacturer-filter-container' collapse_id='manufacturer-filter-collapse' %}
+      {% include 'main/includes/filter_field.html' with field=filter_form.manufacturer container_id='manufacturer-filter-container' collapse_id='manufacturer-filter-collapse' available_options=available_manufacturers available_options_label='Доступные производители' collapsible=False %}
 
-      {% include 'main/includes/filter_field.html' with field=filter_form.category container_id='category-filter-container' collapse_id='category-filter-collapse' is_category=True category_tree=category_tree selected_categories=selected_categories %}
+      {% include 'main/includes/filter_field.html' with field=filter_form.category container_id='category-filter-container' collapse_id='category-filter-collapse' is_category=True category_tree=category_tree selected_categories=selected_categories available_options=None collapsible=False %}
 
 
-      <div class="row mt-3">
-          <div class="col-12">
-              <button type="submit" class="btn btn-primary">
-                🔍 Искать
-              </button>
-              <a href="{% url 'main-product-sync'%}" class="btn btn-success">
-                <i class="bi bi-recycle"></i> Обновить
-              </a>
-          </div>
+      <div class="mt-4 d-flex gap-2">
+          <button type="submit" class="btn btn-primary flex-grow-1">
+            🔍 Искать
+          </button>
+          <a href="{% url 'main-product-sync'%}" class="btn btn-success">
+            <i class="bi bi-recycle"></i> Обновить
+          </a>
       </div>
     </form>
-  </div>
-  <div class="container-fluid mt-4 mb-5 col-md-8">
-    <h1 class="mb-4">Главный прайс</h1>
-    
-      <!-- Таблица -->
-      <div class="col-md-12 mb-5">
-        {% load export_url from django_tables2 %}
-    
-        <div class="table-responsive card p-3 shadow-sm overflow-visible">
-          {% load django_tables2 %}
-          {% render_table table %}
-        </div>
-      </div>
-    </div>
   </div>
 </div>
 {% endblock %}
@@ -158,9 +184,85 @@
     buttons.forEach(initFilterToggle);
   };
 
+  const debounce = (fn, delay = 300) => {
+    let timerId;
+    return (...args) => {
+      if (timerId) {
+        clearTimeout(timerId);
+      }
+      timerId = window.setTimeout(() => {
+        timerId = null;
+        fn(...args);
+      }, delay);
+    };
+  };
+
+  const getFilterForm = () => document.getElementById('main-filter-form');
+
+  const requestTableUpdate = () => {
+    if (!window.htmx) {
+      return;
+    }
+
+    const form = getFilterForm();
+    if (!form) {
+      return;
+    }
+
+    const params = new URLSearchParams(new FormData(form));
+    params.delete('page');
+
+    const queryString = params.toString();
+    const tableUrl = '{{ table_update_url|escapejs }}';
+    const separator = tableUrl.includes('?') ? '&' : '?';
+    const url = queryString ? `${tableUrl}${separator}${queryString}` : tableUrl;
+
+    window.htmx.ajax('GET', url, {
+      target: '#main-table-container',
+      swap: 'outerHTML',
+    });
+
+    const newLocation = queryString ? `${window.location.pathname}?${queryString}` : window.location.pathname;
+    window.history.replaceState({}, '', newLocation);
+  };
+
+  const scheduleTableUpdate = debounce(requestTableUpdate, 500);
+
+  const registerAutoUpdate = () => {
+    const form = getFilterForm();
+    if (!form || form.dataset.autoUpdateInitialized === 'true') {
+      return;
+    }
+
+    form.addEventListener('input', (event) => {
+      const target = event.target;
+      if (!target) {
+        return;
+      }
+
+      if (target.matches('input[type="text"], input[type="search"], textarea')) {
+        scheduleTableUpdate();
+      }
+    });
+
+    form.addEventListener('change', (event) => {
+      const target = event.target;
+      if (!target) {
+        return;
+      }
+
+      if (target.matches('input, select, textarea')) {
+        requestTableUpdate();
+      }
+    });
+
+    form.dataset.autoUpdateInitialized = 'true';
+  };
+
   document.addEventListener('DOMContentLoaded', () => {
     initDynamicFilters();
     initFilterToggles();
+    registerAutoUpdate();
   });
 
   const shouldEnhance = (target) => {
@@ -174,6 +276,7 @@
     if (event.target && event.target.id === 'filters-update-sink') {
       initDynamicFilters();
       initFilterToggles();
+      registerAutoUpdate();
     }
   });
 
@@ -182,6 +285,7 @@
       initDynamicFilters();
     }
     initFilterToggles();
+    registerAutoUpdate();
   });
 </script>
 {% endblock %}

--- a/price_manager/core/views.py
+++ b/price_manager/core/views.py
@@ -158,6 +158,9 @@ def get_main_filter_context(request):
   filter_form.fields['manufacturer'].queryset = manufacturer_queryset
   filter_form.fields['category'].queryset = category_queryset
 
+  available_suppliers = list(supplier_queryset)
+  available_manufacturers = list(manufacturer_queryset)
+
   selected_categories = {str(value) for value in request.GET.getlist('category') if value}
 
   category_tree = build_category_tree(list(category_queryset))
@@ -166,6 +169,8 @@ def get_main_filter_context(request):
       'filter_form': filter_form,
       'category_tree': category_tree,
       'selected_categories': selected_categories,
+      'available_suppliers': available_suppliers,
+      'available_manufacturers': available_manufacturers,
   }
 
 
@@ -211,6 +216,7 @@ class MainPage(SingleTableMixin, FilterView):
           'hx-trigger': 'change',
       })
 
+    context['table_update_url'] = reverse('main-table')
     return context
 
 
@@ -220,6 +226,10 @@ class MainFilterOptionsView(View):
   def get(self, request, *args, **kwargs):
     context = get_main_filter_context(request)
     return render(request, self.template_name, context)
+
+
+class MainTableView(MainPage):
+  template_name = 'main/includes/table.html'
 
 # Обработка поставщика
 

--- a/price_manager/price_manager/urls.py
+++ b/price_manager/price_manager/urls.py
@@ -10,6 +10,7 @@ urlpatterns = [
 
     path('', views.MainPage.as_view(), name='main'),
     path('main/filter-options/', views.MainFilterOptionsView.as_view(), name='main-filter-options'),
+    path('main/table/', views.MainTableView.as_view(), name='main-table'),
     
     path('supplier/', views.SupplierList.as_view(), name='supplier'),
     path('supplier/<int:id>/', views.SupplierDetail.as_view(), name='supplier-detail'),


### PR DESCRIPTION
## Summary
- extract the main table into a reusable include and serve it from a new table-only endpoint
- trigger HTMX refreshes of the table when any filter input changes while keeping the query string updated

## Testing
- python price_manager/manage.py check *(fails: ModuleNotFoundError: No module named 'dal')*

------
https://chatgpt.com/codex/tasks/task_e_68d004ff4c08832d95913193572b6cc7