### PR TITLE
Fix discounts display and add main page column toggles

### DIFF
--- a/price_manager/core/templates/main/includes/table.html
+++ b/price_manager/core/templates/main/includes/table.html
@@ -137,7 +137,9 @@
               {{ category_table.table.rows|length }}
             </span>
           </div>
-          {% render_table category_table.table %}
+          <div class="main-price-table-wrap">
+            {% render_table category_table.table %}
+          </div>
         </div>
       {% endfor %}
     </div>
@@ -151,6 +153,10 @@
 <style>
   .main-columns-menu {
     min-width: 240px;
+  }
+
+  .main-price-table-wrap {
+    overflow-x: auto;
   }
 </style>
 <script>

--- a/price_manager/core/templates/main/includes/table.html
+++ b/price_manager/core/templates/main/includes/table.html
@@ -14,6 +14,10 @@
           <label class="form-check-label" for="main-col-actions">Действия</label>
         </div>
         <div class="form-check">
+          <input class="form-check-input main-column-toggle" type="checkbox" value="sku" id="main-col-sku" checked>
+          <label class="form-check-label" for="main-col-sku">SKU</label>
+        </div>
+        <div class="form-check">
           <input class="form-check-input main-column-toggle" type="checkbox" value="article" id="main-col-article" checked>
           <label class="form-check-label" for="main-col-article">Артикул</label>
         </div>
@@ -26,16 +30,93 @@
           <label class="form-check-label" for="main-col-name">Название</label>
         </div>
         <div class="form-check">
+          <input class="form-check-input main-column-toggle" type="checkbox" value="category" id="main-col-category" checked>
+          <label class="form-check-label" for="main-col-category">Категория</label>
+        </div>
+        <div class="form-check">
           <input class="form-check-input main-column-toggle" type="checkbox" value="manufacturer" id="main-col-manufacturer" checked>
           <label class="form-check-label" for="main-col-manufacturer">Производитель</label>
+        </div>
+        <div class="form-check">
+          <input class="form-check-input main-column-toggle" type="checkbox" value="stock" id="main-col-stock" checked>
+          <label class="form-check-label" for="main-col-stock">Остаток</label>
+        </div>
+        <div class="form-check">
+          <input class="form-check-input main-column-toggle" type="checkbox" value="weight" id="main-col-weight" checked>
+          <label class="form-check-label" for="main-col-weight">Вес</label>
         </div>
         <div class="form-check">
           <input class="form-check-input main-column-toggle" type="checkbox" value="prime_cost" id="main-col-prime-cost" checked>
           <label class="form-check-label" for="main-col-prime-cost">Себестоимость</label>
         </div>
         <div class="form-check">
