### PR TITLE
Add shopping tab management UI and modal integration

### DIFF
--- a/price_manager/core/forms.py
+++ b/price_manager/core/forms.py
@@ -5,6 +5,51 @@ from .models import PriceManager, Discount
 
 from .models import *
 
+
+class ShopingTabForm(forms.ModelForm):
+  class Meta:
+    model = ShopingTab
+    fields = ['name']
+    widgets = {
+      'name': forms.TextInput(attrs={'class': 'form-control', 'placeholder': 'Название корзины'})
+    }
+
+
+class AlternateProductForm(forms.ModelForm):
+  def __init__(self, *args, **kwargs):
+    super().__init__(*args, **kwargs)
+    self.fields['main_product'].required = False
+    self.fields['main_product'].queryset = MainProduct.objects.order_by('name')
+
+  class Meta:
+    model = AlternateProduct
+    fields = ['name', 'main_product']
+    widgets = {
+      'name': forms.TextInput(attrs={'class': 'form-control', 'placeholder': 'Название товара'}),
+      'main_product': forms.Select(attrs={'class': 'form-select select2'})
+    }
+    labels = {
+      'name': 'Название',
+      'main_product': 'Главный товар'
+    }
+
+
+class ShopingTabAddProductForm(forms.Form):
+  shoping_tab = forms.ModelChoiceField(
+    queryset=ShopingTab.objects.none(),
+    label='Корзина',
+    widget=forms.Select(attrs={'class': 'form-select'})
+  )
+  main_product = forms.ModelChoiceField(
+    queryset=MainProduct.objects.order_by('name'),
+    label='',
+    widget=forms.HiddenInput()
+  )
+
+  def __init__(self, user, *args, **kwargs):
+    super().__init__(*args, **kwargs)
+    self.fields['shoping_tab'].queryset = ShopingTab.objects.filter(user=user).order_by('name')
+
 class SupplierForm(forms.ModelForm):
   class Meta:
     model = Supplier

--- a/price_manager/core/tables.py
+++ b/price_manager/core/tables.py
@@ -192,7 +192,6 @@ class MainProductListTable(tables.Table):
             'main/product/actions.html',
             {
                 'record': record,
-                'basket': self.request.session.get('basket', []),
             }
         )
   def render_name(self, record):

--- a/price_manager/core/templates/includes/header.html
+++ b/price_manager/core/templates/includes/header.html
@@ -18,6 +18,9 @@
         <li class="nav-item">
           <a class="nav-link" href="{% url 'currency' %}">Валюта</a>
         </li>
+        <li class="nav-item">
+          <a class="nav-link" href="{% url 'shoping-tab-list' %}">Корзины</a>
+        </li>
         <li class="nav-item dropdown">
           <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
             Еще

--- a/price_manager/core/templates/main/main.html
+++ b/price_manager/core/templates/main/main.html
@@ -117,6 +117,7 @@
     </form>
   </div>
 </div>
+<div id="shopping-tab-modal-container"></div>
 {% endblock %}
 
 {% block script %}
@@ -287,6 +288,107 @@
     }
     initFilterToggles();
     registerAutoUpdate();
