### PR TITLE
Add supplier markup creation shortcut on supplier detail page

### DIFF
--- a/price_manager/core/templates/price_manager/create.html
+++ b/price_manager/core/templates/price_manager/create.html
@@ -9,50 +9,125 @@
   <div class="d-flex flex-wrap align-items-center justify-content-between gap-3 mb-4">
     <div>
       <h1 class="mb-1">Новая наценка</h1>
-      <p class="text-muted mb-0">Создайте правило расчёта цен для выбранного поставщика.</p>
+      <p class="text-muted mb-0">
+        Настройте правило расчёта цен. Сначала выберите поставщика и источник цены,
+        затем укажите целевую цену и формулу.
+      </p>
     </div>
-    <a href="{% url 'price-manager'%}" class="btn btn-secondary">
+    <a href="{% url 'price-manager'%}" class="btn btn-outline-secondary">
       <i class="bi bi-arrow-left"></i> Все наценки
     </a>
   </div>
   <div class="row">
     <!-- Блок фильтров -->
-    <div class="col-md-3">
-      <form method="post" class="card p-3 shadow-sm">
+    <div class="col-lg-4 col-xl-3">
+      <form method="post" class="card p-3 shadow-sm markup-form">
         {% csrf_token %}
-        <h5 class="mb-3">Параметры наценки</h5>
+        <h5 class="mb-3">Параметры правила</h5>
         {% if form.non_field_errors %}
           <div class="alert alert-danger">{{ form.non_field_errors }}</div>
         {% endif %}
 
-        <!-- Поиск по всем полям -->
-        {% for field in form %}
+        <div class="mb-4">
+          <h6 class="text-muted text-uppercase small mb-2">1. Общие данные</h6>
           <div class="mb-3">
-            <label class="form-label" for="{{ field.id_for_label }}">{{ field.label }}</label>
-            {{ field }}
-            {% if field.help_text %}
-              <div class="form-text">{{ field.help_text }}</div>
-            {% endif %}
-            {% if field.name == 'price_from' %}
-              <div class="form-text">Диапазон действует на цену-источник. Оставьте пустым для «от нуля».</div>
-            {% endif %}
-            {% if field.name == 'price_to' %}
-              <div class="form-text">Оставьте пустым, если правило без верхней границы.</div>
-            {% endif %}
-            {% if field.name == 'markup' %}
-              <div class="form-text">Процентная наценка, отрицательное значение = скидка.</div>
-            {% endif %}
-            {% if field.name == 'increase' %}
-              <div class="form-text">Фиксированная надбавка добавляется после процента.</div>
-            {% endif %}
-            {% if field.errors %}
-              <div class="text-danger small mt-1">{{ field.errors }}</div>
+            <label class="form-label" for="{{ form.name.id_for_label }}">{{ form.name.label }}</label>
+            {{ form.name }}
+            {% if form.name.errors %}
+              <div class="text-danger small mt-1">{{ form.name.errors }}</div>
             {% endif %}
           </div>
