### PR TITLE
Add category filter search and restrict parent category selection

### DIFF
--- a/price_manager/core/templates/includes/category_tree_filter.html
+++ b/price_manager/core/templates/includes/category_tree_filter.html
@@ -1,4 +1,4 @@
-<div class="category-tree">
+<div class="category-tree" data-category-tree>
   <ul class="list-unstyled">
     {% for node in category_tree %}
       {% include 'includes/category_tree_node.html' with node=node field=field selected_categories=selected_categories %}

--- a/price_manager/core/templates/includes/category_tree_node.html
+++ b/price_manager/core/templates/includes/category_tree_node.html
@@ -1,4 +1,4 @@
-<li>
+<li data-category-node data-category-name="{{ node.category.name|lower|escape }}">
   <div class="form-check">
     <input
         class="form-check-input"
@@ -6,9 +6,15 @@
         name="{{ field.html_name }}"
         value="{{ node.category.pk }}"
         id="{{ field.auto_id }}_{{ node.category.pk }}"
-        {% if node.category.pk|stringformat:'s' in selected_categories %}checked{% endif %}
+        {% if node.children %}disabled data-category-non-selectable="true"{% else %}{% if node.category.pk|stringformat:'s' in selected_categories %}checked{% endif %}{% endif %}
     >
-    <label class="form-check-label" for="{{ field.auto_id }}_{{ node.category.pk }}">{{ node.category.name }}</label>
+    <label
+        class="form-check-label{% if node.children %} text-muted{% endif %}"
+        for="{{ field.auto_id }}_{{ node.category.pk }}"
+        {% if node.children %}title="Выберите подкатегорию"{% endif %}
+    >
+      {{ node.category.name }}
+    </label>
   </div>
   {% if node.children %}
     <ul class="list-unstyled ms-3">

--- a/price_manager/core/templates/main/includes/filter_field.html
+++ b/price_manager/core/templates/main/includes/filter_field.html
@@ -23,7 +23,18 @@
       <label for="{{ field.id_for_label }}" class="form-label">{{ field.label }}</label>
       {{ field }}
     {% else %}
-      {% include 'includes/category_tree_filter.html' with field=field category_tree=category_tree selected_categories=selected_categories %}
+      <div data-category-filter>
+        <label for="{{ field.auto_id }}_search" class="form-label">Поиск категории</label>
+        <input
+            type="search"
+            id="{{ field.auto_id }}_search"
+            class="form-control form-control-sm"
+            placeholder="Начните вводить название категории"
+            data-category-filter-search
+            data-ignore-auto-update="true"
+        >
+        {% include 'includes/category_tree_filter.html' with field=field category_tree=category_tree selected_categories=selected_categories %}
+      </div>
     {% endif %}
     {% if options is not None %}
       <div class="mt-3">

--- a/price_manager/core/templates/main/main.html
+++ b/price_manager/core/templates/main/main.html
@@ -229,6 +229,10 @@
 
   const scheduleTableUpdate = debounce(requestTableUpdate, 500);
 
+  const shouldIgnoreAutoUpdate = (element) => {
+    return Boolean(element && element.dataset && element.dataset.ignoreAutoUpdate === 'true');
+  };
+
   const registerAutoUpdate = () => {
     const form = getFilterForm();
     if (!form || form.dataset.autoUpdateInitialized === 'true') {
@@ -242,6 +246,9 @@
       }
 
       if (target.matches('input[type="text"], input[type="search"], textarea')) {
+        if (shouldIgnoreAutoUpdate(target)) {
+          return;
+        }
         scheduleTableUpdate();
       }
     });
@@ -253,6 +260,9 @@
       }
 
       if (target.matches('input, select, textarea')) {
+        if (shouldIgnoreAutoUpdate(target)) {
+          return;
+        }
         requestTableUpdate();
       }
     });
@@ -260,10 +270,84 @@
     form.dataset.autoUpdateInitialized = 'true';
   };
 
+  const initCategoryFilterSearch = () => {
+    const containers = document.querySelectorAll('[data-category-filter]');
+    containers.forEach((container) => {
+      if (container.dataset.categoryFilterInitialized === 'true') {
+        return;
+      }
+
+      const searchInput = container.querySelector('[data-category-filter-search]');
+      const tree = container.querySelector('[data-category-tree]');
+
+      if (!searchInput || !tree) {
+        return;
+      }
+
+      const getChildList = (parent) => {
+        return Array.from(parent.children).find((element) => element.tagName === 'UL');
+      };
+
+      const getChildNodes = (parent) => {
+        const list = getChildList(parent);
+        if (!list) {
+          return [];
+        }
+        return Array.from(list.children).filter((child) => child.matches('[data-category-node]'));
+      };
+
+      const getRootNodes = () => {
+        const rootList = tree.querySelector('ul');
+        if (!rootList) {
+          return [];
+        }
+        return Array.from(rootList.children).filter((child) => child.matches('[data-category-node]'));
+      };
+
+      const filterTree = () => {
+        const term = searchInput.value.trim().toLowerCase();
+
+        if (!term) {
+          tree.querySelectorAll('[data-category-node]').forEach((node) => {
+            node.classList.remove('d-none');
+          });
+          return;
+        }
+
+        const applyFilter = (node) => {
+          const name = (node.dataset.categoryName || '').toLowerCase();
+          const children = getChildNodes(node);
+
+          let hasMatchingChild = false;
+          children.forEach((child) => {
+            if (applyFilter(child)) {
+              hasMatchingChild = true;
+            }
+          });
+
+          const matchesSelf = name.includes(term);
+          const shouldShow = matchesSelf || hasMatchingChild;
+          node.classList.toggle('d-none', !shouldShow);
+          return shouldShow;
+        };
+
+        getRootNodes().forEach((node) => {
+          applyFilter(node);
+        });
+      };
+
+      const debouncedFilter = debounce(filterTree, 150);
+      searchInput.addEventListener('input', debouncedFilter);
+      filterTree();
+      container.dataset.categoryFilterInitialized = 'true';
+    });
+  };
+
   document.addEventListener('DOMContentLoaded', () => {
     initDynamicFilters();
     initFilterToggles();
     registerAutoUpdate();
+    initCategoryFilterSearch();
     const shoppingTabModal = document.getElementById('shoppingTabSelectionModal');
     if (shoppingTabModal) {
       const modalContent = shoppingTabModal.querySelector('#shopping-tab-selection-modal-content');
@@ -288,6 +372,7 @@
       initDynamicFilters();
       initFilterToggles();
       registerAutoUpdate();
+      initCategoryFilterSearch();
     }
   });
 
@@ -297,6 +382,7 @@
     }
     initFilterToggles();
     registerAutoUpdate();
+    initCategoryFilterSearch();
   });
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add a search box to the category filter and implement client-side filtering of the tree
- disable selection of categories that have children and update styling/labels accordingly
- keep the auto-update logic from reacting to the local category search field

## Testing
- python price_manager/manage.py test *(fails: PostgreSQL database server is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e3c50200b8832d86175bf1c1a3883c