-          <input class="form-check-input main-column-toggle" type="checkbox" value="stock" id="main-col-stock" checked>
-          <label class="form-check-label" for="main-col-stock">Остаток</label>
+          <input class="form-check-input main-column-toggle" type="checkbox" value="wholesale_price" id="main-col-wholesale-price" checked>
+          <label class="form-check-label" for="main-col-wholesale-price">Оптовая цена</label>
+        </div>
+        <div class="form-check">
+          <input class="form-check-input main-column-toggle" type="checkbox" value="basic_price" id="main-col-basic-price" checked>
+          <label class="form-check-label" for="main-col-basic-price">Базовая цена</label>
+        </div>
+        <div class="form-check">
+          <input class="form-check-input main-column-toggle" type="checkbox" value="m_price" id="main-col-m-price" checked>
+          <label class="form-check-label" for="main-col-m-price">Цена ИМ</label>
+        </div>
+        <div class="form-check">
+          <input class="form-check-input main-column-toggle" type="checkbox" value="wholesale_price_extra" id="main-col-wholesale-price-extra" checked>
+          <label class="form-check-label" for="main-col-wholesale-price-extra">Оптовая цена доп.</label>
+        </div>
+        <div class="form-check">
+          <input class="form-check-input main-column-toggle" type="checkbox" value="length" id="main-col-length" checked>
+          <label class="form-check-label" for="main-col-length">Длина</label>
+        </div>
+        <div class="form-check">
+          <input class="form-check-input main-column-toggle" type="checkbox" value="width" id="main-col-width" checked>
+          <label class="form-check-label" for="main-col-width">Ширина</label>
+        </div>
+        <div class="form-check">
+          <input class="form-check-input main-column-toggle" type="checkbox" value="depth" id="main-col-depth" checked>
+          <label class="form-check-label" for="main-col-depth">Глубина</label>
+        </div>
+        <div class="form-check">
+          <input class="form-check-input main-column-toggle" type="checkbox" value="price_updated_at" id="main-col-price-updated-at" checked>
+          <label class="form-check-label" for="main-col-price-updated-at">Обновление цены</label>
+        </div>
+        <div class="form-check">
+          <input class="form-check-input main-column-toggle" type="checkbox" value="stock_updated_at" id="main-col-stock-updated-at" checked>
+          <label class="form-check-label" for="main-col-stock-updated-at">Обновление остатков</label>
+        </div>
+        <div class="form-check">
+          <input class="form-check-input main-column-toggle" type="checkbox" value="price_managers" id="main-col-price-managers" checked>
+          <label class="form-check-label" for="main-col-price-managers">Наценки</label>
+        </div>
+        <div class="form-check">
+          <input class="form-check-input main-column-toggle" type="checkbox" value="special_prices" id="main-col-special-prices" checked>
+          <label class="form-check-label" for="main-col-special-prices">Спец наценки</label>
+        </div>
+        <hr class="my-2">
+        <div class="form-check">
+          <input class="form-check-input main-column-toggle" type="checkbox" value="supplier_delivery_days" id="main-col-supplier-delivery-days" checked>
+          <label class="form-check-label" for="main-col-supplier-delivery-days">Срок поставки (дней)</label>
+        </div>
+        <div class="form-check">
+          <input class="form-check-input main-column-toggle" type="checkbox" value="supplier_price_update_rate" id="main-col-supplier-price-update-rate" checked>
+          <label class="form-check-label" for="main-col-supplier-price-update-rate">Частота обновления цен (поставщик)</label>
+        </div>
+        <div class="form-check">
+          <input class="form-check-input main-column-toggle" type="checkbox" value="supplier_stock_update_rate" id="main-col-supplier-stock-update-rate" checked>
+          <label class="form-check-label" for="main-col-supplier-stock-update-rate">Частота обновления остатков (поставщик)</label>
+        </div>
+        <div class="form-check">
+          <input class="form-check-input main-column-toggle" type="checkbox" value="supplier_currency" id="main-col-supplier-currency" checked>
+          <label class="form-check-label" for="main-col-supplier-currency">Валюта поставщика</label>
+        </div>
+        <div class="form-check">
+          <input class="form-check-input main-column-toggle" type="checkbox" value="supplier_price_updated_at" id="main-col-supplier-price-updated-at" checked>
+          <label class="form-check-label" for="main-col-supplier-price-updated-at">Обновление цены поставщика</label>
+        </div>
+        <div class="form-check">
+          <input class="form-check-input main-column-toggle" type="checkbox" value="supplier_stock_updated_at" id="main-col-supplier-stock-updated-at" checked>
+          <label class="form-check-label" for="main-col-supplier-stock-updated-at">Обновление остатков поставщика</label>
         </div>
         <div class="mt-2">
           <button class="btn btn-link btn-sm p-0 text-decoration-none reset-main-columns" type="button">Сбросить</button>

--- a/price_manager/core/templates/main/includes/table.html
+++ b/price_manager/core/templates/main/includes/table.html
@@ -2,7 +2,47 @@
 {% load django_tables2 %}
 
 <div id="main-table-container" class="table-area mb-5">