-        {% endfor %}
+          <div class="mb-3">
+            <label class="form-label" for="{{ form.supplier.id_for_label }}">{{ form.supplier.label }}</label>
+            {{ form.supplier }}
+            {% if form.supplier.errors %}
+              <div class="text-danger small mt-1">{{ form.supplier.errors }}</div>
+            {% endif %}
+          </div>
+          <div class="mb-3">
+            <label class="form-label" for="{{ form.has_rrp.id_for_label }}">{{ form.has_rrp.label }}</label>
+            {{ form.has_rrp }}
+            {% if form.has_rrp.errors %}
+              <div class="text-danger small mt-1">{{ form.has_rrp.errors }}</div>
+            {% endif %}
+          </div>
+          <div class="mb-0">
+            <label class="form-label" for="{{ form.discounts.id_for_label }}">{{ form.discounts.label }}</label>
+            {{ form.discounts }}
+            <div class="form-text">Можно выбрать несколько групп скидок.</div>
+            {% if form.discounts.errors %}
+              <div class="text-danger small mt-1">{{ form.discounts.errors }}</div>
+            {% endif %}
+          </div>
+        </div>
+
+        <div class="mb-4">
+          <h6 class="text-muted text-uppercase small mb-2">2. Логика расчёта</h6>
+          <div class="mb-3">
+            <label class="form-label" for="{{ form.source.id_for_label }}">{{ form.source.label }}</label>
+            {{ form.source }}
+            {% if form.source.errors %}
+              <div class="text-danger small mt-1">{{ form.source.errors }}</div>
+            {% endif %}
+          </div>
+          <div class="mb-0">
+            <label class="form-label" for="{{ form.dest.id_for_label }}">{{ form.dest.label }}</label>
+            {{ form.dest }}
+            {% if form.dest.errors %}
+              <div class="text-danger small mt-1">{{ form.dest.errors }}</div>
+            {% endif %}
+          </div>
+        </div>
+
+        <div class="mb-4">
+          <h6 class="text-muted text-uppercase small mb-2">3. Ценовой диапазон</h6>
+          <div class="row g-2">
+            <div class="col-6">
+              <label class="form-label" for="{{ form.price_from.id_for_label }}">{{ form.price_from.label }}</label>
+              {{ form.price_from }}
+              <div class="form-text">Порог от, можно пустым.</div>
+              {% if form.price_from.errors %}
+                <div class="text-danger small mt-1">{{ form.price_from.errors }}</div>
+              {% endif %}
+            </div>
+            <div class="col-6">
+              <label class="form-label" for="{{ form.price_to.id_for_label }}">{{ form.price_to.label }}</label>
+              {{ form.price_to }}
+              <div class="form-text">Порог до, можно пустым.</div>
+              {% if form.price_to.errors %}
+                <div class="text-danger small mt-1">{{ form.price_to.errors }}</div>
+              {% endif %}
+            </div>
+          </div>
+          <div class="form-text mt-2">
+            Диапазон применяется к выбранной цене-источнику.
+          </div>
+        </div>
+
+        <div class="mb-4">
+          <h6 class="text-muted text-uppercase small mb-2">4. Формула</h6>
+          <div class="row g-2">
+            <div class="col-6">
+              <label class="form-label" for="{{ form.markup.id_for_label }}">{{ form.markup.label }}</label>
+              {{ form.markup }}
+              <div class="form-text">Процент, можно отрицательный.</div>
+              {% if form.markup.errors %}
+                <div class="text-danger small mt-1">{{ form.markup.errors }}</div>
+              {% endif %}
+            </div>
+            <div class="col-6">
+              <label class="form-label" for="{{ form.increase.id_for_label }}">{{ form.increase.label }}</label>
+              {{ form.increase }}
+              <div class="form-text">Фиксированная надбавка.</div>
+              {% if form.increase.errors %}
+                <div class="text-danger small mt-1">{{ form.increase.errors }}</div>
+              {% endif %}
+            </div>
+          </div>
+        </div>
 
         <!-- Кнопки -->
-        <div class=" d-flex gap-2 mt-5">
+        <div class="d-grid gap-2">
           <button name="btn" type="submit" class="btn btn-secondary" value="apply">
             Применить
           </button>
@@ -64,7 +139,7 @@
     </div>
 
     <!-- Таблица -->
-    <div class="col-md-9 mb-5">
+    <div class="col-lg-8 col-xl-9 mb-5">
       {% load export_url from django_tables2 %}
 
       <div class="table-responsive card p-3 shadow-sm overflow-visible">
@@ -83,5 +158,17 @@
 {% endblock %}
 
 {% block script %}
+<style>
+  .markup-form input,
+  .markup-form select,
+  .markup-form textarea {
+    width: 100%;
+    max-width: 100%;
+    box-sizing: border-box;
+  }
 
+  .markup-form select[multiple] {
+    min-height: 120px;
+  }
+</style>
 {% endblock %}

--- a/price_manager/core/templates/price_manager/create.html
+++ b/price_manager/core/templates/price_manager/create.html
@@ -14,9 +14,16 @@
         затем укажите целевую цену и формулу.
       </p>
     </div>
-    <a href="{% url 'price-manager'%}" class="btn btn-outline-secondary">
-      <i class="bi bi-arrow-left"></i> Все наценки
-    </a>
+    <div class="d-flex flex-wrap gap-2">
+      {% if request.GET.supplier %}
+        <a href="{% url 'supplier-detail' request.GET.supplier %}" class="btn btn-outline-secondary">
+          <i class="bi bi-arrow-left"></i> К поставщику
+        </a>
+      {% endif %}
+      <a href="{% url 'price-manager'%}" class="btn btn-outline-secondary">
+        <i class="bi bi-arrow-left"></i> Все наценки
+      </a>
+    </div>
   </div>
   <div class="row">
     <!-- Блок фильтров -->

--- a/price_manager/core/templates/price_manager/create.html
+++ b/price_manager/core/templates/price_manager/create.html
@@ -6,8 +6,11 @@
 
 {% block body %}
 <div class="container-fluid mt-4 mb-5">
