### PR TITLE
Разделить правило срока поставки по наличию товара

### DIFF
--- a/price_manager/main_product_manager/tables.py
+++ b/price_manager/main_product_manager/tables.py
@@ -18,6 +18,11 @@ class MainProductTable(tables.Table):
   stock_msg = tables.Column(verbose_name='Статус наличия',
                             orderable=False,
                             empty_values=())
+  delivery_days = tables.Column(
+    verbose_name='Срок поставки (Рабочие дни)',
+    orderable=False,
+    empty_values=(),
+  )
   def __init__(self, *args, **kwargs):
     self.request = kwargs.pop('request')
     self.url = kwargs.pop('url', None)
@@ -29,7 +34,17 @@ class MainProductTable(tables.Table):
 
   class Meta:
     model = MainProduct
-    fields = ['actions', 'article', 'supplier', 'name', 'manufacturer','prime_cost', 'stock', 'stock_msg']
+    fields = [
+      'actions',
+      'article',
+      'supplier',
+      'name',
+      'manufacturer',
+      'prime_cost',
+      'stock',
+      'delivery_days',
+      'stock_msg',
+    ]
     template_name = 'core/includes/table_htmx.html'
     attrs = {
       'class': 'clickable-rows table table-auto table-stripped table-hover'
@@ -39,6 +54,9 @@ class MainProductTable(tables.Table):
       return record.supplier.msg_navailable
     else:
       return record.supplier.msg_available
+  
+  def render_delivery_days(self, record):
+    return record.supplier.get_delivery_days_for_stock(record.stock)
   def render_actions(self, record):
         return render_to_string(
             'main/product/actions.html',

--- a/price_manager/supplier_manager/forms.py
+++ b/price_manager/supplier_manager/forms.py
@@ -7,7 +7,16 @@ from crispy_forms.layout import Submit, Layout, Field, Div, HTML
 class SupplierForm(forms.ModelForm):
   class Meta:
     model = Supplier
-    fields = ['name', 'delivery_days', 'currency', 'price_update_rate', 'stock_update_rate', 'msg_available', 'msg_navailable']
+    fields = [
+      'name',
+      'delivery_days_available',
+      'delivery_days_navailable',
+      'currency',
+      'price_update_rate',
+      'stock_update_rate',
+      'msg_available',
+      'msg_navailable',
+    ]
   def __init__(self, *args, **kwargs):
     url = kwargs.pop('url', None)
     if not url: return None
@@ -23,7 +32,11 @@ class SupplierForm(forms.ModelForm):
     }
     self.helper.layout = Layout(
       'name', 
-      'delivery_days', 
+      Div(
+        Div('delivery_days_available', css_class='col-4'),
+        Div('delivery_days_navailable', css_class='col-4'),
+        css_class='row',
+      ),
       Field('currency', css_class='form-select'),
       HTML('<hr class="my-4 border-secondary">'),
       Div(

--- a/price_manager/supplier_manager/migrations/0007_supplier_delivery_days_stock_split.py
+++ b/price_manager/supplier_manager/migrations/0007_supplier_delivery_days_stock_split.py
@@ -1,0 +1,31 @@
+from django.db import migrations, models
+
+
+def copy_delivery_days_to_split_fields(apps, schema_editor):
+    Supplier = apps.get_model('supplier_manager', 'Supplier')
+    for supplier in Supplier.objects.all().only('id', 'delivery_days'):
+        Supplier.objects.filter(pk=supplier.pk).update(
+            delivery_days_available=supplier.delivery_days,
+            delivery_days_navailable=supplier.delivery_days,
+        )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('supplier_manager', '0006_remove_supplier_grouping_priority'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='supplier',
+            name='delivery_days_available',
+            field=models.PositiveIntegerField(default=0, verbose_name='Срок поставки (Рабочие дни) при наличии'),
+        ),
+        migrations.AddField(
+            model_name='supplier',
+            name='delivery_days_navailable',
+            field=models.PositiveIntegerField(default=0, verbose_name='Срок поставки (Рабочие дни) при отсутствии'),
+        ),
+        migrations.RunPython(copy_delivery_days_to_split_fields, migrations.RunPython.noop),
+    ]

--- a/price_manager/supplier_manager/models.py
+++ b/price_manager/supplier_manager/models.py
@@ -47,6 +47,14 @@ class Supplier(models.Model):
                                           blank=True)
   delivery_days = models.PositiveIntegerField(verbose_name='Срок доставки',
                                               default=0)
+  delivery_days_available = models.PositiveIntegerField(
+    verbose_name='Срок поставки (Рабочие дни) при наличии',
+    default=0,
+  )
+  delivery_days_navailable = models.PositiveIntegerField(
+    verbose_name='Срок поставки (Рабочие дни) при отсутствии',
+    default=0,
+  )
   price_update_rate = models.CharField(verbose_name='Частота обновления цен',
                                        choices=[(_, _) for _ in TIME_FREQ.keys()])
   stock_update_rate = models.CharField(verbose_name='Частота обновления остатков',
@@ -60,6 +68,11 @@ class Supplier(models.Model):
     ordering = ['name']
   def __str__(self):
     return self.name
+  
+  def get_delivery_days_for_stock(self, stock):
+    if stock and stock > 0:
+      return self.delivery_days_available
+    return self.delivery_days_navailable
   
 
 class Discount(models.Model):

--- a/price_manager/supplier_manager/views.py
+++ b/price_manager/supplier_manager/views.py
@@ -123,6 +123,10 @@ class SupplierUpdate(UpdateView):
   def get_success_url(self):
     return reverse('supplier-update', kwargs={'pk':self.kwargs.get('pk')})
   
+  def form_valid(self, form):
+    messages.success(self.request, 'Настройки поставщика сохранены.')
+    return super().form_valid(form)
+  
 
 class ManufacturerList(SingleTableView):
   '''Отображение производителей <<manufacturer/>>'''


### PR DESCRIPTION
### Motivation
- Нужно позволить в настройках поставщика вводить отдельные значения срока поставки (в рабочих днях) для случая, когда товар есть в наличии и когда товара нет, и чтобы отображаемое значение в главном прайсе выбиралось в зависимости от остатка товара.

### Description
- В модель `Supplier` добавлены поля `delivery_days_available` и `delivery_days_navailable` и метод `get_delivery_days_for_stock(stock)`, который возвращает корректный срок по значению `stock`.
- Обновлена форма `SupplierForm` для ввода двух полей сроков поставки вместо одного и подправлен Layout для отображения этих полей в интерфейсе.
- В таблицу главного прайса `MainProductTable` добавлена колонка `delivery_days` и реализован рендер `render_delivery_days`, который использует `supplier.get_delivery_days_for_stock(record.stock)` для вывода значения.
- Добавлена миграция `0007_supplier_delivery_days_stock_split.py`, которая добавляет новые поля и копирует текущее значение `delivery_days` в оба новых поля для существующих записей.

### Testing
- Выполнена проверка компиляции изменённых файлов командой `python -m compileall` для `models.py`, `forms.py`, `tables.py` и созданной миграции, и компиляция прошла успешно. 
- Попытка автогенерации миграции `python manage.py makemigrations supplier_manager` в текущем окружении не удалась из-за отсутствующей зависимости `widget_tweaks`. 
- Миграция была добавлена вручную как `price_manager/supplier_manager/migrations/0007_supplier_delivery_days_stock_split.py` и также успешно скомпилирована. 
- Снимок интерфейса был создан автоматически скриптом Playwright и сохранён как артефакт для визуальной проверки.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c04197c3c832db4009a77b7246267)