-  <h1 class="mb-4">Главный прайс</h1>
+  <div class="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-4">
+    <h1 class="mb-0">Главный прайс</h1>
+    <div class="dropdown">
+      <button class="btn btn-outline-secondary btn-sm dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+        Столбцы
+      </button>
+      <div class="dropdown-menu dropdown-menu-end p-3 main-columns-menu">
+        <div class="form-check">
+          <input class="form-check-input main-column-toggle" type="checkbox" value="actions" id="main-col-actions" checked>
+          <label class="form-check-label" for="main-col-actions">Действия</label>
+        </div>
+        <div class="form-check">
+          <input class="form-check-input main-column-toggle" type="checkbox" value="article" id="main-col-article" checked>
+          <label class="form-check-label" for="main-col-article">Артикул</label>
+        </div>
+        <div class="form-check">
+          <input class="form-check-input main-column-toggle" type="checkbox" value="supplier" id="main-col-supplier" checked>
+          <label class="form-check-label" for="main-col-supplier">Поставщик</label>
+        </div>
+        <div class="form-check">
+          <input class="form-check-input main-column-toggle" type="checkbox" value="name" id="main-col-name" checked>
+          <label class="form-check-label" for="main-col-name">Название</label>
+        </div>
+        <div class="form-check">
+          <input class="form-check-input main-column-toggle" type="checkbox" value="manufacturer" id="main-col-manufacturer" checked>
+          <label class="form-check-label" for="main-col-manufacturer">Производитель</label>
+        </div>
+        <div class="form-check">
+          <input class="form-check-input main-column-toggle" type="checkbox" value="prime_cost" id="main-col-prime-cost" checked>
+          <label class="form-check-label" for="main-col-prime-cost">Себестоимость</label>
+        </div>
+        <div class="form-check">
+          <input class="form-check-input main-column-toggle" type="checkbox" value="stock" id="main-col-stock" checked>
+          <label class="form-check-label" for="main-col-stock">Остаток</label>
+        </div>
+        <div class="mt-2">
+          <button class="btn btn-link btn-sm p-0 text-decoration-none reset-main-columns" type="button">Сбросить</button>
+        </div>
+      </div>
+    </div>
+  </div>
 
   {% if category_tables %}
     <div class="d-flex flex-column gap-4">
@@ -26,3 +66,64 @@
     </div>
   {% endif %}
 </div>
+
+<style>
+  .main-columns-menu {
+    min-width: 240px;
+  }
+</style>
+<script>
+  (function () {
+    const storageKey = 'main-price-columns';
+    const toggles = document.querySelectorAll('.main-column-toggle');
+    const resetBtn = document.querySelector('.reset-main-columns');
+
+    const applyVisibility = (column, visible) => {
+      document.querySelectorAll(`[data-col="${column}"]`).forEach((cell) => {
+        cell.classList.toggle('d-none', !visible);
+      });
+    };
+
+    const loadState = () => {
+      try {
+        const raw = localStorage.getItem(storageKey);
+        return raw ? JSON.parse(raw) : null;
+      } catch (err) {
+        return null;
+      }
+    };
+
+    const saveState = (state) => {
+      localStorage.setItem(storageKey, JSON.stringify(state));
+    };
+
+    const state = loadState();
+    if (state) {
+      toggles.forEach((toggle) => {
+        if (Object.prototype.hasOwnProperty.call(state, toggle.value)) {
+          toggle.checked = state[toggle.value];
+          applyVisibility(toggle.value, toggle.checked);
+        }
+      });
+    }
+
+    toggles.forEach((toggle) => {
+      toggle.addEventListener('change', () => {
+        applyVisibility(toggle.value, toggle.checked);
+        const nextState = loadState() || {};
+        nextState[toggle.value] = toggle.checked;
+        saveState(nextState);
+      });
+    });
+
+    if (resetBtn) {
+      resetBtn.addEventListener('click', () => {
+        toggles.forEach((toggle) => {
+          toggle.checked = true;
+          applyVisibility(toggle.value, true);
+        });
+        localStorage.removeItem(storageKey);
+      });
+    }
+  })();
+</script>