-  <h1 class="mb-4">Новая наценка</h1>
-  <div class="container">
+  <div class="d-flex flex-wrap align-items-center justify-content-between gap-3 mb-4">
+    <div>
+      <h1 class="mb-1">Новая наценка</h1>
+      <p class="text-muted mb-0">Создайте правило расчёта цен для выбранного поставщика.</p>
+    </div>
     <a href="{% url 'price-manager'%}" class="btn btn-secondary">
       <i class="bi bi-arrow-left"></i> Все наценки
     </a>
@@ -17,10 +20,36 @@
     <div class="col-md-3">
       <form method="post" class="card p-3 shadow-sm">
         {% csrf_token %}
-        <h5 class="mb-3">Фильтры</h5>
+        <h5 class="mb-3">Параметры наценки</h5>
+        {% if form.non_field_errors %}
+          <div class="alert alert-danger">{{ form.non_field_errors }}</div>
+        {% endif %}
 
         <!-- Поиск по всем полям -->
-        {{form}}
+        {% for field in form %}
+          <div class="mb-3">
+            <label class="form-label" for="{{ field.id_for_label }}">{{ field.label }}</label>
+            {{ field }}
+            {% if field.help_text %}
+              <div class="form-text">{{ field.help_text }}</div>
+            {% endif %}
+            {% if field.name == 'price_from' %}
+              <div class="form-text">Диапазон действует на цену-источник. Оставьте пустым для «от нуля».</div>
+            {% endif %}
+            {% if field.name == 'price_to' %}
+              <div class="form-text">Оставьте пустым, если правило без верхней границы.</div>
+            {% endif %}
+            {% if field.name == 'markup' %}
+              <div class="form-text">Процентная наценка, отрицательное значение = скидка.</div>
+            {% endif %}
+            {% if field.name == 'increase' %}
+              <div class="form-text">Фиксированная надбавка добавляется после процента.</div>
+            {% endif %}
+            {% if field.errors %}
+              <div class="text-danger small mt-1">{{ field.errors }}</div>
+            {% endif %}
+          </div>
+        {% endfor %}
 
         <!-- Кнопки -->
         <div class=" d-flex gap-2 mt-5">
@@ -39,6 +68,12 @@
       {% load export_url from django_tables2 %}
 
       <div class="table-responsive card p-3 shadow-sm overflow-visible">
+        <div class="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-3">
+          <div>
+            <h5 class="mb-1">Предпросмотр товаров</h5>
+            <p class="text-muted mb-0 small">Проверьте, какие товары попадут под правило.</p>
+          </div>
+        </div>
         {% load django_tables2 %}
         {% render_table table %}
       </div>

--- a/price_manager/core/templates/supplier/detail.html
+++ b/price_manager/core/templates/supplier/detail.html
@@ -18,6 +18,31 @@
   <div class="row">
     <!-- Блок фильтров -->
     <div class="col-md-3">
+      <div class="card p-3 shadow-sm mb-3">
+        <div class="d-flex align-items-start justify-content-between gap-2">
+          <div>
+            <h5 class="mb-1">Наценки поставщика</h5>
+            <p class="text-muted mb-2 small">Быстро настройте правила расчёта цен.</p>
+          </div>
+          <a class="btn btn-sm btn-primary" href="{% url 'price-manager-create' %}?supplier={{ supplier.id }}">
+            Создать
+          </a>
+        </div>
+        {% if price_managers %}
+          <ul class="list-unstyled mb-0 small">
+            {% for price_manager in price_managers %}
+              <li class="d-flex justify-content-between align-items-center py-1 border-top">
+                <a href="{% url 'price-manager-update' price_manager.id %}" class="text-decoration-none">
+                  {{ price_manager.name }}
+                </a>
+                <span class="text-muted">→ {{ price_manager.get_dest_display }}</span>
+              </li>
+            {% endfor %}
+          </ul>
+        {% else %}
+          <div class="text-muted small">Пока нет наценок. Создайте первую.</div>
+        {% endif %}
+      </div>
       <form method="get" class="card p-3 shadow-sm">
         <h5 class="mb-3">Фильтры</h5>
 

--- a/price_manager/core/templates/supplier/detail.html
+++ b/price_manager/core/templates/supplier/detail.html
@@ -6,72 +6,93 @@
 
 {% block body %}
 <div class="container-fluid mt-4 mb-5">
-  <div class="container d-flex gap-4">
-    <h1 class="mb-4">
-      {{supplier.name}}
-    </h1>
+  <div class="d-flex flex-wrap align-items-center justify-content-between gap-3 mb-4">
     <div>
-      <a class="btn btn-secondary mt-2" href="settings" role="button">Импорт</a>
+      <h1 class="mb-1">{{supplier.name}}</h1>
+      <p class="text-muted mb-0">Управляйте товарами и наценками поставщика в одном месте.</p>
     </div>