+  });
+
+  const getCsrfToken = () => {
+    const match = document.cookie.match(/csrftoken=([^;]+)/);
+    return match ? decodeURIComponent(match[1]) : '';
+  };
+
+  const showTemporaryAlert = (message, type = 'success') => {
+    let container = document.querySelector('.alert-container');
+    if (!container) {
+      container = document.createElement('div');
+      container.className = 'alert-container m-5 position-fixed end-0 top-0 p-3';
+      container.style.zIndex = '1055';
+      document.body.appendChild(container);
+    }
+
+    const alert = document.createElement('div');
+    alert.className = `alert alert-${type} alert-dismissible fade show d-flex align-items-center`;
+    alert.setAttribute('role', 'alert');
+    alert.innerHTML = `<div>${message}</div><button type="button" class="btn-close ms-auto" data-bs-dismiss="alert" aria-label="Close"></button>`;
+    container.appendChild(alert);
+
+    window.setTimeout(() => {
+      try {
+        bootstrap.Alert.getOrCreateInstance(alert).close();
+      } catch (error) {
+        alert.remove();
+      }
+    }, 4000);
+  };
+
+  document.addEventListener('click', async (event) => {
+    const button = event.target.closest('.add-to-shopping-tab-btn');
+    if (!button) {
+      return;
+    }
+
+    event.preventDefault();
+
+    const modalUrl = button.getAttribute('data-modal-url');
+    if (!modalUrl) {
+      return;
+    }
+
+    try {
+      const response = await fetch(modalUrl, {
+        headers: {
+          'X-Requested-With': 'XMLHttpRequest',
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error('Не удалось открыть окно выбора корзины');
+      }
+
+      const html = await response.text();
+      const container = document.getElementById('shopping-tab-modal-container');
+      if (container) {
+        container.innerHTML = html;
+      }
+    } catch (error) {
+      showTemporaryAlert(error.message || 'Произошла ошибка', 'danger');
+    }
+  });
+
+  document.addEventListener('submit', async (event) => {
+    const form = event.target;
+    if (!(form instanceof HTMLFormElement) || form.id !== 'add-to-shopping-tab-form') {
+      return;
+    }
+
+    event.preventDefault();
+
+    const formData = new FormData(form);
+
+    try {
+      const response = await fetch(form.action, {
+        method: 'POST',
+        headers: {
+          'X-CSRFToken': getCsrfToken(),
+          'X-Requested-With': 'XMLHttpRequest',
+        },
+        body: formData,
+      });
+
+      const data = await response.json();
+
+      if (response.ok && data.status === 'ok') {
+        const modalElement = document.getElementById('add-to-shopping-tab-modal');
+        if (modalElement) {
+          const modalInstance = bootstrap.Modal.getInstance(modalElement) || new bootstrap.Modal(modalElement);
+          modalInstance.hide();
+        }
+        showTemporaryAlert(data.message || 'Товар добавлен в корзину', 'success');
+      } else {
+        const message = data && data.errors ? Object.values(data.errors).flat().join('\n') : 'Не удалось добавить товар';
+        showTemporaryAlert(message, 'danger');
+      }
+    } catch (error) {
+      showTemporaryAlert('Не удалось добавить товар', 'danger');
+    }
   });
 </script>
 {% endblock %}

--- a/price_manager/core/templates/main/product/actions.html
+++ b/price_manager/core/templates/main/product/actions.html
@@ -1,14 +1,13 @@
-<form hx-post="{% url 'toggle-basket' pk=record.pk %}"
-hx-target="this"
-hx-swap="outerHTML"
-style="display:inline;">
-<div class="container d-flex">
-<a href="{% url 'main-product-update' record.id %}" class="btn btn-sm btn-primary">
+<div class="btn-group" role="group">
+  <a href="{% url 'main-product-update' record.id %}" class="btn btn-sm btn-primary" title="Редактировать">
     <i class="bi bi-pencil-square"></i>
   </a>
-<button type="submit"
-class="btn btn-sm {% if record.pk in basket %}btn-danger{% else %}btn-success{% endif %}">
-{% if record.pk in basket %}<i class="bi bi-cart-plus-fill"></i>{% else %}<i class="bi bi-cart-plus"></i>{% endif %}
-</button>
+  <button type="button"
+          class="btn btn-sm btn-success add-to-shopping-tab-btn"
+          data-product-id="{{ record.pk }}"
+          data-product-name="{{ record.name }}"
+          data-modal-url="{% url 'shoping-tab-selection' record.pk %}"
+          title="Добавить в корзину">
+    <i class="bi bi-cart-plus"></i>
+  </button>
 </div>
-</form>

--- a/price_manager/core/templates/shoping_tab/add_from_main_modal.html
+++ b/price_manager/core/templates/shoping_tab/add_from_main_modal.html
@@ -1,0 +1,53 @@
+<div class="modal fade" id="add-to-shopping-tab-modal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h1 class="modal-title fs-5">Добавить в корзину</h1>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Закрыть"></button>
+      </div>
+      <div class="modal-body">
+        <p class="mb-3">Выберите корзину для товара <strong>{{ product.name }}</strong>.</p>
+        {% if tabs %}
+          <form id="add-to-shopping-tab-form" action="{% url 'shoping-tab-add-product' %}" method="post">
+            {% csrf_token %}
+            <input type="hidden" name="main_product" value="{{ product.pk }}">
+            <div class="mb-3">
+              <label for="id_shoping_tab" class="form-label">Корзина</label>
+              <select name="shoping_tab" class="form-select" required>
+                <option value="" selected disabled>Выберите корзину</option>
+                {% for tab in tabs %}
+                  <option value="{{ tab.pk }}">{{ tab.name }}</option>
+                {% endfor %}
+              </select>
+            </div>
+            <div class="modal-footer px-0 pb-0">
+              <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Отмена</button>
+              <button type="submit" class="btn btn-primary">
+                <i class="bi bi-cart-plus"></i> Добавить
+              </button>
+            </div>
+          </form>
+        {% else %}
+          <div class="alert alert-info">
+            У вас еще нет корзин. <a href="{% url 'shoping-tab-list' %}">Создайте корзину</a>, чтобы добавить в нее товары.
+          </div>
+          <div class="modal-footer px-0 pb-0">
+            <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Закрыть</button>
+            <a href="{% url 'shoping-tab-list' %}" class="btn btn-primary">Перейти к корзинам</a>
+          </div>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+</div>
+<script>
+  (function() {
+    const modalElement = document.getElementById('add-to-shopping-tab-modal');
+    const modal = new bootstrap.Modal(modalElement);
+    modalElement.addEventListener('hidden.bs.modal', () => {
+      modal.dispose();
+      modalElement.remove();
+    });
+    modal.show();
+  })();
+</script>

--- a/price_manager/core/templates/shoping_tab/alternate_product_form.html
+++ b/price_manager/core/templates/shoping_tab/alternate_product_form.html
@@ -1,0 +1,51 @@
+{% extends 'base.html' %}
+
+{% block title %}
+Редактирование товара
+{% endblock %}
+
+{% block body %}
+<h1 class="h3 mb-4">Редактирование товара</h1>
+<form method="post" class="card card-body shadow-sm">
+  {% csrf_token %}
+  <div class="row g-3">
+    <div class="col-md-6 col-lg-4">
+      <label for="{{ form.name.id_for_label }}" class="form-label">Название</label>
+      {{ form.name }}
+      {% if form.name.errors %}
+        <div class="text-danger small">{{ form.name.errors|join:', ' }}</div>
+      {% endif %}
+    </div>
+    <div class="col-md-6 col-lg-4">
+      <label for="{{ form.main_product.id_for_label }}" class="form-label">Главный товар</label>
+      {{ form.main_product }}
+      {% if form.main_product.errors %}
+        <div class="text-danger small">{{ form.main_product.errors|join:', ' }}</div>
+      {% endif %}
+    </div>
+  </div>
+  <div class="mt-4 d-flex gap-2">
+    <button type="submit" class="btn btn-primary">
+      <i class="bi bi-save"></i> Сохранить
+    </button>
+    <a href="{% url 'shoping-tab-list' %}" class="btn btn-outline-secondary">Отмена</a>
+  </div>
+</form>
+{% endblock %}
+
+{% block script %}
+{{ block.super }}
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('.select2').forEach((element) => {
+      if (window.jQuery && window.jQuery(element).select2) {
+        window.jQuery(element).select2({
+          width: '100%',
+          allowClear: true,
+          placeholder: element.dataset.placeholder || ''
+        });
+      }
+    });
+  });
+</script>
+{% endblock %}

