### PR TITLE
Improve main product search term matching

### DIFF
--- a/price_manager/core/filters.py
+++ b/price_manager/core/filters.py
@@ -1,6 +1,9 @@
 from django_filters import filters, FilterSet
-from .models import *
 from django import forms
+from django.contrib.postgres.fields import ArrayField
+from django.db import models
+from django.db.models import F, Func
+from .models import *
 
 class MainProductFilter(FilterSet):
   search = filters.CharFilter(method='search_method', label='Поиск')
@@ -33,16 +36,53 @@ class MainProductFilter(FilterSet):
     model = MainProduct
     fields = ['search', 'anti_search', 'supplier', 'category', 'manufacturer', 'available']
   def search_method(self, queryset, name, value):
-    query = SearchQuery(value, search_type="websearch")  # or "websearch" or "plain"
-    rank  = SearchRank("search_vector", query)
+    if not value:
+      return queryset
 
+    bits = [bit.lower() for bit in value.split() if bit.strip()]
+    if not bits:
+      return queryset
+
+    lexeme_lists = queryset.model.objects.annotate(
+      lexemes=Func(
+        F('search_vector'),
+        function='tsvector_to_array',
+        output_field=ArrayField(models.TextField())
+      )
+    ).values_list('lexemes', flat=True)
+
+    lexemes = set()
+    for lexeme_list in lexeme_lists:
+      if not lexeme_list:
+        continue
+      for component in lexeme_list:
+        if component:
+          lexemes.add(component.lower())
+
+    matched_terms = []
+    for bit in bits:
+      best_match = bit
+      best_ratio = 0
+      for component in lexemes:
+        if bit in component or component in bit:
+          ratio = min(len(bit), len(component)) / max(len(bit), len(component))
+          if ratio > best_ratio:
+            best_ratio = ratio
+            best_match = component
+      matched_terms.append(best_match)
+
+    if not matched_terms:
+      return queryset
+
+    search_queries = [SearchQuery(term, search_type="websearch") for term in matched_terms]
+    combined_query = search_queries[0]
+    for query_obj in search_queries[1:]:
+      combined_query &= query_obj
+
+    rank = SearchRank("search_vector", combined_query)
     queryset = queryset.annotate(rank=rank)
 
-    for bit in value.split(' '):
-      query = SearchQuery(bit, search_type="websearch")
-      queryset = queryset.filter(search_vector=query)      # uses GIN index
-    
-    return queryset.order_by("-rank")
+    return queryset.filter(search_vector=combined_query).order_by("-rank")
   def anti_search_method(self, queryset, name, value):
     query = SearchQuery(value, search_type="websearch")  # or "websearch" or "plain"
     rank  = SearchRank("search_vector", query)

--- a/price_manager/core/filters.py
+++ b/price_manager/core/filters.py
@@ -56,8 +56,13 @@ class MainProductFilter(FilterSet):
       if not lexeme_list:
         continue
       for component in lexeme_list:
-        if component:
-          lexemes.add(component.lower())
+        if not component:
+          continue
+        component_lower = component.lower()
+        for bit in bits:
+          if bit in component_lower or component_lower in bit:
+            lexemes.add(component_lower)
+            break
 
     matched_terms = []
     for bit in bits:


### PR DESCRIPTION
## Summary
- extract search vector lexemes to map each query token to the closest component by length ratio
- build a combined SearchQuery from the matched terms and rank results with SearchRank

## Testing
- python -m compileall price_manager/core/filters.py

------
https://chatgpt.com/codex/tasks/task_e_68dcd1f93240832da339bd1b87632db8