### PR TITLE
Add shopping tab management interface

### DIFF
--- a/price_manager/core/tables.py
+++ b/price_manager/core/tables.py
@@ -177,8 +177,10 @@ class MainProductListTable(tables.Table):
                          verbose_name='')
   def __init__(self, *args, **kwargs):
     self.request = kwargs.pop('request')
+    self.shoping_tabs = list(ShopingTab.objects.filter(user=self.request.user).order_by('name')) if self.request.user.is_authenticated else []
+    self.tabs_available = bool(self.shoping_tabs)
     super().__init__(*args, **kwargs)
-  
+
   class Meta:
     model = MainProduct
     fields = ['actions']
@@ -192,7 +194,7 @@ class MainProductListTable(tables.Table):
             'main/product/actions.html',
             {
                 'record': record,
-                'basket': self.request.session.get('basket', []),
+                'tabs_available': self.tabs_available,
             }
         )
   def render_name(self, record):

--- a/price_manager/core/templates/includes/header.html
+++ b/price_manager/core/templates/includes/header.html
@@ -18,6 +18,9 @@
         <li class="nav-item">
           <a class="nav-link" href="{% url 'currency' %}">Валюта</a>
         </li>
+        <li class="nav-item">
+          <a class="nav-link" href="{% url 'shoping-tab-list' %}">Корзины</a>
+        </li>
         <li class="nav-item dropdown">
           <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
             Еще

--- a/price_manager/core/templates/main/main.html
+++ b/price_manager/core/templates/main/main.html
@@ -115,6 +115,42 @@
           </a>
       </div>
     </form>
+</div>
+</div>
+<div class="modal fade" id="addToTabModal" tabindex="-1" aria-labelledby="addToTabModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <form method="post" action="{% url 'shoping-tab-add-main-product' %}">
+        {% csrf_token %}
+        <input type="hidden" name="main_product_id" id="add-to-tab-main-product-id">
+        <div class="modal-header">
+          <h1 class="modal-title fs-5" id="addToTabModalLabel">Добавить товар в корзину</h1>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Закрыть"></button>
+        </div>
+        <div class="modal-body">
+          {% if shoping_tabs %}
+            <p class="mb-3">Выберите корзину, в которую нужно добавить товар.</p>
+            <div class="list-group">
+              {% for tab in shoping_tabs %}
+                <label class="list-group-item list-group-item-action d-flex justify-content-between align-items-center" for="add-to-tab-option-{{ tab.id }}">
+                  <div class="form-check">
+                    <input class="form-check-input" type="radio" name="tab_id" value="{{ tab.id }}" id="add-to-tab-option-{{ tab.id }}" required>
+                    <span class="ms-2">{{ tab.name }}</span>
+                  </div>
+                  <span class="badge text-bg-secondary">{{ tab.products.all|length }}</span>
+                </label>
+              {% endfor %}
+            </div>
+          {% else %}
+            <p class="mb-3">У вас пока нет корзин. Создайте первую на странице <a href="{% url 'shoping-tab-list' %}">управления корзинами</a>.</p>
+          {% endif %}
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Отмена</button>
+          <button type="submit" class="btn btn-primary" {% if not shoping_tabs %}disabled{% endif %}>Добавить</button>
+        </div>
+      </form>
+    </div>
   </div>
 </div>
 {% endblock %}
@@ -288,5 +324,26 @@
     initFilterToggles();
     registerAutoUpdate();
   });
+
+  const addToTabModal = document.getElementById('addToTabModal');
+  if (addToTabModal) {
+    addToTabModal.addEventListener('show.bs.modal', (event) => {
+      const button = event.relatedTarget;
+      const productIdInput = document.getElementById('add-to-tab-main-product-id');
+      if (productIdInput) {
+        productIdInput.value = button ? button.getAttribute('data-main-product-id') : '';
+      }
+      const firstRadio = addToTabModal.querySelector('input[name="tab_id"]');
+      if (firstRadio) {
+        firstRadio.focus();
+      }
+    });
+
+    addToTabModal.addEventListener('hidden.bs.modal', () => {
+      addToTabModal.querySelectorAll('input[name="tab_id"]').forEach((radio) => {
+        radio.checked = false;
+      });
+    });
+  }
 </script>
 {% endblock %}

--- a/price_manager/core/templates/main/product/actions.html
+++ b/price_manager/core/templates/main/product/actions.html
@@ -1,14 +1,14 @@
-<form hx-post="{% url 'toggle-basket' pk=record.pk %}"
-hx-target="this"
-hx-swap="outerHTML"
-style="display:inline;">
-<div class="container d-flex">
-<a href="{% url 'main-product-update' record.id %}" class="btn btn-sm btn-primary">
+<div class="btn-group" role="group" aria-label="Действия с товаром">
+  <a href="{% url 'main-product-update' record.id %}" class="btn btn-sm btn-outline-primary" title="Редактировать товар">
     <i class="bi bi-pencil-square"></i>
   </a>