--- a/price_manager/core/templates/supplier/detail.html
+++ b/price_manager/core/templates/supplier/detail.html
@@ -82,6 +82,10 @@
                     <label class="form-check-label" for="col-name">Название</label>
                   </div>
                   <div class="form-check">
+                    <input class="form-check-input column-toggle" type="checkbox" value="stock" id="col-stock" checked>
+                    <label class="form-check-label" for="col-stock">Остаток</label>
+                  </div>
+                  <div class="form-check">
                     <input class="form-check-input column-toggle" type="checkbox" value="supplier_price" id="col-supplier-price" checked>
                     <label class="form-check-label" for="col-supplier-price">Цена поставщика</label>
                   </div>

--- a/price_manager/main_product_manager/models.py
+++ b/price_manager/main_product_manager/models.py
@@ -6,7 +6,34 @@ from supplier_manager.models import Supplier, Category, Manufacturer
 from product_price_manager.models import PriceManager, SpecialPrice, PRICE_TYPES
 
    
-MP_TABLE_FIELDS = ['article', 'supplier', 'name', 'manufacturer','prime_cost', 'stock']
+MP_TABLE_FIELDS = [
+  'sku',
+  'article',
+  'supplier',
+  'name',
+  'category',
+  'manufacturer',
+  'stock',
+  'weight',
+  'prime_cost',
+  'wholesale_price',
+  'basic_price',
+  'm_price',
+  'wholesale_price_extra',
+  'length',
+  'width',
+  'depth',
+  'price_updated_at',
+  'stock_updated_at',
+  'price_managers',
+  'special_prices',
+  'supplier_delivery_days',
+  'supplier_price_update_rate',
+  'supplier_stock_update_rate',
+  'supplier_currency',
+  'supplier_price_updated_at',
+  'supplier_stock_updated_at',
+]
 MP_CHARS = ['sku', 'article', 'name']
 MP_FKS = ['supplier', 'category', 'discount', 'manufacturer', 'price_manager']
 MP_DECIMALS = ['weight', 'length', 'width', 'depth']

--- a/price_manager/main_product_manager/tables.py
+++ b/price_manager/main_product_manager/tables.py
@@ -13,7 +13,26 @@ class MainProductListTable(tables.Table):
   '''Таблица Главного прайса отображаемая на главной странице'''
   actions = tables.Column(empty_values=(),
                          orderable=False,
-                         verbose_name='')
+                         verbose_name='',
+                         attrs={'td': {'data-col': 'actions'}, 'th': {'data-col': 'actions'}})
+  article = tables.Column(
+    attrs={'td': {'data-col': 'article'}, 'th': {'data-col': 'article'}}
+  )
+  supplier = tables.Column(
+    attrs={'td': {'data-col': 'supplier'}, 'th': {'data-col': 'supplier'}}
+  )
+  name = tables.Column(
+    attrs={'td': {'data-col': 'name'}, 'th': {'data-col': 'name'}}
+  )
+  manufacturer = tables.Column(
+    attrs={'td': {'data-col': 'manufacturer'}, 'th': {'data-col': 'manufacturer'}}
+  )
+  prime_cost = tables.Column(
+    attrs={'td': {'data-col': 'prime_cost'}, 'th': {'data-col': 'prime_cost'}}
+  )
+  stock = tables.Column(
+    attrs={'td': {'data-col': 'stock'}, 'th': {'data-col': 'stock'}}
+  )
   def __init__(self, *args, **kwargs):
     self.request = kwargs.pop('request')
     super().__init__(*args, **kwargs)