+    <a class="btn btn-secondary" href="settings" role="button">Импорт</a>
   </div>
 
-  <div class="row">
-    <!-- Блок фильтров -->
-    <div class="col-md-3">
-      <div class="card p-3 shadow-sm mb-3">
-        <div class="d-flex align-items-start justify-content-between gap-2">
-          <div>
-            <h5 class="mb-1">Наценки поставщика</h5>
-            <p class="text-muted mb-2 small">Быстро настройте правила расчёта цен.</p>
-          </div>
-          <a class="btn btn-sm btn-primary" href="{% url 'price-manager-create' %}?supplier={{ supplier.id }}">
-            Создать
-          </a>
+  <ul class="nav nav-tabs mb-3" id="supplier-tabs" role="tablist">
+    <li class="nav-item" role="presentation">
+      <button class="nav-link active" id="products-tab" data-bs-toggle="tab" data-bs-target="#products" type="button" role="tab" aria-controls="products" aria-selected="true">
+        Товары
+      </button>
+    </li>
+    <li class="nav-item" role="presentation">
+      <button class="nav-link" id="markups-tab" data-bs-toggle="tab" data-bs-target="#markups" type="button" role="tab" aria-controls="markups" aria-selected="false">
+        Наценки
+      </button>
+    </li>
+  </ul>
+
+  <div class="tab-content">
+    <div class="tab-pane fade show active" id="products" role="tabpanel" aria-labelledby="products-tab">
+      <div class="row">
+        <!-- Блок фильтров -->
+        <div class="col-lg-4 col-xl-3">
+          <form method="get" class="card p-3 shadow-sm">
+            <h5 class="mb-3">Фильтры</h5>
+
+            <!-- Поиск по всем полям -->
+            {% for item in filter.form %}
+            <div class="container overflow-hidden">
+              <label>{{item.label}}</label>
+              <div class="mb-r">
+                {{ item}}
+              </div>
+            </div>
+            {%endfor%}
+
+            <!-- Кнопки -->
+            <div class=" d-flex gap-2 mt-5">
+              <button type="submit" class="btn btn-primary">
+                Искать
+              </button>
+            </div>
+          </form>
         </div>
-        {% if price_managers %}
-          <ul class="list-unstyled mb-0 small">
-            {% for price_manager in price_managers %}
-              <li class="d-flex justify-content-between align-items-center py-1 border-top">
-                <a href="{% url 'price-manager-update' price_manager.id %}" class="text-decoration-none">
-                  {{ price_manager.name }}
-                </a>
-                <span class="text-muted">→ {{ price_manager.get_dest_display }}</span>
-              </li>
-            {% endfor %}
-          </ul>
-        {% else %}
-          <div class="text-muted small">Пока нет наценок. Создайте первую.</div>
-        {% endif %}
+
+        <!-- Таблица -->
+        <div class="col-lg-8 col-xl-9 mb-5">
+          {% load export_url from django_tables2 %}
+
+          <div class="table-responsive card p-3 shadow-sm overflow-visible">
+            {% load django_tables2 %}
+            {% render_table table %}
+          </div>
+        </div>
       </div>
-      <form method="get" class="card p-3 shadow-sm">
-        <h5 class="mb-3">Фильтры</h5>
-
-        <!-- Поиск по всем полям -->
-        {% for item in filter.form %}
-        <div class="container overflow-hidden">
-          <label>{{item.label}}</label>
-          <div class="mb-r">
-            {{ item}}
-          </div>
-        </div>
-        {%endfor%}
-
-        <!-- Кнопки -->
-        <div class=" d-flex gap-2 mt-5">
-          <button type="submit" class="btn btn-primary">
-            Искать
-          </button>
-        </div>
-      </form>
     </div>
 
-    <!-- Таблица -->
-    <div class="col-md-9 mb-5">
-      {% load export_url from django_tables2 %}
-
-      <div class="table-responsive card p-3 shadow-sm overflow-visible">
-        {% load django_tables2 %}
-        {% render_table table %}
+    <div class="tab-pane fade" id="markups" role="tabpanel" aria-labelledby="markups-tab">
+      <div class="card p-3 shadow-sm">
+        <div class="d-flex flex-wrap align-items-center justify-content-between gap-3">
+          <div>
+            <h5 class="mb-1">Наценки поставщика</h5>
+            <p class="text-muted mb-0">Создавайте и редактируйте правила расчёта цен.</p>
+          </div>
+          <a class="btn btn-primary" href="{% url 'price-manager-create' %}?supplier={{ supplier.id }}">
+            Создать наценку
+          </a>
+        </div>
+        <hr class="my-3">
+        {% if price_managers %}
+          <div class="list-group list-group-flush">
+            {% for price_manager in price_managers %}
+              <a href="{% url 'price-manager-update' price_manager.id %}" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
+                <div>
+                  <div class="fw-semibold">{{ price_manager.name }}</div>
+                  <div class="text-muted small">Цель: {{ price_manager.get_dest_display }}</div>
+                </div>
+                <span class="text-muted small">Открыть</span>
+              </a>
+            {% endfor %}
+          </div>
+        {% else %}
+          <div class="text-muted">Пока нет наценок. Создайте первую, чтобы задать правила расчёта цен.</div>
+        {% endif %}
       </div>
     </div>
   </div>