--- a/price_manager/core/templates/shoping_tab/list.html
+++ b/price_manager/core/templates/shoping_tab/list.html
@@ -1,0 +1,135 @@
+{% extends 'base.html' %}
+
+{% block title %}
+Корзины
+{% endblock %}
+
+{% block body %}
+<div class="d-flex justify-content-between align-items-center mb-4">
+  <h1 class="h3 mb-0">Корзины</h1>
+  <a href="{% url 'main' %}" class="btn btn-outline-secondary">
+    <i class="bi bi-arrow-left"></i> На главную
+  </a>
+</div>
+
+<div class="card mb-4">
+  <div class="card-body">
+    <h2 class="h5">Создать корзину</h2>
+    <form method="post" action="{% url 'shoping-tab-list' %}" class="row g-3 align-items-end mt-2">
+      {% csrf_token %}
+      <div class="col-md-6 col-lg-4">
+        <label for="{{ create_form.name.id_for_label }}" class="form-label">Название</label>
+        {{ create_form.name }}
+      </div>
+      <div class="col-auto">
+        <button type="submit" class="btn btn-primary">
+          <i class="bi bi-plus-lg"></i> Добавить
+        </button>
+      </div>
+    </form>
+  </div>
+</div>
+
+{% if tab_entries %}
+  {% for tab, product_form in tab_entries %}
+    <div class="card mb-4">
+      <div class="card-header d-flex justify-content-between align-items-center">
+        <div>
+          <h2 class="h5 mb-1">{{ tab.name }}</h2>
+          <span class="text-muted">Товаров: {{ tab.products.count }}</span>
+        </div>
+        <form method="post" action="{% url 'shoping-tab-delete' tab.pk %}" onsubmit="return confirm('Удалить корзину "{{ tab.name }}"?');">
+          {% csrf_token %}
+          <button type="submit" class="btn btn-outline-danger btn-sm">
+            <i class="bi bi-trash"></i> Удалить
+          </button>
+        </form>
+      </div>
+      <div class="card-body">
+        <h3 class="h6">Добавить товар</h3>
+        <form method="post" action="{% url 'shoping-tab-product-create' tab.pk %}" class="row g-3 align-items-end mb-4">
+          {% csrf_token %}
+          <div class="col-md-6 col-lg-4">
+            <label for="{{ product_form.name.id_for_label }}" class="form-label">Название</label>
+            {{ product_form.name }}
+          </div>
+          <div class="col-md-6 col-lg-4">
+            <label for="{{ product_form.main_product.id_for_label }}" class="form-label">Главный товар</label>
+            {{ product_form.main_product }}
+            <div class="form-text">Необязательно. Можно выбрать товар из главного прайса.</div>
+          </div>
+          <div class="col-auto">
+            <button type="submit" class="btn btn-success">
+              <i class="bi bi-plus-lg"></i> Добавить
+            </button>
+          </div>
+        </form>
+
+        <div class="table-responsive">
+          <table class="table table-sm align-middle">
+            <thead>
+              <tr>
+                <th>Название</th>
+                <th>Главный товар</th>
+                <th class="text-end">Действия</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for product in tab.products.all %}
+                <tr>
+                  <td>{{ product.name }}</td>
+                  <td>
+                    {% if product.main_product %}
+                      <a href="{% url 'main-product-update' product.main_product.pk %}">
+                        {{ product.main_product.name }}
+                      </a>
+                    {% else %}
+                      <span class="text-muted">Не указано</span>
+                    {% endif %}
+                  </td>
+                  <td class="text-end">
+                    <div class="btn-group" role="group">
+                      <a href="{% url 'alternate-product-update' product.pk %}" class="btn btn-outline-primary btn-sm">
+                        <i class="bi bi-pencil"></i>
+                      </a>
+                      <form method="post" action="{% url 'shoping-tab-product-remove' tab.pk product.pk %}" class="d-inline">
+                        {% csrf_token %}
+                        <button type="submit" class="btn btn-outline-danger btn-sm" title="Удалить" onclick="return confirm('Удалить товар из корзины?');">
+                          <i class="bi bi-trash"></i>
+                        </button>
+                      </form>
+                    </div>
+                  </td>
+                </tr>
+              {% empty %}
+                <tr>
+                  <td colspan="3" class="text-center text-muted">В корзине нет товаров</td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  {% endfor %}
+{% else %}
+  <div class="alert alert-info">Пока нет ни одной корзины. Создайте первую, чтобы начать.</div>
+{% endif %}
+{% endblock %}
+
+{% block script %}
+{{ block.super }}
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('.select2').forEach((element) => {
+      if (window.jQuery && window.jQuery(element).select2) {
+        window.jQuery(element).select2({
+          width: '100%',
+          allowClear: true,
+          placeholder: element.dataset.placeholder || ''
+        });
+      }
+    });
+  });
+</script>
+{% endblock %}

