### PR TITLE
Добавить управление корзинами и выбор корзины из прайса

### DIFF
--- a/price_manager/core/forms.py
+++ b/price_manager/core/forms.py
@@ -83,12 +83,57 @@ class InitialForm(forms.Form):
   initial = forms.CharField(label='Начальное значение',
                             required=False,
                             empty_value='')
-  
+
 
 class PriceManagerForm(forms.ModelForm):
   class Meta:
     model = PriceManager
     fields = ['name', 'supplier', 'discounts', 'source', 'dest', 'price_from', 'price_to', 'markup', 'increase']
+
+
+class ShopingTabCreateForm(forms.ModelForm):
+  class Meta:
+    model = ShopingTab
+    fields = ['name']
+    labels = {
+      'name': 'Название корзины',
+    }
+    widgets = {
+      'name': forms.TextInput(attrs={'class': 'form-control', 'placeholder': 'Например, Заказ №1'}),
+    }
+
+
+class ShopingTabUpdateForm(forms.ModelForm):
+  class Meta:
+    model = ShopingTab
+    fields = ['name', 'open']
+    labels = {
+      'name': 'Название',
+      'open': 'Открыта',
+    }
+    widgets = {
+      'name': forms.TextInput(attrs={'class': 'form-control'}),
+      'open': forms.CheckboxInput(attrs={'class': 'form-check-input'}),
+    }
+
+
+class AlternateProductForm(forms.ModelForm):
+  class Meta:
+    model = AlternateProduct
+    fields = ['name', 'main_product']
+    labels = {
+      'name': 'Название',
+      'main_product': 'Главный товар',
+    }
+    widgets = {
+      'name': forms.TextInput(attrs={'class': 'form-control'}),
+      'main_product': forms.Select(attrs={'class': 'form-select'}),
+    }
+
+  def __init__(self, *args, **kwargs):
+    super().__init__(*args, **kwargs)
+    self.fields['main_product'].required = False
+    self.fields['main_product'].queryset = MainProduct.objects.order_by('name')
 
 # class PriceManagerAdminForm(forms.ModelForm):
 #     class Meta:

--- a/price_manager/core/tables.py
+++ b/price_manager/core/tables.py
@@ -192,8 +192,9 @@ class MainProductListTable(tables.Table):
             'main/product/actions.html',
             {
                 'record': record,
-                'basket': self.request.session.get('basket', []),
-            }
+                'request': self.request,
+            },
+            request=self.request,
         )
   def render_name(self, record):
     return render_to_string(

--- a/price_manager/core/templates/base.html
+++ b/price_manager/core/templates/base.html
@@ -37,7 +37,22 @@
         </div>
         {% endif %}
     {% block body %}{% endblock %}
-    </div>  
+    </div>
+    <div class="modal fade" id="shoppingTabSelectionModal" tabindex="-1" aria-labelledby="shoppingTabSelectionModalLabel" aria-hidden="true">
+      <div class="modal-dialog modal-dialog-centered modal-lg modal-dialog-scrollable">
+        <div class="modal-content">
+          <div id="shopping-tab-selection-modal-content">
+            <div class="modal-header">
+              <h5 class="modal-title" id="shoppingTabSelectionModalLabel">Добавить в корзину</h5>
+              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Закрыть"></button>
+            </div>
+            <div class="modal-body">
+              <p class="mb-0 text-muted">Загрузка…</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
     {% block script %}{% endblock %}
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <script src="https://unpkg.com/htmx.org@1.9.12"></script>

--- a/price_manager/core/templates/includes/header.html
+++ b/price_manager/core/templates/includes/header.html
@@ -18,6 +18,9 @@
         <li class="nav-item">
           <a class="nav-link" href="{% url 'currency' %}">Валюта</a>
         </li>
+        <li class="nav-item">
+          <a class="nav-link" href="{% url 'shopping-tab-list' %}">Корзины</a>
+        </li>
         <li class="nav-item dropdown">
           <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
             Еще

--- a/price_manager/core/templates/main/main.html
+++ b/price_manager/core/templates/main/main.html
@@ -264,6 +264,16 @@
     initDynamicFilters();
     initFilterToggles();
     registerAutoUpdate();
+    const shoppingTabModal = document.getElementById('shoppingTabSelectionModal');
+    if (shoppingTabModal) {
+      const modalContent = shoppingTabModal.querySelector('#shopping-tab-selection-modal-content');
+      const defaultMarkup = modalContent ? modalContent.innerHTML : '';
+      shoppingTabModal.addEventListener('hidden.bs.modal', () => {
+        if (modalContent) {
+          modalContent.innerHTML = defaultMarkup;
+        }
+      });
+    }
   });
 
   const shouldEnhance = (target) => {

--- a/price_manager/core/templates/main/product/actions.html
+++ b/price_manager/core/templates/main/product/actions.html
@@ -1,14 +1,23 @@
-<form hx-post="{% url 'toggle-basket' pk=record.pk %}"
-hx-target="this"
-hx-swap="outerHTML"
-style="display:inline;">
-<div class="container d-flex">
-<a href="{% url 'main-product-update' record.id %}" class="btn btn-sm btn-primary">
+<div class="d-flex gap-1">
+  <a href="{% url 'main-product-update' record.id %}" class="btn btn-sm btn-primary" title="Редактировать товар">
     <i class="bi bi-pencil-square"></i>
   </a>
-<button type="submit"
-class="btn btn-sm {% if record.pk in basket %}btn-danger{% else %}btn-success{% endif %}">
-{% if record.pk in basket %}<i class="bi bi-cart-plus-fill"></i>{% else %}<i class="bi bi-cart-plus"></i>{% endif %}
-</button>
+  {% if request.user.is_authenticated %}
+    <button type="button"
+            class="btn btn-sm btn-success"
+            title="Добавить в корзину"
+            data-bs-toggle="modal"
+            data-bs-target="#shoppingTabSelectionModal"
+            hx-get="{% url 'shopping-tab-select' record.pk %}"
+            hx-target="#shopping-tab-selection-modal-content"
+            hx-swap="innerHTML">
+      <i class="bi bi-cart-plus"></i>
+    </button>
+  {% else %}
+    <a href="{% url 'login' %}?next={{ request.get_full_path|urlencode }}"
+       class="btn btn-sm btn-outline-secondary"
+       title="Войти, чтобы добавить в корзину">
+      <i class="bi bi-cart-plus"></i>
+    </a>
+  {% endif %}
 </div>
-</form>

--- a/price_manager/core/templates/shopping_tab/add_to_tab_modal.html
+++ b/price_manager/core/templates/shopping_tab/add_to_tab_modal.html
@@ -1,0 +1,40 @@
+<div class="modal-header">
+  <h5 class="modal-title">Добавить «{{ product.name|truncatechars:60 }}»</h5>
+  <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Закрыть"></button>
+</div>
+<div class="modal-body">
+  {% if tabs %}
+    <p class="text-muted">Выберите корзину, в которую нужно добавить товар.</p>
+    <div class="list-group">
+      {% for tab in tabs %}
+        <form method="post"
+              hx-post="{% url 'shopping-tab-add-product' tab_pk=tab.pk product_id=product.pk %}"
+              hx-target="#shopping-tab-selection-modal-content"
+              hx-swap="innerHTML"
+              class="list-group-item list-group-item-action d-flex justify-content-between align-items-center gap-3">
+          {% csrf_token %}
+          <div class="flex-grow-1">
+            <div class="fw-semibold">{{ tab.name }}</div>
+            <div class="small text-muted">Товаров: {{ tab.product_count }}</div>
+          </div>
+          {% if tab.pk in existing_tab_ids %}
+            <span class="badge bg-success-subtle text-success-emphasis">Уже добавлен</span>
+          {% else %}
+            <button type="submit" class="btn btn-primary btn-sm">
+              <i class="bi bi-cart-plus"></i> Добавить
+            </button>
+          {% endif %}
+        </form>
+      {% endfor %}
+    </div>
+  {% else %}
+    <div class="text-center text-muted py-4">
+      <i class="bi bi-basket fs-1 d-block mb-3"></i>
+      <p class="mb-0">У вас еще нет корзин. Сначала создайте корзину.</p>
+    </div>
+  {% endif %}
+</div>
+<div class="modal-footer">
+  <a href="{% url 'shopping-tab-list' %}" class="btn btn-outline-secondary">Управлять корзинами</a>
+  <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Закрыть</button>
+</div>

--- a/price_manager/core/templates/shopping_tab/add_to_tab_modal.html
+++ b/price_manager/core/templates/shopping_tab/add_to_tab_modal.html
@@ -11,19 +11,44 @@
               hx-post="{% url 'shopping-tab-add-product' tab_pk=tab.pk product_id=product.pk %}"
               hx-target="#shopping-tab-selection-modal-content"
               hx-swap="innerHTML"
-              class="list-group-item list-group-item-action d-flex justify-content-between align-items-center gap-3">
+              class="list-group-item list-group-item-action">
           {% csrf_token %}
-          <div class="flex-grow-1">
-            <div class="fw-semibold">{{ tab.name }}</div>
-            <div class="small text-muted">Товаров: {{ tab.product_count }}</div>
+          <div class="d-flex flex-column gap-2">
+            <div class="d-flex justify-content-between align-items-start gap-2">
+              <div>
+                <div class="fw-semibold">{{ tab.name }}</div>
+                <div class="small text-muted">Товаров: {{ tab.product_count }}</div>
+              </div>
+              {% if tab.pk in existing_tab_ids %}
+                <span class="badge bg-success-subtle text-success-emphasis">Есть связка</span>
+              {% endif %}
+            </div>
+            {% if tab.products.all %}
+              <div>
+                <label class="form-label small mb-1">Связать с товаром корзины</label>
+                <select name="alternate_product_id" class="form-select form-select-sm">
+                  <option value="">Создать новый товар</option>
+                  {% for alternate in tab.products.all %}
+                    <option value="{{ alternate.pk }}" {% if alternate.main_product_id == product.pk %}selected{% endif %}>
+                      {{ alternate.name }}{% if alternate.main_product %} ({{ alternate.main_product.name }}){% endif %}
+                    </option>
+                  {% endfor %}
+                </select>
+              </div>
+            {% else %}
+              <input type="hidden" name="alternate_product_id" value="">
+              <div class="small text-muted">В корзине пока нет товаров. Будет создан новый товар.</div>
+            {% endif %}
+            <div class="d-flex justify-content-end">
+              <button type="submit" class="btn btn-primary btn-sm">
+                {% if tab.pk in existing_tab_ids %}
+                  <i class="bi bi-arrow-repeat"></i> Обновить связь
+                {% else %}
+                  <i class="bi bi-cart-plus"></i> Добавить
+                {% endif %}
+              </button>
+            </div>
           </div>
-          {% if tab.pk in existing_tab_ids %}
-            <span class="badge bg-success-subtle text-success-emphasis">Уже добавлен</span>
-          {% else %}
-            <button type="submit" class="btn btn-primary btn-sm">
-              <i class="bi bi-cart-plus"></i> Добавить
-            </button>
-          {% endif %}
         </form>
       {% endfor %}
     </div>

--- a/price_manager/core/templates/shopping_tab/add_to_tab_modal_result.html
+++ b/price_manager/core/templates/shopping_tab/add_to_tab_modal_result.html
@@ -1,0 +1,13 @@
+<div class="modal-header">
+  <h5 class="modal-title">{% if status == 'success' %}Товар добавлен{% else %}Информация{% endif %}</h5>
+  <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Закрыть"></button>
+</div>
+<div class="modal-body">
+  <div class="alert {% if status == 'success' %}alert-success{% else %}alert-info{% endif %} mb-0">
+    {{ message }}
+  </div>
+</div>
+<div class="modal-footer">
+  <a href="{% url 'shopping-tab-detail' tab.pk %}" class="btn btn-primary">Перейти к корзине</a>
+  <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Закрыть</button>
+</div>

--- a/price_manager/core/templates/shopping_tab/detail.html
+++ b/price_manager/core/templates/shopping_tab/detail.html
@@ -1,0 +1,106 @@
+{% extends 'base.html' %}
+
+{% block title %}Корзина {{ tab.name }}{% endblock %}
+
+{% block body %}
+<div class="d-flex justify-content-between align-items-start flex-wrap gap-3 mb-4">
+  <div>
+    <h1 class="h3 mb-1">{{ tab.name }}</h1>
+    <p class="text-muted mb-0">Всего товаров: {{ products|length }}</p>
+  </div>
+  <a href="{% url 'shopping-tab-list' %}" class="btn btn-outline-secondary">
+    <i class="bi bi-arrow-left"></i> Ко всем корзинам
+  </a>
+</div>
+
+<div class="row g-4">
+  <div class="col-lg-4">
+    <div class="card shadow-sm h-100">
+      <div class="card-body">
+        <h2 class="h5 mb-3">Настройки корзины</h2>
+        <form method="post" novalidate>
+          {% csrf_token %}
+          {% if form.non_field_errors %}
+            <div class="alert alert-danger">
+              {{ form.non_field_errors }}
+            </div>
+          {% endif %}
+          <div class="mb-3">
+            {{ form.name.label_tag }}
+            {{ form.name }}
+            {% if form.name.errors %}
+              <div class="invalid-feedback d-block">{{ form.name.errors|striptags }}</div>
+            {% endif %}
+          </div>
+          <div class="form-check form-switch mb-3">
+            {{ form.open }}
+            <label class="form-check-label" for="{{ form.open.id_for_label }}">{{ form.open.label }}</label>
+            {% if form.open.errors %}
+              <div class="invalid-feedback d-block">{{ form.open.errors|striptags }}</div>
+            {% endif %}
+          </div>
+          <button type="submit" class="btn btn-primary w-100">Сохранить</button>
+        </form>
+      </div>
+    </div>
+  </div>
+  <div class="col-lg-8">
+    <div class="card shadow-sm h-100">
+      <div class="card-body d-flex flex-column">
+        <div class="d-flex justify-content-between align-items-start flex-wrap gap-2 mb-3">
+          <h2 class="h5 mb-0">Товары в корзине</h2>
+          <a href="{% url 'shopping-tab-product-create' tab.pk %}" class="btn btn-primary btn-sm">
+            <i class="bi bi-plus-lg"></i> Добавить товар
+          </a>
+        </div>
+        {% if products %}
+          <div class="table-responsive">
+            <table class="table table-hover align-middle mb-0">
+              <thead>
+                <tr>
+                  <th scope="col">Название</th>
+                  <th scope="col">Главный товар</th>
+                  <th scope="col" class="text-end">Действия</th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for product in products %}
+                  <tr>
+                    <td class="fw-semibold">{{ product.name }}</td>
+                    <td>
+                      {% if product.main_product %}
+                        <a href="{% url 'main-product-update' product.main_product.pk %}">{{ product.main_product.name }}</a>
+                        <div class="small text-muted">Артикул: {{ product.main_product.article }}</div>
+                      {% else %}
+                        <span class="text-muted">Не привязан к основному товару</span>
+                      {% endif %}
+                    </td>
+                    <td class="text-end">
+                      <div class="btn-group btn-group-sm" role="group" aria-label="Управление товаром">
+                        <a href="{% url 'shopping-tab-product-update' tab.pk product.pk %}" class="btn btn-outline-secondary" title="Редактировать">
+                          <i class="bi bi-pencil"></i>
+                        </a>
+                        <form method="post" action="{% url 'shopping-tab-product-delete' tab.pk product.pk %}" class="d-inline" onsubmit="return confirm('Удалить товар \"{{ product.name }}\" из корзины?');">
+                          {% csrf_token %}
+                          <button type="submit" class="btn btn-outline-danger" title="Удалить">
+                            <i class="bi bi-trash"></i>
+                          </button>
+                        </form>
+                      </div>
+                    </td>
+                  </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+        {% else %}
+          <div class="text-center text-muted py-5">
+            <i class="bi bi-card-list fs-1 d-block mb-3"></i>
+            <p class="mb-0">В этой корзине пока нет товаров. Добавьте товар вручную или через главный прайс.</p>
+          </div>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/price_manager/core/templates/shopping_tab/list.html
+++ b/price_manager/core/templates/shopping_tab/list.html
@@ -1,0 +1,89 @@
+{% extends 'base.html' %}
+
+{% block title %}Корзины{% endblock %}
+
+{% block body %}
+<div class="row g-4">
+  <div class="col-lg-4">
+    <div class="card shadow-sm h-100">
+      <div class="card-body">
+        <h1 class="h4 mb-3">Создать корзину</h1>
+        <form method="post" novalidate>
+          {% csrf_token %}
+          {% if form.non_field_errors %}
+            <div class="alert alert-danger">
+              {{ form.non_field_errors }}
+            </div>
+          {% endif %}
+          <div class="mb-3">
+            {{ form.name.label_tag }}
+            {{ form.name }}
+            {% if form.name.help_text %}
+              <div class="form-text">{{ form.name.help_text }}</div>
+            {% endif %}
+            {% if form.name.errors %}
+              <div class="invalid-feedback d-block">
+                {{ form.name.errors|striptags }}
+              </div>
+            {% endif %}
+          </div>
+          <button type="submit" class="btn btn-primary w-100">
+            <i class="bi bi-plus-lg"></i> Создать
+          </button>
+        </form>
+      </div>
+    </div>
+  </div>
+  <div class="col-lg-8">
+    <div class="card shadow-sm h-100">
+      <div class="card-body d-flex flex-column">
+        <div class="d-flex justify-content-between align-items-start flex-wrap gap-2 mb-3">
+          <h2 class="h4 mb-0">Мои корзины</h2>
+          <a href="{% url 'shopping-tab-list' %}" class="btn btn-outline-secondary btn-sm">
+            <i class="bi bi-arrow-clockwise"></i> Обновить
+          </a>
+        </div>
+        {% if tabs %}
+          <div class="list-group list-group-flush">
+            {% for tab in tabs %}
+              <div class="list-group-item py-3">
+                <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-3">
+                  <div>
+                    <h3 class="h5 mb-1">
+                      <a href="{% url 'shopping-tab-detail' tab.pk %}" class="text-decoration-none">{{ tab.name }}</a>
+                    </h3>
+                    <div class="text-muted small d-flex flex-wrap align-items-center gap-2">
+                      <span>{{ tab.product_count }} товар(ов)</span>
+                      {% if tab.open %}
+                        <span class="badge bg-success-subtle text-success-emphasis">Открыта</span>
+                      {% else %}
+                        <span class="badge bg-secondary">Закрыта</span>
+                      {% endif %}
+                    </div>
+                  </div>
+                  <div class="d-flex gap-2">
+                    <a href="{% url 'shopping-tab-detail' tab.pk %}" class="btn btn-sm btn-outline-primary">
+                      <i class="bi bi-box-arrow-in-right"></i> Открыть
+                    </a>
+                    <form method="post" action="{% url 'shopping-tab-delete' tab.pk %}" onsubmit="return confirm('Удалить корзину \"{{ tab.name }}\"?');">
+                      {% csrf_token %}
+                      <button type="submit" class="btn btn-sm btn-outline-danger">
+                        <i class="bi bi-trash"></i>
+                      </button>
+                    </form>
+                  </div>
+                </div>
+              </div>
+            {% endfor %}
+          </div>
+        {% else %}
+          <div class="text-center text-muted py-5">
+            <i class="bi bi-basket fs-1 d-block mb-3"></i>
+            <p class="mb-0">У вас пока нет созданных корзин. Используйте форму слева, чтобы добавить первую.</p>
+          </div>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/price_manager/core/templates/shopping_tab/product_form.html
+++ b/price_manager/core/templates/shopping_tab/product_form.html
@@ -1,0 +1,46 @@
+{% extends 'base.html' %}
+
+{% block title %}{% if is_update %}Редактировать товар{% else %}Добавить товар{% endif %}{% endblock %}
+
+{% block body %}
+<div class="mb-4">
+  <a href="{% url 'shopping-tab-detail' tab.pk %}" class="btn btn-outline-secondary btn-sm">
+    <i class="bi bi-arrow-left"></i> Назад к корзине
+  </a>
+</div>
+
+<div class="card shadow-sm">
+  <div class="card-body">
+    <h1 class="h4 mb-3">{% if is_update %}Редактировать товар{% else %}Добавить товар{% endif %}</h1>
+    <form method="post" novalidate>
+      {% csrf_token %}
+      {% if form.non_field_errors %}
+        <div class="alert alert-danger">
+          {{ form.non_field_errors }}
+        </div>
+      {% endif %}
+      <div class="mb-3">
+        {{ form.name.label_tag }}
+        {{ form.name }}
+        {% if form.name.errors %}
+          <div class="invalid-feedback d-block">{{ form.name.errors|striptags }}</div>
+        {% endif %}
+      </div>
+      <div class="mb-3">
+        {{ form.main_product.label_tag }}
+        {{ form.main_product }}
+        {% if form.main_product.errors %}
+          <div class="invalid-feedback d-block">{{ form.main_product.errors|striptags }}</div>
+        {% endif %}
+      </div>
+      <button type="submit" class="btn btn-primary">
+        {% if is_update %}
+          <i class="bi bi-check-lg"></i> Сохранить изменения
+        {% else %}
+          <i class="bi bi-plus-lg"></i> Добавить
+        {% endif %}
+      </button>
+    </form>
+  </div>
+</div>
+{% endblock %}