--- a/price_manager/core/templates/supplier/detail.html
+++ b/price_manager/core/templates/supplier/detail.html
@@ -100,4 +100,26 @@
 {% endblock %}
 
 {% block script %}
+<style>
+  .supplier-products-table th {
+    white-space: normal;
+    font-size: 0.85rem;
+    vertical-align: bottom;
+  }
+
+  .supplier-products-table td {
+    white-space: nowrap;
+    vertical-align: top;
+  }
+
+  .supplier-products-table td:nth-child(4) {
+    white-space: normal;
+    min-width: 220px;
+  }
+
+  .supplier-products-table td:nth-last-child(1),
+  .supplier-products-table th:nth-last-child(1) {
+    white-space: nowrap;
+  }
+</style>
 {% endblock %}

--- a/price_manager/core/templates/supplier/detail.html
+++ b/price_manager/core/templates/supplier/detail.html
@@ -132,7 +132,7 @@
             <h5 class="mb-1">Наценки поставщика</h5>
             <p class="text-muted mb-0">Создавайте и редактируйте правила расчёта цен.</p>
           </div>
-          <a class="btn btn-primary" href="{% url 'price-manager-create' %}?supplier={{ supplier.id }}">
+          <a class="btn btn-primary" href="{% url 'price-manager-create' %}?supplier={{ supplier.id }}&next={% url 'supplier-detail' supplier.id %}">
             Создать наценку
           </a>
         </div>

--- a/price_manager/core/templates/supplier/detail.html
+++ b/price_manager/core/templates/supplier/detail.html
@@ -58,9 +58,68 @@
         <div class="col-lg-8 col-xl-9 mb-5">
           {% load export_url from django_tables2 %}
 
-          <div class="table-responsive card p-3 shadow-sm overflow-visible">
+          <div class="card p-3 shadow-sm">
+            <div class="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-3">
+              <div>
+                <h5 class="mb-1">Товары поставщика</h5>
+                <p class="text-muted mb-0 small">Настройте видимость столбцов, чтобы таблица помещалась по ширине.</p>
+              </div>
+              <div class="dropdown">
+                <button class="btn btn-outline-secondary btn-sm dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+                  Столбцы
+                </button>
+                <div class="dropdown-menu dropdown-menu-end p-3 supplier-columns-menu">
+                  <div class="form-check">
+                    <input class="form-check-input column-toggle" type="checkbox" value="discounts" id="col-discounts" checked>
+                    <label class="form-check-label" for="col-discounts">Группа скидок</label>
+                  </div>
+                  <div class="form-check">
+                    <input class="form-check-input column-toggle" type="checkbox" value="article" id="col-article" checked>
+                    <label class="form-check-label" for="col-article">Артикул</label>
+                  </div>
+                  <div class="form-check">
+                    <input class="form-check-input column-toggle" type="checkbox" value="name" id="col-name" checked>
+                    <label class="form-check-label" for="col-name">Название</label>
+                  </div>
+                  <div class="form-check">
+                    <input class="form-check-input column-toggle" type="checkbox" value="supplier_price" id="col-supplier-price" checked>
+                    <label class="form-check-label" for="col-supplier-price">Цена поставщика</label>
+                  </div>
+                  <div class="form-check">
+                    <input class="form-check-input column-toggle" type="checkbox" value="rrp" id="col-rrp" checked>
+                    <label class="form-check-label" for="col-rrp">РРЦ</label>
+                  </div>
+                  <hr class="my-2">
+                  <div class="form-check">
+                    <input class="form-check-input column-toggle" type="checkbox" value="main_basic_price" id="col-main-basic" checked>
+                    <label class="form-check-label" for="col-main-basic">Базовая (главный прайс)</label>
+                  </div>
+                  <div class="form-check">
+                    <input class="form-check-input column-toggle" type="checkbox" value="main_m_price" id="col-main-m" checked>
+                    <label class="form-check-label" for="col-main-m">Цена ИМ (главный прайс)</label>
+                  </div>
+                  <div class="form-check">
+                    <input class="form-check-input column-toggle" type="checkbox" value="main_wholesale_price" id="col-main-wholesale" checked>
+                    <label class="form-check-label" for="col-main-wholesale">Опт (главный прайс)</label>
+                  </div>
+                  <div class="form-check">
+                    <input class="form-check-input column-toggle" type="checkbox" value="main_wholesale_price_extra" id="col-main-wholesale-extra" checked>
+                    <label class="form-check-label" for="col-main-wholesale-extra">Опт 1 (главный прайс)</label>
+                  </div>
+                  <div class="form-check">
+                    <input class="form-check-input column-toggle" type="checkbox" value="actions" id="col-actions" checked>
+                    <label class="form-check-label" for="col-actions">Действия</label>
+                  </div>
+                  <div class="mt-2">
+                    <button class="btn btn-link btn-sm p-0 text-decoration-none reset-columns" type="button">Сбросить</button>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="table-responsive supplier-table-wrap">
             {% load django_tables2 %}
             {% render_table table %}