-<button type="submit"
-class="btn btn-sm {% if record.pk in basket %}btn-danger{% else %}btn-success{% endif %}">
-{% if record.pk in basket %}<i class="bi bi-cart-plus-fill"></i>{% else %}<i class="bi bi-cart-plus"></i>{% endif %}
-</button>
+  <button type="button"
+          class="btn btn-sm btn-success"
+          title="Добавить в корзину"
+          data-bs-toggle="modal"
+          data-bs-target="#addToTabModal"
+          data-main-product-id="{{ record.pk }}"
+          {% if not tabs_available %}disabled{% endif %}>
+    <i class="bi bi-cart-plus"></i>
+  </button>
 </div>
-</form>

--- a/price_manager/core/templates/shoping_tab/alternate_product_form.html
+++ b/price_manager/core/templates/shoping_tab/alternate_product_form.html
@@ -1,0 +1,40 @@
+{% extends 'base.html' %}
+
+{% block title %}Редактирование товара{% endblock %}
+
+{% block body %}
+<div class="col-lg-8 mx-auto">
+  <div class="card shadow-sm">
+    <div class="card-header">
+      <h1 class="h5 mb-0">Редактирование товара в корзине «{{ tab.name }}»</h1>
+    </div>
+    <div class="card-body">
+      <form method="post" class="row g-3">
+        {% csrf_token %}
+        <div class="col-12">
+          <label class="form-label" for="{{ form.name.id_for_label }}">Название</label>
+          {{ form.name }}
+          {% if form.name.errors %}
+            <div class="invalid-feedback d-block">
+              {% for error in form.name.errors %}{{ error }}{% if not forloop.last %}<br>{% endif %}{% endfor %}
+            </div>
+          {% endif %}
+        </div>
+        <div class="col-12">
+          <label class="form-label" for="{{ form.main_product.id_for_label }}">Связанный товар</label>
+          {{ form.main_product }}
+          {% if form.main_product.errors %}
+            <div class="invalid-feedback d-block">
+              {% for error in form.main_product.errors %}{{ error }}{% if not forloop.last %}<br>{% endif %}{% endfor %}
+            </div>
+          {% endif %}
+        </div>
+        <div class="col-12 d-flex justify-content-end gap-2">
+          <a href="{% url 'shoping-tab-list' %}#tab-{{ tab.id }}" class="btn btn-outline-secondary">Отмена</a>
+          <button type="submit" class="btn btn-primary">Сохранить</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/price_manager/core/templates/shoping_tab/list.html
+++ b/price_manager/core/templates/shoping_tab/list.html
@@ -1,0 +1,130 @@
+{% extends 'base.html' %}
+{% load special_tags %}
+
+{% block title %}Корзины{% endblock %}
+
+{% block body %}
+<div class="d-flex flex-column flex-lg-row align-items-lg-center justify-content-lg-between gap-3 mb-4">
+  <h1 class="h3 mb-0">Корзины</h1>
+  <a class="btn btn-outline-secondary" href="{% url 'main' %}"><i class="bi bi-arrow-left"></i> Вернуться к прайсу</a>
+</div>
+
+<div class="card shadow-sm mb-4">
+  <div class="card-body">
+    <h2 class="h5 mb-3">Создать новую корзину</h2>
+    <form method="post" class="row g-3 align-items-end">
+      {% csrf_token %}
+      <input type="hidden" name="action" value="create_tab">
+      <div class="col-lg-6">
+        <label class="form-label" for="{{ tab_form.name.id_for_label }}">Название корзины</label>
+        {{ tab_form.name }}
+        {% if tab_form.name.errors %}
+          <div class="invalid-feedback d-block">
+            {% for error in tab_form.name.errors %}{{ error }}{% if not forloop.last %}<br>{% endif %}{% endfor %}
+          </div>
+        {% endif %}
+      </div>
+      <div class="col-lg-auto">
+        <button type="submit" class="btn btn-primary"><i class="bi bi-plus-circle"></i> Создать</button>
+      </div>
+    </form>
+  </div>
+</div>
+
+{% if not tabs %}
+  <div class="alert alert-info">Корзины ещё не созданы. Используйте форму выше, чтобы добавить первую корзину.</div>
+{% endif %}
+
+{% for tab in tabs %}
+  {% with products=tab.products.all %}
+  <div class="card shadow-sm mb-4" id="tab-{{ tab.id }}">
+    <div class="card-header d-flex flex-column flex-lg-row justify-content-lg-between align-items-lg-center gap-2">
+      <div>
+        <h2 class="h5 mb-1">{{ tab.name }}</h2>
+        <span class="text-muted">{{ products|length }} товар(ов)</span>
+      </div>
+      <form method="post" action="{% url 'shoping-tab-delete' tab.id %}" class="ms-lg-auto" onsubmit="return confirm('Удалить корзину «{{ tab.name }}»?');">
+        {% csrf_token %}
+        <button type="submit" class="btn btn-outline-danger btn-sm">
+          <i class="bi bi-trash"></i> Удалить корзину
+        </button>
+      </form>
+    </div>
+    <div class="card-body">
+      {% if products %}
+        <div class="table-responsive">
+          <table class="table table-striped align-middle">
+            <thead>
+              <tr>
+                <th>Название</th>
+                <th>Главный товар</th>
+                <th class="text-end">Действия</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for product in products %}
+                <tr>
+                  <td>{{ product.name }}</td>
+                  <td>
+                    {% if product.main_product %}
+                      <a href="{% url 'main-product-update' product.main_product_id %}" class="link-primary">{{ product.main_product.name }}</a>
+                    {% else %}
+                      <span class="text-muted">Не привязан</span>
+                    {% endif %}
+                  </td>
+                  <td class="text-end">
+                    <a href="{% url 'shoping-tab-product-edit' tab.id product.id %}" class="btn btn-sm btn-outline-primary me-1">
+                      <i class="bi bi-pencil"></i>
+                    </a>
+                    <form method="post" action="{% url 'shoping-tab-product-remove' tab.id product.id %}" class="d-inline" onsubmit="return confirm('Удалить товар из корзины?');">
+                      {% csrf_token %}
+                      <button type="submit" class="btn btn-sm btn-outline-danger">
+                        <i class="bi bi-x"></i>
+                      </button>
+                    </form>
+                  </td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      {% else %}
+        <p class="text-muted">В корзине пока нет товаров.</p>
+      {% endif %}
+
+      <div class="border-top pt-3 mt-4">
+        <h3 class="h6">Добавить товар вручную</h3>
+        {% with add_form=product_forms|get_item:tab.id %}
+        <form method="post" class="row g-3 align-items-end">
+          {% csrf_token %}
+          <input type="hidden" name="action" value="add_product">
+          <input type="hidden" name="tab_id" value="{{ tab.id }}">
+          <div class="col-md-4">
+            <label class="form-label" for="{{ add_form.name.id_for_label }}">Название</label>
+            {{ add_form.name }}
+            {% if add_form.name.errors %}
+              <div class="invalid-feedback d-block">
+                {% for error in add_form.name.errors %}{{ error }}{% if not forloop.last %}<br>{% endif %}{% endfor %}
+              </div>
+            {% endif %}
+          </div>
+          <div class="col-md-5">
+            <label class="form-label" for="{{ add_form.main_product.id_for_label }}">Связанный товар</label>
+            {{ add_form.main_product }}
+            {% if add_form.main_product.errors %}
+              <div class="invalid-feedback d-block">
+                {% for error in add_form.main_product.errors %}{{ error }}{% if not forloop.last %}<br>{% endif %}{% endfor %}
+              </div>
+            {% endif %}
+          </div>
+          <div class="col-md-auto">
+            <button type="submit" class="btn btn-success"><i class="bi bi-cart-plus"></i> Добавить</button>
+          </div>
+        </form>
+        {% endwith %}
+      </div>
+    </div>
+  </div>
+  {% endwith %}
+{% endfor %}
+{% endblock %}

