### PR TITLE
Добавить тест загрузки прайса поставщика через `load_setting`

### DIFF
--- a/price_manager/supplier_manager/migrations/0006_remove_supplier_grouping_priority.py
+++ b/price_manager/supplier_manager/migrations/0006_remove_supplier_grouping_priority.py
@@ -10,8 +10,15 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RemoveField(
-            model_name='supplier',
-            name='grouping_priority',
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.RemoveField(
+                    model_name='supplier',
+                    name='grouping_priority',
+                ),
+            ],
+            # Column was never added at the DB level in 0005 (state-only migration),
+            # so there is nothing to remove physically from the database.
+            database_operations=[],
         ),
     ]

--- a/price_manager/supplier_product_manager/migrations/0022_remove_setting_update_main.py
+++ b/price_manager/supplier_product_manager/migrations/0022_remove_setting_update_main.py
@@ -11,15 +11,9 @@ class Migration(migrations.Migration):
 
     operations = [
         
-        migrations.SeparateDatabaseAndState(
-            state_operations=[
-                migrations.RemoveField(
-                    model_name='setting',
-                    name='update_main',
-                ),
-            ],
-            # Table already exists. See core\migrations\0045_remove_link_setting_remove_setting_supplier_and_more.py
-            database_operations=[],
+        migrations.RemoveField(
+            model_name='setting',
+            name='update_main',
         ),
         
         migrations.SeparateDatabaseAndState(

--- a/price_manager/supplier_product_manager/migrations/0023_supplierproduct_discount_price_alter_link_key.py
+++ b/price_manager/supplier_product_manager/migrations/0023_supplierproduct_discount_price_alter_link_key.py
@@ -10,6 +10,36 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.RemoveField(
+                    model_name='setting',
+                    name='update_main_content',
+                ),
+            ],
+            # Table already exists. See core\migrations\0045_remove_link_setting_remove_setting_supplier_and_more.py
+            database_operations=[
+            ],
+        ),
+        migrations.RemoveField(
+            model_name='setting',
+            name='differ_by_name',
+        ),
+        migrations.RemoveField(
+            model_name='setting',
+            name='priced_only',
+        ),
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.RemoveField(
+                    model_name='setting',
+                    name='add_main_products',
+                ),
+            ],
+            # Table already exists. See core\migrations\0045_remove_link_setting_remove_setting_supplier_and_more.py
+            database_operations=[
+            ],
+        ),
         migrations.AddField(
             model_name='supplierproduct',
             name='discount_price',
@@ -19,21 +49,5 @@ class Migration(migrations.Migration):
             model_name='link',
             name='key',
             field=models.CharField(choices=[('', 'Не включать'), ('article', 'Артикул поставщика'), ('name', 'Название'), ('manufacturer', 'Производитель'), ('discount', 'Группа скидок'), ('stock', 'Остаток'), ('supplier_price', 'Цена поставщика в валюте поставщика'), ('rrp', 'РРЦ в валюте поставщика'), ('discount_price', 'Цена со скидкой в валюте поставщика')]),
-        ),
-        migrations.RemoveField(
-            model_name='setting',
-            name='add_main_products',
-        ),
-        migrations.RemoveField(
-            model_name='setting',
-            name='priced_only',
-        ),
-        migrations.RemoveField(
-            model_name='setting',
-            name='differ_by_name',
-        ),
-        migrations.RemoveField(
-            model_name='setting',
-            name='update_main_content',
         ),
     ]

--- a/price_manager/supplier_product_manager/models.py
+++ b/price_manager/supplier_product_manager/models.py
@@ -66,7 +66,6 @@ class SupplierProduct(models.Model):
   updated_at = models.DateTimeField(verbose_name='Последнее обновление',
                                     auto_now=True,
       blank=True)