--- a/price_manager/price_manager/urls.py
+++ b/price_manager/price_manager/urls.py
@@ -51,7 +51,13 @@ urlpatterns = [
 
     path('main-product/<int:id>/update', views.MainProductUpdate.as_view(), name='main-product-update'),
     path('main-product/sync/', views.sync_main_products, name='main-product-sync'),
-    path('toggle-basket/<int:pk>/', views.toggle_basket, name='toggle-basket'),
+    path('shoping-tabs/', views.ShopingTabListView.as_view(), name='shoping-tab-list'),
+    path('shoping-tabs/<int:pk>/delete/', views.ShopingTabDeleteView.as_view(), name='shoping-tab-delete'),
+    path('shoping-tabs/<int:tab_id>/products/add/', views.ShopingTabProductCreateView.as_view(), name='shoping-tab-product-create'),
+    path('shoping-tabs/<int:tab_id>/products/<int:product_id>/remove/', views.ShopingTabProductRemoveView.as_view(), name='shoping-tab-product-remove'),
+    path('alternate-products/<int:pk>/update/', views.AlternateProductUpdateView.as_view(), name='alternate-product-update'),
+    path('shoping-tabs/select/<int:product_id>/', views.ShopingTabSelectionView.as_view(), name='shoping-tab-selection'),
+    path('shoping-tabs/add-product/', views.ShopingTabAddProductView.as_view(), name='shoping-tab-add-product'),
 
     path('upload/<str:name>/<int:id>/', views.FileUpload.as_view(), name='upload'),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
## Summary
- add forms and views to manage shopping tabs and alternate products
- add a shopping tab management page with inline product controls
- integrate the main catalog with shopping tabs through a modal selection flow and navigation updates

## Testing
- python manage.py test *(fails: ModuleNotFoundError: No module named 'dal')*

------
https://chatgpt.com/codex/tasks/task_e_68dba7db0ac0832da153bb92f95a16cc