--- a/price_manager/main_product_manager/tables.py
+++ b/price_manager/main_product_manager/tables.py
@@ -15,6 +15,9 @@ class MainProductListTable(tables.Table):
                          orderable=False,
                          verbose_name='',
                          attrs={'td': {'data-col': 'actions'}, 'th': {'data-col': 'actions'}})
+  sku = tables.Column(
+    attrs={'td': {'data-col': 'sku'}, 'th': {'data-col': 'sku'}}
+  )
   article = tables.Column(
     attrs={'td': {'data-col': 'article'}, 'th': {'data-col': 'article'}}
   )
@@ -24,14 +27,85 @@ class MainProductListTable(tables.Table):
   name = tables.Column(
     attrs={'td': {'data-col': 'name'}, 'th': {'data-col': 'name'}}
   )
+  category = tables.Column(
+    attrs={'td': {'data-col': 'category'}, 'th': {'data-col': 'category'}}
+  )
   manufacturer = tables.Column(
     attrs={'td': {'data-col': 'manufacturer'}, 'th': {'data-col': 'manufacturer'}}
+  )
+  stock = tables.Column(
+    attrs={'td': {'data-col': 'stock'}, 'th': {'data-col': 'stock'}}
+  )
+  weight = tables.Column(
+    attrs={'td': {'data-col': 'weight'}, 'th': {'data-col': 'weight'}}
   )
   prime_cost = tables.Column(
     attrs={'td': {'data-col': 'prime_cost'}, 'th': {'data-col': 'prime_cost'}}
   )
-  stock = tables.Column(
-    attrs={'td': {'data-col': 'stock'}, 'th': {'data-col': 'stock'}}
+  wholesale_price = tables.Column(
+    attrs={'td': {'data-col': 'wholesale_price'}, 'th': {'data-col': 'wholesale_price'}}
+  )
+  basic_price = tables.Column(
+    attrs={'td': {'data-col': 'basic_price'}, 'th': {'data-col': 'basic_price'}}
+  )
+  m_price = tables.Column(
+    attrs={'td': {'data-col': 'm_price'}, 'th': {'data-col': 'm_price'}}
+  )
+  wholesale_price_extra = tables.Column(
+    attrs={'td': {'data-col': 'wholesale_price_extra'}, 'th': {'data-col': 'wholesale_price_extra'}}
+  )
+  length = tables.Column(
+    attrs={'td': {'data-col': 'length'}, 'th': {'data-col': 'length'}}
+  )
+  width = tables.Column(
+    attrs={'td': {'data-col': 'width'}, 'th': {'data-col': 'width'}}
+  )
+  depth = tables.Column(
+    attrs={'td': {'data-col': 'depth'}, 'th': {'data-col': 'depth'}}
+  )
+  price_updated_at = tables.Column(
+    attrs={'td': {'data-col': 'price_updated_at'}, 'th': {'data-col': 'price_updated_at'}}
+  )
+  stock_updated_at = tables.Column(
+    attrs={'td': {'data-col': 'stock_updated_at'}, 'th': {'data-col': 'stock_updated_at'}}
+  )
+  price_managers = tables.Column(
+    verbose_name='Наценки',
+    attrs={'td': {'data-col': 'price_managers'}, 'th': {'data-col': 'price_managers'}}
+  )
+  special_prices = tables.Column(
+    verbose_name='Спец наценки',
+    attrs={'td': {'data-col': 'special_prices'}, 'th': {'data-col': 'special_prices'}}
+  )
+  supplier_delivery_days = tables.Column(
+    accessor='supplier.delivery_days',
+    verbose_name='Срок поставки (дней)',
+    attrs={'td': {'data-col': 'supplier_delivery_days'}, 'th': {'data-col': 'supplier_delivery_days'}}
+  )
+  supplier_price_update_rate = tables.Column(
+    accessor='supplier.price_update_rate',
+    verbose_name='Частота обновления цен (поставщик)',
+    attrs={'td': {'data-col': 'supplier_price_update_rate'}, 'th': {'data-col': 'supplier_price_update_rate'}}
+  )
+  supplier_stock_update_rate = tables.Column(
+    accessor='supplier.stock_update_rate',
+    verbose_name='Частота обновления остатков (поставщик)',
+    attrs={'td': {'data-col': 'supplier_stock_update_rate'}, 'th': {'data-col': 'supplier_stock_update_rate'}}
+  )
+  supplier_currency = tables.Column(
+    accessor='supplier.currency',
+    verbose_name='Валюта поставщика',
+    attrs={'td': {'data-col': 'supplier_currency'}, 'th': {'data-col': 'supplier_currency'}}
+  )
+  supplier_price_updated_at = tables.Column(
+    accessor='supplier.price_updated_at',
+    verbose_name='Обновление цены поставщика',
+    attrs={'td': {'data-col': 'supplier_price_updated_at'}, 'th': {'data-col': 'supplier_price_updated_at'}}
+  )
+  supplier_stock_updated_at = tables.Column(
+    accessor='supplier.stock_updated_at',
+    verbose_name='Обновление остатков поставщика',
+    attrs={'td': {'data-col': 'supplier_stock_updated_at'}, 'th': {'data-col': 'supplier_stock_updated_at'}}
   )
   def __init__(self, *args, **kwargs):
     self.request = kwargs.pop('request')
@@ -61,6 +135,12 @@ class MainProductListTable(tables.Table):
         'record': record,
       }
     )
