### PR TITLE
Require authentication for site access

### DIFF
--- a/price_manager/core/middleware.py
+++ b/price_manager/core/middleware.py
@@ -1,0 +1,72 @@
+from urllib.parse import urlparse
+
+from django.conf import settings
+from django.contrib.auth.views import redirect_to_login
+from django.shortcuts import resolve_url
+from django.urls import NoReverseMatch
+
+
+class LoginRequiredMiddleware:
+    """Redirect anonymous users to the login page for protected views."""
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+        self.login_path = self._resolve_to_path(settings.LOGIN_URL)
+        self.exempt_paths = {self.login_path}
+
+        for url in getattr(settings, "LOGIN_EXEMPT_URLS", ()):
+            resolved_path = self._resolve_to_path(url)
+            if resolved_path:
+                self.exempt_paths.add(resolved_path)
+
+        self.static_prefixes = tuple(
+            self._normalize_prefix(prefix)
+            for prefix in (getattr(settings, "STATIC_URL", None), getattr(settings, "MEDIA_URL", None))
+            if prefix
+        )
+
+    def __call__(self, request):
+        if request.user.is_authenticated:
+            return self.get_response(request)
+
+        path = request.path_info
+
+        if self._is_exempt(path):
+            return self.get_response(request)
+
+        return redirect_to_login(request.get_full_path(), settings.LOGIN_URL)
+
+    def _is_exempt(self, path: str) -> bool:
+        if not path:
+            return False
+
+        if any(path.startswith(prefix) for prefix in self.static_prefixes):
+            return True
+
+        if path in self.exempt_paths:
+            return True
+
+        # Allow access to the admin authentication views so the default admin login works.
+        if path.startswith("/admin/login") or path.startswith("/admin/logout"):
+            return True
+
+        return False
+
+    def _resolve_to_path(self, url: str | None) -> str | None:
+        if not url:
+            return None
+
+        try:
+            resolved = resolve_url(url)
+        except NoReverseMatch:
+            resolved = url
+
+        parsed = urlparse(str(resolved))
+        return parsed.path or "/"
+
+    def _normalize_prefix(self, prefix: str) -> str:
+        parsed = urlparse(prefix)
+        path = parsed.path or "/"
+        if not path.startswith("/"):
+            path = "/" + path
+        return path

--- a/price_manager/core/templates/base.html
+++ b/price_manager/core/templates/base.html
@@ -18,7 +18,7 @@
     </style>
 </head>
 <body>
-    {% include 'includes\header.html' %}
+    {% include 'includes/header.html' %}
     <div class="container mt-5">
         {% if messages %}
         <div class="alert-container m-5 position-fixed end-0 top-0 p-3" style="z-index: 10;">

--- a/price_manager/core/templates/includes/header.html
+++ b/price_manager/core/templates/includes/header.html
@@ -29,7 +29,10 @@
         <a class="btn btn-link" href="{% url 'admin:index' %}">Админ</a>
         {% if user.is_authenticated %}
           <span class="navbar-text">{{ user.get_username }}</span>
-          <a class="btn btn-outline-secondary" href="{% url 'logout' %}">Выйти</a>
+          <form action="{% url 'logout' %}" method="post">
+            {% csrf_token %}
+            <button type="submit" class="btn btn-secondary">Выйти</button>
+          </form>
         {% else %}
           <a class="btn btn-primary" href="{% url 'login' %}">Войти</a>
         {% endif %}

--- a/price_manager/core/templates/includes/header.html
+++ b/price_manager/core/templates/includes/header.html
@@ -1,34 +1,38 @@
-<nav class="navbar navbar-expand-lg sticky-top bg-light">
+<nav class="navbar navbar-expand-lg sticky-top bg-light navbar-light border-bottom">
   <div class="container-fluid">
-    <!-- Brand -->
-    <a class="navbar-brand" href="/">PriceManager</a>
+    <a class="navbar-brand" href="{% url 'main' %}">PriceManager</a>
 
-    <!-- Toggler -->
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainNav"
             aria-controls="mainNav" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
 
-    <!-- Collapsible content -->
     <div class="collapse navbar-collapse" id="mainNav">
       <ul class="navbar-nav me-auto mb-2 mb-lg-0">
         <li class="nav-item">
-          <a class="nav-link" href="\supplier\">Поставщики</a>
+          <a class="nav-link" href="{% url 'supplier' %}">Поставщики</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="\price-manager\">Наценки</a>
+          <a class="nav-link" href="{% url 'price-manager' %}">Наценки</a>
         </li>
-        <li class="nav-item"><a class="nav-link" href="\currency\">Валюта</a></li>
+        <li class="nav-item">
+          <a class="nav-link" href="{% url 'currency' %}">Валюта</a>
+        </li>
         <li class="nav-item dropdown">
-          <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown">
+          <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
             Еще
           </a>
         </li>
       </ul>
 
-      <!-- Right-aligned item(s) -->
-      <div class="d-flex">
-        <a class="btn" href="\admin\">Админ</a>
+      <div class="d-flex align-items-center gap-2">
+        <a class="btn btn-link" href="{% url 'admin:index' %}">Админ</a>
+        {% if user.is_authenticated %}
+          <span class="navbar-text">{{ user.get_username }}</span>
+          <a class="btn btn-outline-secondary" href="{% url 'logout' %}">Выйти</a>
+        {% else %}
+          <a class="btn btn-primary" href="{% url 'login' %}">Войти</a>
+        {% endif %}
       </div>
     </div>
   </div>

--- a/price_manager/core/templates/main/main.html
+++ b/price_manager/core/templates/main/main.html
@@ -97,12 +97,13 @@
         {{ filter_form.available }}
       </div>
       {% endif %}
