### PR TITLE
Fix admin export crash for MainProduct supplier prices

### DIFF
--- a/price_manager/main_product_manager/resources.py
+++ b/price_manager/main_product_manager/resources.py
@@ -139,12 +139,12 @@ class MainProductResource(resources.ModelResource):
 
     def dehydrate_supplier_prices(self, mainproduct):
         """Format all supplier prices for this main product"""
-        supplier_product = mainproduct.supplier_product.all()
-        if not supplier_product:
+        supplier_products = mainproduct.supplierproducts.all()
+        if not supplier_products:
             return "No suppliers"
         
         price_list = []
-        for sp in supplier_product:
+        for sp in supplier_products:
             price_list.append(f"{sp.supplier.name}: {sp.supplier_price}({sp.rrp}) {sp.supplier.currency}")
         
         return " | ".join(price_list)


### PR DESCRIPTION
### Motivation
- Исправить падение экспорта в админке при экспорте `MainProduct`, вызванное обращением к несуществующему обратному полю `supplier_product` вместо фактического `supplierproducts`.

### Description
- В `price_manager/main_product_manager/resources.py` в методе `dehydrate_supplier_prices` заменено `mainproduct.supplier_product.all()` на `mainproduct.supplierproducts.all()` и соответствующим образом обновлена локальная переменная, при этом логика формирования строки экспорта сохранена.

### Testing
- Выполнены автоматические проверки: `python price_manager/manage.py check` и `python price_manager/manage.py test main_product_manager.tests`, обе команды завершились успешно (тестов найдено 0).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698af7bbd990832dba958d5d85804ccb)