+            </div>
           </div>
         </div>
       </div>
@@ -112,7 +171,7 @@
     vertical-align: top;
   }
 
-  .supplier-products-table td:nth-child(4) {
+  .supplier-products-table td[data-col="name"] {
     white-space: normal;
     min-width: 220px;
   }
@@ -121,5 +180,69 @@
   .supplier-products-table th:nth-last-child(1) {
     white-space: nowrap;
   }
+
+  .supplier-table-wrap {
+    overflow-x: auto;
+  }
+
+  .supplier-columns-menu {
+    min-width: 260px;
+  }
 </style>
+<script>
+  (function () {
+    const supplierId = '{{ supplier.id }}';
+    const storageKey = `supplier-columns-${supplierId}`;
+    const toggles = document.querySelectorAll('.column-toggle');
+    const resetBtn = document.querySelector('.reset-columns');
+
+    const applyVisibility = (column, visible) => {
+      document.querySelectorAll(`[data-col="${column}"]`).forEach((cell) => {
+        cell.classList.toggle('d-none', !visible);
+      });
+    };
+
+    const loadState = () => {
+      try {
+        const raw = localStorage.getItem(storageKey);
+        return raw ? JSON.parse(raw) : null;
+      } catch (err) {
+        return null;
+      }
+    };
+
+    const saveState = (state) => {
+      localStorage.setItem(storageKey, JSON.stringify(state));
+    };
+
+    const state = loadState();
+    if (state) {
+      toggles.forEach((toggle) => {
+        if (Object.prototype.hasOwnProperty.call(state, toggle.value)) {
+          toggle.checked = state[toggle.value];
+          applyVisibility(toggle.value, toggle.checked);
+        }
+      });
+    }
+
+    toggles.forEach((toggle) => {
+      toggle.addEventListener('change', () => {
+        applyVisibility(toggle.value, toggle.checked);
+        const nextState = loadState() || {};
+        nextState[toggle.value] = toggle.checked;
+        saveState(nextState);
+      });
+    });
+
+    if (resetBtn) {
+      resetBtn.addEventListener('click', () => {
+        toggles.forEach((toggle) => {
+          toggle.checked = true;
+          applyVisibility(toggle.value, true);
+        });
+        localStorage.removeItem(storageKey);
+      });
+    }
+  })();
+</script>
 {% endblock %}

--- a/price_manager/product_price_manager/views.py
+++ b/price_manager/product_price_manager/views.py
@@ -68,11 +68,20 @@ class PriceManagerCreate(SingleTableMixin, CreateView):
   table_class = SupplierProductPriceManagerTable
   success_url = '/price-manager/'
   template_name = 'price_manager/create.html'
+  def get_initial(self):
+    initial = super().get_initial()
+    supplier_id = self.request.GET.get('supplier')
+    if supplier_id:
+      initial['supplier'] = supplier_id
+    return initial
   def get_success_url(self):
     return f'/price-manager'
   def get_table_data(self):
     products = SupplierProduct.objects.all()
     if not hasattr(self, 'cleaned_data'):
+      supplier_id = self.request.GET.get('supplier')
+      if supplier_id:
+        return products.filter(supplier=supplier_id)
       return products
     cleaned_data = self.cleaned_data
     products = products.filter(
@@ -99,6 +108,9 @@ class PriceManagerCreate(SingleTableMixin, CreateView):
     return products
   def get_form(self):
     form = super().get_form(self.form_class)
+    supplier_id = self.request.GET.get('supplier')
+    if supplier_id:
+      form.initial['supplier'] = supplier_id
     discounts = Discount.objects.all()
     discounts = discounts.filter(supplier=form['supplier'].value())
     choices = [(disc.id, disc.name) for disc in discounts]

--- a/price_manager/product_price_manager/views.py
+++ b/price_manager/product_price_manager/views.py
@@ -75,6 +75,12 @@ class PriceManagerCreate(SingleTableMixin, CreateView):
       initial['supplier'] = supplier_id
     return initial
   def get_success_url(self):
+    next_url = self.request.GET.get('next')
+    if next_url:
+      return next_url
+    supplier_id = self.request.GET.get('supplier')
+    if supplier_id:
+      return reverse('supplier-detail', args=[supplier_id])
     return f'/price-manager'
   def get_table_data(self):
     products = SupplierProduct.objects.all()
@@ -168,7 +174,7 @@ class PriceManagerCreate(SingleTableMixin, CreateView):
     if not self.request.POST.get('btn') == 'save': return self.form_invalid(form)
     form.save()
     messages.success(self.request, 'Наценка успешно добавлена')
-    return super().form_invalid(form)
+    return redirect(self.get_success_url())
   
 
 

--- a/price_manager/supplier_product_manager/tables.py
+++ b/price_manager/supplier_product_manager/tables.py
@@ -70,7 +70,7 @@ class SupplierProductListTable(tables.Table):
     ]
     template_name = 'django_tables2/bootstrap5.html'
     attrs = {
-      'class': 'table table-auto table-stripped table-hover clickable-rows'
+      'class': 'table table-auto table-stripped table-hover clickable-rows table-sm supplier-products-table'
       }
     
 class LinkListTable(tables.Table):

--- a/price_manager/supplier_product_manager/tables.py
+++ b/price_manager/supplier_product_manager/tables.py
@@ -29,15 +29,45 @@ class SettingListTable(tables.Table):
 
 class SupplierProductListTable(tables.Table):
   '''Таблица отображаемая на странице Постащик:имя'''
+  main_basic_price = tables.Column(
+    accessor='main_product.basic_price',
+    verbose_name='Базовая цена (главный прайс)'
+  )
+  main_m_price = tables.Column(
+    accessor='main_product.m_price',
+    verbose_name='Цена ИМ (главный прайс)'
+  )
+  main_wholesale_price = tables.Column(
+    accessor='main_product.wholesale_price',
+    verbose_name='Опт (главный прайс)'
+  )
+  main_wholesale_price_extra = tables.Column(
+    accessor='main_product.wholesale_price_extra',
+    verbose_name='Опт 1 (главный прайс)'
+  )
   actions = tables.TemplateColumn(
     template_name='supplier/product/actions.html',
     orderable=False,
     verbose_name='Действия',
     attrs = {'td': {'class': 'text-right'}}
   )
+  def render_main_basic_price(self, value):
+    return value if value is not None else '-'
+  def render_main_m_price(self, value):
+    return value if value is not None else '-'
+  def render_main_wholesale_price(self, value):
+    return value if value is not None else '-'
+  def render_main_wholesale_price_extra(self, value):
+    return value if value is not None else '-'
   class Meta:
     model = SupplierProduct
-    fields = SP_TABLE_FIELDS
+    fields = [
+      *SP_TABLE_FIELDS,
+      'main_basic_price',
+      'main_m_price',
+      'main_wholesale_price',
+      'main_wholesale_price_extra',
+    ]
     template_name = 'django_tables2/bootstrap5.html'
     attrs = {
       'class': 'table table-auto table-stripped table-hover clickable-rows'

--- a/price_manager/supplier_product_manager/tables.py
+++ b/price_manager/supplier_product_manager/tables.py
@@ -62,7 +62,11 @@ class SupplierProductListTable(tables.Table):
   class Meta:
     model = SupplierProduct
     fields = [
-      *SP_TABLE_FIELDS,
+      'discounts',
+      'article',
+      'name',
+      'supplier_price',
+      'rrp',
       'main_basic_price',
       'main_m_price',
       'main_wholesale_price',

--- a/price_manager/supplier_product_manager/tables.py
+++ b/price_manager/supplier_product_manager/tables.py
@@ -29,27 +29,51 @@ class SettingListTable(tables.Table):
 
 class SupplierProductListTable(tables.Table):
   '''Таблица отображаемая на странице Постащик:имя'''
+  discounts = tables.Column(
+    verbose_name='Группа скидок',
+    attrs={'td': {'data-col': 'discounts'}, 'th': {'data-col': 'discounts'}}
+  )
+  article = tables.Column(
+    verbose_name='Артикул поставщика',
+    attrs={'td': {'data-col': 'article'}, 'th': {'data-col': 'article'}}
+  )
+  name = tables.Column(
+    verbose_name='Название',
+    attrs={'td': {'data-col': 'name'}, 'th': {'data-col': 'name'}}
+  )
+  supplier_price = tables.Column(
+    verbose_name='Цена поставщика',
+    attrs={'td': {'data-col': 'supplier_price'}, 'th': {'data-col': 'supplier_price'}}
+  )
+  rrp = tables.Column(
+    verbose_name='РРЦ',
+    attrs={'td': {'data-col': 'rrp'}, 'th': {'data-col': 'rrp'}}
+  )
   main_basic_price = tables.Column(
     accessor='main_product.basic_price',
-    verbose_name='Базовая цена (главный прайс)'
+    verbose_name='Базовая (главный прайс)',
+    attrs={'td': {'data-col': 'main_basic_price'}, 'th': {'data-col': 'main_basic_price'}}
   )
   main_m_price = tables.Column(
     accessor='main_product.m_price',
-    verbose_name='Цена ИМ (главный прайс)'
+    verbose_name='Цена ИМ (главный прайс)',
+    attrs={'td': {'data-col': 'main_m_price'}, 'th': {'data-col': 'main_m_price'}}
   )
   main_wholesale_price = tables.Column(
     accessor='main_product.wholesale_price',
-    verbose_name='Опт (главный прайс)'
+    verbose_name='Опт (главный прайс)',
+    attrs={'td': {'data-col': 'main_wholesale_price'}, 'th': {'data-col': 'main_wholesale_price'}}
   )
   main_wholesale_price_extra = tables.Column(
     accessor='main_product.wholesale_price_extra',
-    verbose_name='Опт 1 (главный прайс)'
+    verbose_name='Опт 1 (главный прайс)',
+    attrs={'td': {'data-col': 'main_wholesale_price_extra'}, 'th': {'data-col': 'main_wholesale_price_extra'}}
   )
   actions = tables.TemplateColumn(
     template_name='supplier/product/actions.html',
     orderable=False,
     verbose_name='Действия',
-    attrs = {'td': {'class': 'text-right'}}
+    attrs = {'td': {'class': 'text-right', 'data-col': 'actions'}, 'th': {'data-col': 'actions'}}
   )
   def render_main_basic_price(self, value):
     return value if value is not None else '-'

--- a/price_manager/supplier_product_manager/views.py
+++ b/price_manager/supplier_product_manager/views.py
@@ -20,6 +20,7 @@ from django.db.models import Value
 # Импорты моделей, функций, форм, таблиц
 from file_manager.models import FileModel
 from main_product_manager.models import MainProduct, MainProductLog
+from product_price_manager.models import PriceManager
 from core.functions import extract_initial_from_post
 from .forms import *
 from .tables import *
@@ -58,6 +59,7 @@ class SupplierDetail(SingleTableMixin, FilterView):
   def get_context_data(self, **kwargs):
     context = super().get_context_data(**kwargs)
     context['supplier'] = Supplier.objects.get(id=self.kwargs.get('id'))
+    context['price_managers'] = PriceManager.objects.filter(supplier_id=self.kwargs.get('id')).order_by('name')
     return context
 
 
@@ -597,4 +599,3 @@ def upload_supplier_products(request, **kwargs):
       request,
       f'''Ошибок: {len(exs)}.     ''' + ex_str)
   return redirect('supplier-detail', id=supplier.pk)
-


### PR DESCRIPTION
### Motivation
- Упростить UX для настройки наценок: дать возможность быстро создать или перейти к наценкам прямо со страницы конкретного поставщика.
- Показать существующие правила наценок поставщика для быстрой навигации и редактирования.

### Description
- Добавлена карточка «Наценки поставщика» в шаблон `core/templates/supplier/detail.html` с кнопкой «Создать» и списком существующих правил, отображающихся по имени и целевой цене.
- В `supplier_product_manager.views.SupplierDetail` контекст страницы теперь включает `price_managers = PriceManager.objects.filter(supplier_id=...)`, отсортированный по `name`.
- В `product_price_manager.views.PriceManagerCreate` добавлена логика предзаполнения поля `supplier` из query-параметра `supplier` через `get_initial` и `get_form`, а также предпросмотр таблицы фильтруется по поставщику, если `cleaned_data` ещё не установлены.

### Testing
- Запуск миграций `python /workspace/price_manager/price_manager/manage.py migrate` выполнялся как автоматическая проверка, но завершился с ошибкой подключения к PostgreSQL (`OperationalError: connection to server at "localhost" port 5432 failed: Connection refused`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e19ce914c832d8f0c8732f69aea8d)