-
+      
+      {% include 'main/includes/filter_field.html' with field=filter_form.category container_id='category-filter-container' collapse_id='category-filter-collapse' is_category=True category_tree=category_tree selected_categories=selected_categories available_options=None collapsible=False %}
+      
+      {% include 'main/includes/filter_field.html' with field=filter_form.manufacturer container_id='manufacturer-filter-container' collapse_id='manufacturer-filter-collapse' available_options=available_manufacturers available_options_label='Доступные производители' collapsible=False %}
+      
       {% include 'main/includes/filter_field.html' with field=filter_form.supplier container_id='supplier-filter-container' collapse_id='supplier-filter-collapse' available_options=available_suppliers available_options_label='Доступные поставщики' collapsible=False %}
 
-      {% include 'main/includes/filter_field.html' with field=filter_form.manufacturer container_id='manufacturer-filter-container' collapse_id='manufacturer-filter-collapse' available_options=available_manufacturers available_options_label='Доступные производители' collapsible=False %}
-
-      {% include 'main/includes/filter_field.html' with field=filter_form.category container_id='category-filter-container' collapse_id='category-filter-collapse' is_category=True category_tree=category_tree selected_categories=selected_categories available_options=None collapsible=False %}
 
 
       <div class="mt-4 d-flex gap-2">

--- a/price_manager/core/templates/registration/login.html
+++ b/price_manager/core/templates/registration/login.html
@@ -1,0 +1,44 @@
+{% extends 'base.html' %}
+
+{% block title %}Вход{% endblock %}
+
+{% block body %}
+<div class="row justify-content-center">
+  <div class="col-md-5 col-lg-4">
+    <h1 class="h3 mb-4 text-center">Вход в систему</h1>
+    <form method="post" novalidate>
+      {% csrf_token %}
+      {% if form.non_field_errors %}
+        <div class="alert alert-danger" role="alert">
+          {% for error in form.non_field_errors %}
+            <div>{{ error }}</div>
+          {% endfor %}
+        </div>
+      {% endif %}
+      <div class="mb-3">
+        <label class="form-label" for="{{ form.username.id_for_label }}">Имя пользователя</label>
+        {{ form.username }}
+        {% if form.username.errors %}
+          <div class="invalid-feedback d-block">
+            {% for error in form.username.errors %}
+              <div>{{ error }}</div>
+            {% endfor %}
+          </div>
+        {% endif %}
+      </div>
+      <div class="mb-3">
+        <label class="form-label" for="{{ form.password.id_for_label }}">Пароль</label>
+        {{ form.password }}
+        {% if form.password.errors %}
+          <div class="invalid-feedback d-block">
+            {% for error in form.password.errors %}
+              <div>{{ error }}</div>
+            {% endfor %}
+          </div>
+        {% endif %}
+      </div>
+      <button type="submit" class="btn btn-primary w-100">Войти</button>
+    </form>
+  </div>
+</div>
+{% endblock %}

--- a/price_manager/core/views.py
+++ b/price_manager/core/views.py
@@ -8,6 +8,7 @@ from django.utils import timezone
 from django.http import HttpResponseRedirect, HttpResponse
 from django.template.loader import render_to_string
 from django.contrib import messages
+from django.contrib.auth.views import LoginView, LogoutView
 from django.views.generic import (View,
                                   ListView,
                                   DetailView,
@@ -37,6 +38,25 @@ from decimal import Decimal, InvalidOperation
 import pandas as pd
 import re
 import math
+
+
+class AppLoginView(LoginView):
+    template_name = 'registration/login.html'
+    redirect_authenticated_user = True
+
+    def get_form(self, form_class=None):
+        form = super().get_form(form_class)
+        for field in form.fields.values():
+            existing_classes = field.widget.attrs.get('class', '')
+            classes = [cls for cls in existing_classes.split() if cls]
+            if 'form-control' not in classes:
+                classes.append('form-control')
+            field.widget.attrs['class'] = ' '.join(classes) if classes else 'form-control'
+        return form
+
+
+class AppLogoutView(LogoutView):
+    next_page = 'login'
 
 class CategoryAutocomplete(autocomplete.Select2QuerySetView):
     def get_queryset(self):

--- a/price_manager/price_manager/settings.py
+++ b/price_manager/price_manager/settings.py
@@ -52,6 +52,7 @@ MIDDLEWARE = [
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'core.middleware.LoginRequiredMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
@@ -167,3 +168,17 @@ MESSAGE_TAGS = {
     messages.WARNING: 'alert-warning',
     messages.ERROR: 'alert-danger',
 }
+
+LOGIN_URL = 'login'
+LOGIN_REDIRECT_URL = 'main'
+LOGOUT_REDIRECT_URL = 'login'
+LOGIN_EXEMPT_URLS = (
+    'login',
+    'logout',
+    'admin:login',
+    'admin:logout',
+    'admin:password_reset',
+    'admin:password_reset_done',
+    'admin:password_reset_confirm',
+    'admin:password_reset_complete',
+)

--- a/price_manager/price_manager/urls.py
+++ b/price_manager/price_manager/urls.py
@@ -7,6 +7,8 @@ from django.conf.urls.static import static
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('accounts/login/', views.AppLoginView.as_view(), name='login'),
+    path('accounts/logout/', views.AppLogoutView.as_view(), name='logout'),
 
     path('', views.MainPage.as_view(), name='main'),
     path('main/filter-options/', views.MainFilterOptionsView.as_view(), name='main-filter-options'),


### PR DESCRIPTION
## Summary
- add a middleware that redirects anonymous users to the login page while allowing static, media and auth URLs
- register dedicated login/logout views with a custom login template and navigation updates
- configure authentication settings and navigation to surface login state and logout links

## Testing
- python manage.py check *(fails: database connection is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db9abdbd04832db0090a976b7fd115