--- a/price_manager/price_manager/urls.py
+++ b/price_manager/price_manager/urls.py
@@ -51,7 +51,14 @@ urlpatterns = [
 
     path('main-product/<int:id>/update', views.MainProductUpdate.as_view(), name='main-product-update'),
     path('main-product/sync/', views.sync_main_products, name='main-product-sync'),
-    path('toggle-basket/<int:pk>/', views.toggle_basket, name='toggle-basket'),
-
     path('upload/<str:name>/<int:id>/', views.FileUpload.as_view(), name='upload'),
+
+    path('shopping-tabs/', views.ShoppingTabListView.as_view(), name='shopping-tab-list'),
+    path('shopping-tabs/<int:pk>/', views.ShoppingTabDetailView.as_view(), name='shopping-tab-detail'),
+    path('shopping-tabs/<int:pk>/delete/', views.ShoppingTabDeleteView.as_view(), name='shopping-tab-delete'),
+    path('shopping-tabs/<int:tab_pk>/products/create/', views.ShoppingTabProductCreateView.as_view(), name='shopping-tab-product-create'),
+    path('shopping-tabs/<int:tab_pk>/products/<int:product_pk>/edit/', views.ShoppingTabProductUpdateView.as_view(), name='shopping-tab-product-update'),
+    path('shopping-tabs/<int:tab_pk>/products/<int:pk>/delete/', views.ShoppingTabProductDeleteView.as_view(), name='shopping-tab-product-delete'),
+    path('shopping-tabs/select/<int:product_id>/', views.ShoppingTabSelectionView.as_view(), name='shopping-tab-select'),
+    path('shopping-tabs/<int:tab_pk>/add/<int:product_id>/', views.ShoppingTabAddProductView.as_view(), name='shopping-tab-add-product'),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
## Summary
- Added CRUD interfaces for shopping tabs, including dedicated forms, views, and templates for managing alternate products.
- Implemented a modal workflow to add main products to a selected shopping tab directly from the main price table.
- Linked the new shopping tab management into the navigation and updated the table action rendering to support the modal flow.

## Testing
- python manage.py test *(fails: отсутствует подключение к PostgreSQL в окружении)*

------
https://chatgpt.com/codex/tasks/task_e_68dba7db0ac0832da153bb92f95a16cc