+  def render_price_managers(self, record):
+    managers = list(record.price_managers.values_list('name', flat=True))
+    return ', '.join(managers) if managers else '-'
+  def render_special_prices(self, record):
+    specials = list(record.special_prices.values_list('name', flat=True))
+    return ', '.join(specials) if specials else '-'
 
 
 class CategoryListTable(tables.Table):

--- a/price_manager/main_product_manager/tables.py
+++ b/price_manager/main_product_manager/tables.py
@@ -139,7 +139,7 @@ class MainProductListTable(tables.Table):
     managers = list(record.price_managers.values_list('name', flat=True))
     return ', '.join(managers) if managers else '-'
   def render_special_prices(self, record):
-    specials = list(record.special_prices.values_list('name', flat=True))
+    specials = [str(item) for item in record.special_prices.all()]
     return ', '.join(specials) if specials else '-'
 
 

--- a/price_manager/supplier_product_manager/filters.py
+++ b/price_manager/supplier_product_manager/filters.py
@@ -1,7 +1,66 @@
-from django_filters import FilterSet
+from django import forms
+from django.db.models import Q
+from django_filters import FilterSet, filters
+
+from supplier_manager.models import Discount
 from .models import SupplierProduct
 
 class SupplierProductFilter(FilterSet):
+  search = filters.CharFilter(method='search_method', label='Поиск')
+  anti_search = filters.CharFilter(method='anti_search_method', label='Исключения')
+  discounts = filters.ModelMultipleChoiceFilter(
+    field_name='discounts',
+    queryset=Discount.objects.none(),
+    widget=forms.SelectMultiple(
+      attrs={
+        'class': 'form-select select2',
+        'data-placeholder': 'Выберите группы скидок'
+      }
+    ),
+    label='Группа скидок'
+  )
+
   class Meta:
     model = SupplierProduct