-  
   class Meta:
     constraints = [
       models.UniqueConstraint(

--- a/price_manager/supplier_product_manager/tests.py
+++ b/price_manager/supplier_product_manager/tests.py
@@ -1,3 +1,66 @@
+from io import BytesIO
+from decimal import Decimal
+
+import pandas as pd
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
 
-# Create your tests here.
+from supplier_manager.models import Currency, Supplier
+from supplier_product_manager.functions import load_setting
+from supplier_product_manager.models import Link, Setting, SupplierFile, SupplierProduct
+
+
+class LoadSettingTests(TestCase):
+    def setUp(self):
+        self.currency = Currency.objects.create(name="KZT", value=Decimal("1"))
+        self.supplier = Supplier.objects.create(
+            name="Test supplier",
+            currency=self.currency,
+            price_update_rate="Каждый день",
+            stock_update_rate="Каждый день",
+            delivery_days_available=1,
+            delivery_days_navailable=3,
+        )
+
+    def _create_supplier_file(self, setting: Setting, dataframe: pd.DataFrame, filename: str = "supplier.xlsx"):
+        excel_buffer = BytesIO()
+        dataframe.to_excel(excel_buffer, index=False)
+        excel_buffer.seek(0)
+        uploaded_file = SimpleUploadedFile(
+            filename,
+            excel_buffer.read(),
+            content_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        )
+        return SupplierFile.objects.create(setting=setting, file=uploaded_file)
+
+    def test_load_setting_imports_products_from_supplier_file(self):
+        setting = Setting.objects.create(
+            name="Основная загрузка",
+            supplier=self.supplier,
+            sheet_name="Sheet1",
+            create_new=True,
+        )
+        Link.objects.create(setting=setting, key="article", value="Артикул")
+        Link.objects.create(setting=setting, key="name", value="Название")
+        Link.objects.create(setting=setting, key="supplier_price", value="Цена")
+
+        self._create_supplier_file(
+            setting,
+            pd.DataFrame(
+                [
+                    {"Артикул": "A-1", "Название": "Товар 1", "Цена": "123.45"},
+                    {"Артикул": "A-2", "Название": "Товар 2", "Цена": "50"},
+                ]
+            ),
+        )
+
+        result = load_setting(setting.pk)
+
+        self.assertIsNotNone(result)
+        self.assertEqual(SupplierProduct.objects.filter(supplier=self.supplier).count(), 2)
+        self.assertEqual(
+            SupplierProduct.objects.get(supplier=self.supplier, article="A-1", name="Товар 1").supplier_price,
+            Decimal("123.45"),
+        )
+        self.supplier.refresh_from_db()
+        self.assertIsNotNone(self.supplier.price_updated_at)

--- a/price_manager/supplier_product_manager/tests.py
+++ b/price_manager/supplier_product_manager/tests.py
@@ -5,14 +5,14 @@ import pandas as pd
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
 
-from supplier_manager.models import Currency, Supplier
+from supplier_manager.models import Currency, Supplier, Manufacturer
 from supplier_product_manager.functions import load_setting
 from supplier_product_manager.models import Link, Setting, SupplierFile, SupplierProduct
 
 
-class LoadSettingTests(TestCase):
+class BasicLoadTests(TestCase):
     def setUp(self):
-        self.currency = Currency.objects.create(name="KZT", value=Decimal("1"))
+        self.currency = Currency.objects.get(name="KZT")
         self.supplier = Supplier.objects.create(
             name="Test supplier",
             currency=self.currency,
@@ -23,6 +23,7 @@ class LoadSettingTests(TestCase):
         )
 
     def _create_supplier_file(self, setting: Setting, dataframe: pd.DataFrame, filename: str = "supplier.xlsx"):
+        setting.supplierfiles.all().delete()
         excel_buffer = BytesIO()
         dataframe.to_excel(excel_buffer, index=False)
         excel_buffer.seek(0)
@@ -32,10 +33,18 @@ class LoadSettingTests(TestCase):
             content_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
         )
         return SupplierFile.objects.create(setting=setting, file=uploaded_file)
+    
+    
+    def _get_asserts_articlename(self, correct_values: list[dict]):
+        res = []
+        for row in correct_values:
+            for attr in ['supplier_price', 'rrp', 'stock', 'manufacturer']:
+                res.append((getattr(SupplierProduct.objects.get(supplier=self.supplier, article=row['article'], name=row['name']), attr), row[attr], row['article'] + attr))
+        return res
 
-    def test_load_setting_imports_products_from_supplier_file(self):
+    def test_basicupload_articlename(self):
         setting = Setting.objects.create(
-            name="Основная загрузка",
+            name="Загрузка артикул+имя",
             supplier=self.supplier,
             sheet_name="Sheet1",
             create_new=True,
@@ -43,24 +52,167 @@ class LoadSettingTests(TestCase):
         Link.objects.create(setting=setting, key="article", value="Артикул")
         Link.objects.create(setting=setting, key="name", value="Название")
         Link.objects.create(setting=setting, key="supplier_price", value="Цена")
+        Link.objects.create(setting=setting, key="rrp", value="РРЦ")
+        Link.objects.create(setting=setting, key="stock", value="Остаток")
+        Link.objects.create(setting=setting, key="manufacturer", value="Производитель")
 
+
+        uppload_df = pd.DataFrame(
+                [
+                    {"Артикул": "А-1", "Название": "Товар 1", "Цена": "1", "РРЦ":"1", "Остаток":"1", "Производитель": "Производитель 1"},
+                    {"Артикул": "А-2", "Название": "Товар 2", "Цена": "2", "РРЦ":"2", "Остаток":"2", "Производитель": ""},
+                    {"Артикул": "А-3", "Название": "Товар 3", "Цена": "3", "РРЦ":"3", "Остаток":"", "Производитель": "Производитель 3"},
+                    {"Артикул": "А-4", "Название": "Товар 4", "Цена": "4", "РРЦ":"", "Остаток":"4", "Производитель": "Производитель 4"},
+                    {"Артикул": "А-5", "Название": "Товар 5", "Цена": "", "РРЦ":"5", "Остаток":"5", "Производитель": "Производитель 5"},
+                    {"Артикул": "А-5", "Название": "Товар 5", "Цена": "6", "РРЦ":"6", "Остаток":"6", "Производитель": "Производитель 6"},
+                ]
+            )
+        
+        correct_values = [
+                {"article": "А-1", "name": "Товар 1", "supplier_price": 1, "rrp":1, "stock":1, "manufacturer": Manufacturer.objects.get_or_create(name="Производитель 1")[0]},
+                {"article": "А-2", "name": "Товар 2", "supplier_price": 2, "rrp":2, "stock":2, "manufacturer": None},
+                {"article": "А-3", "name": "Товар 3", "supplier_price": 3, "rrp":3, "stock":None, "manufacturer": Manufacturer.objects.get_or_create(name="Производитель 3")[0]},
+                {"article": "А-4", "name": "Товар 4", "supplier_price": 4, "rrp":None, "stock":4, "manufacturer": Manufacturer.objects.get_or_create(name="Производитель 4")[0]},
+                {"article": "А-5", "name": "Товар 5", "supplier_price": None, "rrp":5, "stock":5, "manufacturer": Manufacturer.objects.get_or_create(name="Производитель 5")[0]},
+            ]
         self._create_supplier_file(
             setting,
-            pd.DataFrame(
-                [
-                    {"Артикул": "A-1", "Название": "Товар 1", "Цена": "123.45"},
-                    {"Артикул": "A-2", "Название": "Товар 2", "Цена": "50"},
-                ]
-            ),
+            uppload_df,
         )
-
         result = load_setting(setting.pk)
 
         self.assertIsNotNone(result)
-        self.assertEqual(SupplierProduct.objects.filter(supplier=self.supplier).count(), 2)
-        self.assertEqual(
-            SupplierProduct.objects.get(supplier=self.supplier, article="A-1", name="Товар 1").supplier_price,
-            Decimal("123.45"),
-        )
+        self.assertEqual(SupplierProduct.objects.filter(supplier=self.supplier).count(), 5)
+        for product_value, correct_value, attr in self._get_asserts_articlename(correct_values):
+            self.assertEqual(
+                product_value,
+                correct_value,
+                attr
+            )
         self.supplier.refresh_from_db()
+        self.assertIsNotNone(self.supplier.stock_updated_at)
+        self.assertIsNotNone(self.supplier.price_updated_at)
+
+    def test_basicupload_article(self):
+        setting = Setting.objects.create(
+            name="Загрузка артикул",
+            supplier=self.supplier,
+            sheet_name="Sheet1",
+            create_new=True,
+        )
+        Link.objects.create(setting=setting, key="article", value="Артикул")
+        Link.objects.create(setting=setting, key="name", value="Название")
+        Link.objects.create(setting=setting, key="supplier_price", value="Цена")
+        Link.objects.create(setting=setting, key="rrp", value="РРЦ")
+        Link.objects.create(setting=setting, key="stock", value="Остаток")
+        Link.objects.create(setting=setting, key="manufacturer", value="Производитель")
+
+        uppload_df_initial = pd.DataFrame(
+                [
+                    {"Артикул": "А-1", "Название": "Товар 1", "Цена": "1", "РРЦ":"1", "Остаток":"1", "Производитель": "Производитель 1"},
+                    {"Артикул": "А-2", "Название": "Товар 2", "Цена": "2", "РРЦ":"2", "Остаток":"2", "Производитель": ""},
+                    {"Артикул": "А-3", "Название": "Товар 3", "Цена": "3", "РРЦ":"3", "Остаток":"", "Производитель": "Производитель 3"},
+                    {"Артикул": "А-4", "Название": "Товар 4", "Цена": "4", "РРЦ":"", "Остаток":"4", "Производитель": "Производитель 4"},
+                    {"Артикул": "А-5", "Название": "Товар 5", "Цена": "", "РРЦ":"5", "Остаток":"5", "Производитель": "Производитель 5"},
+                    {"Артикул": "А-5", "Название": "Товар 6", "Цена": "", "РРЦ":"6", "Остаток":"6", "Производитель": "Производитель 6"},
+                ]
+            )
+
+        self._create_supplier_file(
+            setting,
+            uppload_df_initial,
+        )
+        load_setting(setting.pk)
+        setting.create_new = False
+        setting.save()
+        namelink = Link.objects.get(setting=setting, key="name")
+        namelink.value = None
+        namelink.save()
+
+
+        uppload_df = pd.DataFrame(
+                [
+                    {"Артикул": "А-1", "Цена": "1", "РРЦ":"1", "Остаток":"1", "Производитель": "Производитель 1"},
+                    {"Артикул": "А-2", "Цена": "2", "РРЦ":"2", "Остаток":"2", "Производитель": ""},
+                    {"Артикул": "А-3", "Цена": "3", "РРЦ":"3", "Остаток":"", "Производитель": "Производитель 3"},
+                    {"Артикул": "А-4", "Цена": "4", "РРЦ":"", "Остаток":"4", "Производитель": "Производитель 4"},
+                    {"Артикул": "А-5", "Цена": "", "РРЦ":"5", "Остаток":"5", "Производитель": "Производитель 5"},
+                ]
+            )
+        
+        correct_values = [
+                {"article": "А-1", "name": "Товар 1", "supplier_price": 1, "rrp":1, "stock":1, "manufacturer": Manufacturer.objects.get_or_create(name="Производитель 1")[0]},
+                {"article": "А-2", "name": "Товар 2", "supplier_price": 2, "rrp":2, "stock":2, "manufacturer": None},
+                {"article": "А-3", "name": "Товар 3", "supplier_price": 3, "rrp":3, "stock":None, "manufacturer": Manufacturer.objects.get_or_create(name="Производитель 3")[0]},
+                {"article": "А-4", "name": "Товар 4", "supplier_price": 4, "rrp":None, "stock":4, "manufacturer": Manufacturer.objects.get_or_create(name="Производитель 4")[0]},
+                {"article": "А-5", "name": "Товар 5", "supplier_price": None, "rrp":5, "stock":5, "manufacturer": Manufacturer.objects.get_or_create(name="Производитель 5")[0]},
+                {"article": "А-5", "name": "Товар 6", "supplier_price": None, "rrp":5, "stock":5, "manufacturer": Manufacturer.objects.get_or_create(name="Производитель 5")[0]},
+            ]
+        
+
+        self._create_supplier_file(
+            setting,
+            uppload_df,
+        )
+        result = load_setting(setting.pk)
+
+        self.assertIsNotNone(result)
+        self.assertEqual(SupplierProduct.objects.filter(supplier=self.supplier).count(), 6)
+        for product_value, correct_value, attr in self._get_asserts_articlename(correct_values):
+            self.assertEqual(
+                product_value,
+                correct_value,
+                attr
+            )
+        self.supplier.refresh_from_db()
+        self.assertIsNotNone(self.supplier.stock_updated_at)
+        self.assertIsNotNone(self.supplier.price_updated_at)
+    def test_uploadinitial(self):
+        setting = Setting.objects.create(
+            name="Загрузка артикул+имя",
+            supplier=self.supplier,
+            sheet_name="Sheet1",
+            create_new=True,
+        )
+        Link.objects.create(setting=setting, key="article", value="Артикул")
+        Link.objects.create(setting=setting, key="name", value="Название")
+        Link.objects.create(setting=setting, key="supplier_price", value="Цена", initial="100")
+        Link.objects.create(setting=setting, key="rrp", value="РРЦ", initial="100")
+        Link.objects.create(setting=setting, key="stock", value="Остаток", initial="100")
+        Link.objects.create(setting=setting, key="manufacturer", value="Производитель", initial="Производитель 100")
+
+
+        uppload_df = pd.DataFrame(
+                [
+                    {"Артикул": "А-1", "Название": "Товар 1", "Цена": "1", "РРЦ":"1", "Остаток":"1", "Производитель": "Производитель 1"},
+                    {"Артикул": "А-2", "Название": "Товар 2", "Цена": "2", "РРЦ":"2", "Остаток":"2", "Производитель": ""},
+                    {"Артикул": "А-3", "Название": "Товар 3", "Цена": "3", "РРЦ":"3", "Остаток":"", "Производитель": "Производитель 3"},
+                    {"Артикул": "А-4", "Название": "Товар 4", "Цена": "4", "РРЦ":"", "Остаток":"4", "Производитель": "Производитель 4"},
+                    {"Артикул": "А-5", "Название": "Товар 5", "Цена": "", "РРЦ":"5", "Остаток":"5", "Производитель": "Производитель 5"},
+                ]
+            )
+        
+        correct_values = [
+                {"article": "А-1", "name": "Товар 1", "supplier_price": 1, "rrp":1, "stock":1, "manufacturer": Manufacturer.objects.get_or_create(name="Производитель 1")[0]},
+                {"article": "А-2", "name": "Товар 2", "supplier_price": 2, "rrp":2, "stock":2, "manufacturer": Manufacturer.objects.get_or_create(name="Производитель 100")[0]},
+                {"article": "А-3", "name": "Товар 3", "supplier_price": 3, "rrp":3, "stock":100, "manufacturer": Manufacturer.objects.get_or_create(name="Производитель 3")[0]},
+                {"article": "А-4", "name": "Товар 4", "supplier_price": 4, "rrp":100, "stock":4, "manufacturer": Manufacturer.objects.get_or_create(name="Производитель 4")[0]},
+                {"article": "А-5", "name": "Товар 5", "supplier_price": 100, "rrp":5, "stock":5, "manufacturer": Manufacturer.objects.get_or_create(name="Производитель 5")[0]},
+            ]
+        self._create_supplier_file(
+            setting,
+            uppload_df,
+        )
+        result = load_setting(setting.pk)
+
+        self.assertIsNotNone(result)
+        self.assertEqual(SupplierProduct.objects.filter(supplier=self.supplier).count(), 5)
+        for product_value, correct_value, attr in self._get_asserts_articlename(correct_values):
+            self.assertEqual(
+                product_value,
+                correct_value,
+                attr
+            )
+        self.supplier.refresh_from_db()
+        self.assertIsNotNone(self.supplier.stock_updated_at)
         self.assertIsNotNone(self.supplier.price_updated_at)


### PR DESCRIPTION
### Motivation
- Гарантировать, что функция `load_setting` корректно импортирует товары из Excel-файла поставщика и обновляет метки времени поставщика (`price_updated_at`).

### Description
- Добавлен тестовый кейс `LoadSettingTests` в файл `price_manager/supplier_product_manager/tests.py`, который покрывает сценарий полной загрузки через `load_setting`.
- Тест создаёт `Currency` и `Supplier`, затем `Setting` и соответствующие `Link`-сопоставления, генерирует in-memory Excel через `pandas` и сохраняет его как `SupplierFile` с помощью `SimpleUploadedFile`, вызывает `load_setting` и проверяет создание `SupplierProduct` и обновление `price_updated_at` у поставщика.
- Введён вспомогательный метод `_create_supplier_file`, который формирует `.xlsx` в памяти и прикрепляет его к модели `SupplierFile` для имитации реального потока загрузки файла.

### Testing
- Выполнена команда `python manage.py test supplier_product_manager.tests -v 2`, но выполнение тестов прервано из-за ошибки подключения к базе данных: PostgreSQL на `localhost:5432` возвращает `Connection refused`.
- Автоматические тесты не могли быть прогнаны в этом окружении из-за недоступного PostgreSQL, тестовый файл добавлен и синтаксически валиден.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d8446988c832d946966554f848357)