--- a/price_manager/price_manager/urls.py
+++ b/price_manager/price_manager/urls.py
@@ -13,6 +13,11 @@ urlpatterns = [
     path('', views.MainPage.as_view(), name='main'),
     path('main/filter-options/', views.MainFilterOptionsView.as_view(), name='main-filter-options'),
     path('main/table/', views.MainTableView.as_view(), name='main-table'),
+    path('shoping-tabs/', views.ShopingTabListView.as_view(), name='shoping-tab-list'),
+    path('shoping-tabs/<int:pk>/delete/', views.ShopingTabDeleteView.as_view(), name='shoping-tab-delete'),
+    path('shoping-tabs/<int:tab_id>/products/<int:pk>/edit/', views.AlternateProductUpdateView.as_view(), name='shoping-tab-product-edit'),
+    path('shoping-tabs/<int:tab_id>/products/<int:pk>/remove/', views.ShopingTabRemoveProductView.as_view(), name='shoping-tab-product-remove'),
+    path('shoping-tabs/add-main-product/', views.add_main_product_to_tab, name='shoping-tab-add-main-product'),
     
     path('supplier/', views.SupplierList.as_view(), name='supplier'),
     path('supplier/<int:id>/', views.SupplierDetail.as_view(), name='supplier-detail'),
@@ -51,7 +56,5 @@ urlpatterns = [
 
     path('main-product/<int:id>/update', views.MainProductUpdate.as_view(), name='main-product-update'),
     path('main-product/sync/', views.sync_main_products, name='main-product-sync'),
-    path('toggle-basket/<int:pk>/', views.toggle_basket, name='toggle-basket'),
-
     path('upload/<str:name>/<int:id>/', views.FileUpload.as_view(), name='upload'),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
## Summary
- add a dedicated page for managing shopping tabs and their alternate products
- integrate a modal flow on the main price table to add products into existing tabs
- expose the new workflows via forms, navigation updates, and supporting URLs

## Testing
- python manage.py test *(fails: database connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68dba7db0ac0832da153bb92f95a16cc