-    fields = ['name']
+    fields = ['search', 'anti_search', 'discounts']
+
+  def __init__(self, data=None, queryset=None, *, request=None, prefix=None):
+    super().__init__(data=data, queryset=queryset, request=request, prefix=prefix)
+    supplier_id = None
+    if request is not None and request.resolver_match:
+      supplier_id = request.resolver_match.kwargs.get('id')
+    if supplier_id:
+      self.filters['discounts'].queryset = Discount.objects.filter(supplier_id=supplier_id)
+    else:
+      self.filters['discounts'].queryset = Discount.objects.none()
+
+  def _build_search_terms(self, value):
+    terms = [bit for bit in value.split() if bit]
+    return terms
+
+  def _build_search_query(self, terms):
+    if not terms:
+      return None
+    query = Q()
+    for term in terms:
+      query &= (
+        Q(name__icontains=term) |
+        Q(article__icontains=term) |
+        Q(category__name__icontains=term) |
+        Q(manufacturer__name__icontains=term)
+      )
+    return query
+
+  def search_method(self, queryset, name, value):
+    terms = self._build_search_terms(value)
+    query = self._build_search_query(terms)
+    if query is None:
+      return queryset
+    return queryset.filter(query)
+
+  def anti_search_method(self, queryset, name, value):
+    terms = self._build_search_terms(value)
+    query = self._build_search_query(terms)
+    if query is None:
+      return queryset
+    return queryset.exclude(query)

--- a/price_manager/supplier_product_manager/tables.py
+++ b/price_manager/supplier_product_manager/tables.py
@@ -41,6 +41,10 @@ class SupplierProductListTable(tables.Table):
     verbose_name='Название',
     attrs={'td': {'data-col': 'name'}, 'th': {'data-col': 'name'}}
   )
+  stock = tables.Column(
+    verbose_name='Остаток',
+    attrs={'td': {'data-col': 'stock'}, 'th': {'data-col': 'stock'}}
+  )
   supplier_price = tables.Column(
     verbose_name='Цена поставщика',
     attrs={'td': {'data-col': 'supplier_price'}, 'th': {'data-col': 'supplier_price'}}
@@ -92,6 +96,7 @@ class SupplierProductListTable(tables.Table):
       'discounts',
       'article',
       'name',
+      'stock',
       'supplier_price',
       'rrp',
       'main_basic_price',

--- a/price_manager/supplier_product_manager/tables.py
+++ b/price_manager/supplier_product_manager/tables.py
@@ -83,6 +83,9 @@ class SupplierProductListTable(tables.Table):
     return value if value is not None else '-'
   def render_main_wholesale_price_extra(self, value):
     return value if value is not None else '-'
+  def render_discounts(self, record):
+    discounts = list(record.discounts.values_list('name', flat=True))
+    return ', '.join(discounts) if discounts else '-'
   class Meta:
     model = SupplierProduct
     fields = [


### PR DESCRIPTION
### Motivation
- Исправить пустой столбец «Группа скидок» в таблице товаров поставщика, чтобы отображались названия связанных скидок.
- Добавить на главную страницу (Главный прайс) механизм переключения видимости столбцов аналогично меню в странице поставщика для удобства просмотра.

### Description
- Добавлен метод `render_discounts` в `supplier_product_manager/tables.py`, который собирает и возвращает список названий скидок (`Discount`) через `record.discounts.values_list('name', flat=True)`; пустые значения показываются как `'-'`.
- В `main_product_manager/tables.py` добавлены колонки с `attrs` (`data-col`) для ключевых полей (`actions`, `article`, `supplier`, `name`, `manufacturer`, `prime_cost`, `stock`) чтобы их можно было скрывать на клиенте.
- В `core/templates/main/includes/table.html` добавлено выпадающее меню выбора столбцов (`main-columns-menu`) с чекбоксами, кнопкой сброса, минимальным CSS и скриптом, который сохраняет состояние в `localStorage` и переключает видимость ячеек по `data-col`.

### Testing
- Запуск локального сервера через `python manage.py runserver` был выполнен автоматизированно и завершился с ошибкой соединения к БД (`psycopg2.OperationalError: connection to server at "localhost", port 5432 failed`), поэтому интеграционные проверки не прошли.
- Выполнен headless скриншот страницы с помощью Playwright и сохранён артефакт `artifacts/main-price-columns.png`, однако из-за ошибки БД сервер прервался и это ограничивает валидацию UI в реальной среде.
- Юнит-тесты не запускались в рамках этого изменения.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f0fb2adf8832da89e00def03ae093)