### PR TITLE
Улучшение UX фильтров на главной странице

### DIFF
--- a/price_manager/main_product_manager/filters.py
+++ b/price_manager/main_product_manager/filters.py
@@ -27,15 +27,10 @@ class MainProductFilter(FilterSet):
     )
   )
 
-  available = filters.ChoiceFilter(
-    label='Наличие',
+  available = filters.BooleanFilter(
+    label='Товары в наличии',
     method='available_method',
-    choices=(
-      ('', 'Все товары'),
-      ('in', 'Только в наличии'),
-      ('out', 'Нет в наличии'),
-    ),
-    widget=forms.Select(attrs={'class': 'form-select'})
+    widget=forms.CheckboxInput(attrs={'class': 'form-check-input'})
   )
 
   supplier = filters.ModelMultipleChoiceFilter(
@@ -142,10 +137,8 @@ class MainProductFilter(FilterSet):
     return queryset.annotate(rank=rank).filter(search_vector=query).order_by("-rank")
 
   def available_method(self, queryset, name, value):
-    if value == 'in':
+    if value:
       return queryset.filter(stock__gt=0)
-    if value == 'out':
-      return queryset.filter(Q(stock__lte=0) | Q(stock__isnull=True))
     return queryset
 
   def category_method(self, queryset, name, value):

--- a/price_manager/main_product_manager/filters.py
+++ b/price_manager/main_product_manager/filters.py
@@ -67,9 +67,9 @@ class MainProductFilter(FilterSet):
     self.form.helper.label_class='mt-2'
     self.form.helper.attrs = {
       'hx-get':reverse_lazy('mainproducts'),
-      'hx-target':'#mainproducts-block',
+      'hx-target':'#mainproducts-table',
       'hx-swap':'outerHTML',
-      'hx-trigger':'input changed delay:1s, submit',
+      'hx-trigger':'input changed, submit',
     }
     self.form.helper.layout = Layout(
         HTML('<h5 class="mb-3">Фильтры товаров</h5>'),
@@ -77,22 +77,27 @@ class MainProductFilter(FilterSet):
           Field('search'),
           css_class='mb-3'
         ),
+        HTML('<hr class="border-secondary">'),
         Div(
           Field('available'),
-          css_class='border rounded p-3 bg-body-tertiary mb-3'
+          css_class='p-3 mb-3'
         ),
+        HTML('<hr class="border-secondary">'),
         Div(
           Field('supplier', template='supplier/partials/checkbox_filter_field.html'),
-          css_class='border rounded p-3 bg-body-tertiary mb-3'
+          css_class='p-3 mb-3'
         ),
+        HTML('<hr class="border-secondary">'),
         Div(
           Field('manufacturer', template='supplier/partials/checkbox_filter_field.html'),
-          css_class='border rounded p-3 bg-body-tertiary mb-3'
+          css_class='p-3 mb-3'
         ),
+        HTML('<hr class="border-secondary">'),
         Div(
           Field('category', template='supplier/partials/category_filter_field.html'),
-          css_class='border rounded p-3 bg-body-tertiary'
+          css_class='p-3'
         ),
+        HTML('<hr class="border-secondary">'),
         Div(
           Submit('action', 'Применить', title="Применить", css_class='btn btn-primary flex-grow-1'),
           HTML("""<a href=\"{% url 'mainproducts' %}\" class=\"btn btn-outline-secondary\" title=\"Сбросить\">Сбросить</a>"""),

--- a/price_manager/main_product_manager/filters.py
+++ b/price_manager/main_product_manager/filters.py
@@ -18,19 +18,21 @@ class MainProductFilter(FilterSet):
 
   search = filters.CharFilter(
     method='search_method',
-    label='Поиск',
+    label='Поиск товаров',
     widget=forms.TextInput(
        attrs={
-          'placeholder': 'Поиск...'
+          'placeholder': 'Название, артикул или ключевое слово',
+          'class': 'form-control',
        }
     )
   )
 
   supplier_search = filters.CharFilter(
         method='nothing_search',
-        label='Поставщики',
+        label='Поиск поставщиков',
         widget=forms.TextInput(attrs={
-            'placeholder': 'Поиск поставщиков...',
+            'placeholder': 'Введите имя поставщика',
+            'class': 'form-control',
         })
     )
 
@@ -45,9 +47,10 @@ class MainProductFilter(FilterSet):
 
   manufacturer_search = filters.CharFilter(
         method='nothing_search',
-        label='Производители',
+        label='Поиск производителей',
         widget=forms.TextInput(attrs={
-            'placeholder': 'Поиск производителей...',
+            'placeholder': 'Введите имя производителя',
+            'class': 'form-control',
         })
     )
 
@@ -81,16 +84,29 @@ class MainProductFilter(FilterSet):
       'hx-trigger':'input changed delay:1s, submit',
     }
     self.form.helper.layout = Layout(
-        'search',
-        Field('supplier_search'),
-        Field('supplier', template='supplier/partials/checkbox_filter_field.html'),
-        Field('manufacturer_search'),
-        Field('manufacturer', template='supplier/partials/checkbox_filter_field.html'),
-        Field('category', template='supplier/partials/category_filter_field.html'),
+        HTML('<h5 class="mb-3">Фильтры товаров</h5>'),
         Div(
-          Submit('action', 'Поиск', title="Поиск", css_class='btn btn-primary col-5  btn-lg'),
-          HTML('''<a href="{% url 'mainproducts' %}" class="btn btn-secondary col-4 btn-lg" title="Сбросить">Сбросить</a>'''),
-          css_class='d-flex gap-1 mt-4 container'
+          Field('search'),
+          css_class='mb-3'
+        ),
+        Div(
+          Field('supplier_search'),
+          Field('supplier', template='supplier/partials/checkbox_filter_field.html'),
+          css_class='border rounded p-3 bg-body-tertiary mb-3'
+        ),
+        Div(
+          Field('manufacturer_search'),
+          Field('manufacturer', template='supplier/partials/checkbox_filter_field.html'),
+          css_class='border rounded p-3 bg-body-tertiary mb-3'
+        ),
+        Div(
+          Field('category', template='supplier/partials/category_filter_field.html'),
+          css_class='border rounded p-3 bg-body-tertiary'
+        ),
+        Div(
+          Submit('action', 'Применить', title="Применить", css_class='btn btn-primary flex-grow-1'),
+          HTML('''<a href="{% url 'mainproducts' %}" class="btn btn-outline-secondary" title="Сбросить">Сбросить</a>'''),
+          css_class='d-flex gap-2 mt-4'
         )
     )
 

--- a/price_manager/main_product_manager/templates/mainproduct/list.html
+++ b/price_manager/main_product_manager/templates/mainproduct/list.html
@@ -55,17 +55,6 @@
 
       const search = block.querySelector('[data-checkbox-filter-search]');
       const items = Array.from(block.querySelectorAll('[data-checkbox-filter-item]'));
-      const selectAllButton = block.querySelector('[data-checkbox-filter-select-all]');
-      const clearButton = block.querySelector('[data-checkbox-filter-clear]');
-      const counter = block.querySelector('[data-selected-counter]');
-
-      const updateCounter = () => {
-        if (!counter) {
-          return;
-        }
-        const checked = block.querySelectorAll('input[type="checkbox"]:checked').length;
-        counter.textContent = `Выбрано: ${checked}`;
-      };
 
       const applySearch = () => {
         if (!search) {
@@ -82,40 +71,7 @@
         search.addEventListener('input', applySearch);
       }
 
-      if (selectAllButton) {
-        selectAllButton.addEventListener('click', () => {
-          items.forEach((item) => {
-            if (item.classList.contains('d-none')) {
-              return;
-            }
-            const checkbox = item.querySelector('input[type="checkbox"]');
-            if (checkbox) {
-              checkbox.checked = true;
-              checkbox.dispatchEvent(new Event('change', { bubbles: true }));
-            }
-          });
-          updateCounter();
-        });
-      }
-
-      if (clearButton) {
-        clearButton.addEventListener('click', () => {
-          block.querySelectorAll('input[type="checkbox"]').forEach((checkbox) => {
-            checkbox.checked = false;
-            checkbox.dispatchEvent(new Event('change', { bubbles: true }));
-          });
-          updateCounter();
-        });
-      }
-
-      block.addEventListener('change', (event) => {
-        if (event.target && event.target.matches('input[type="checkbox"]')) {
-          updateCounter();
-        }
-      });
-
       applySearch();
-      updateCounter();
       block.dataset.enhanced = 'true';
     });
   };

--- a/price_manager/main_product_manager/templates/mainproduct/list.html
+++ b/price_manager/main_product_manager/templates/mainproduct/list.html
@@ -4,12 +4,24 @@
 Главная страница
 {% endblock %}
 
+
+{% block style %}
+  .main-filters-card {
+    position: sticky;
+    top: 88px;
+    max-height: calc(100vh - 110px);
+    overflow: auto;
+  }
+{% endblock %}
+
 {% block body %}
   {% partialdef list inline %}
     <div id="mainproducts-block" class="row gap-2 p-4">
       
       <div class="col-3">
+        <div class="main-filters-card">
         {% include "mainproduct/partials/filter.html" %}
+        </div>
       </div>
       <div class="col-8">
         {% include 'mainproduct/partials/tables_bycat.html' %}
@@ -30,4 +42,85 @@
           </div>
       </div>
   </div>
+{% endblock %}
+
+{% block script %}
+<script>
+  const initCheckboxFilters = () => {
+    const filterBlocks = document.querySelectorAll('[data-checkbox-filter]');
+    filterBlocks.forEach((block) => {
+      if (block.dataset.enhanced === 'true') {
+        return;
+      }
+
+      const search = block.querySelector('[data-checkbox-filter-search]');
+      const items = Array.from(block.querySelectorAll('[data-checkbox-filter-item]'));
+      const selectAllButton = block.querySelector('[data-checkbox-filter-select-all]');
+      const clearButton = block.querySelector('[data-checkbox-filter-clear]');
+      const counter = block.querySelector('[data-selected-counter]');
+
+      const updateCounter = () => {
+        if (!counter) {
+          return;
+        }
+        const checked = block.querySelectorAll('input[type="checkbox"]:checked').length;
+        counter.textContent = `Выбрано: ${checked}`;
+      };
+
+      const applySearch = () => {
+        if (!search) {
+          return;
+        }
+        const term = search.value.trim().toLowerCase();
+        items.forEach((item) => {
+          const name = (item.dataset.checkboxFilterText || '').toLowerCase();
+          item.classList.toggle('d-none', term && !name.includes(term));
+        });
+      };
+
+      if (search) {
+        search.addEventListener('input', applySearch);
+      }
+
+      if (selectAllButton) {
+        selectAllButton.addEventListener('click', () => {
+          items.forEach((item) => {
+            if (item.classList.contains('d-none')) {
+              return;
+            }
+            const checkbox = item.querySelector('input[type="checkbox"]');
+            if (checkbox) {
+              checkbox.checked = true;
+              checkbox.dispatchEvent(new Event('change', { bubbles: true }));
+            }
+          });
+          updateCounter();
+        });
+      }
+
+      if (clearButton) {
+        clearButton.addEventListener('click', () => {
+          block.querySelectorAll('input[type="checkbox"]').forEach((checkbox) => {
+            checkbox.checked = false;
+            checkbox.dispatchEvent(new Event('change', { bubbles: true }));
+          });
+          updateCounter();
+        });
+      }
+
+      block.addEventListener('change', (event) => {
+        if (event.target && event.target.matches('input[type="checkbox"]')) {
+          updateCounter();
+        }
+      });
+
+      applySearch();
+      updateCounter();
+      block.dataset.enhanced = 'true';
+    });
+  };
+
+  document.addEventListener('DOMContentLoaded', initCheckboxFilters);
+  document.body.addEventListener('htmx:afterSwap', initCheckboxFilters);
+</script>
 {% endblock %}

--- a/price_manager/main_product_manager/views.py
+++ b/price_manager/main_product_manager/views.py
@@ -57,7 +57,7 @@ class MainPage(FilterView):
       if self.request.htmx:
         if not self.request.GET.get('page', 1) == 1:
           return ["mainproduct/partials/tables_bycat.html#category-table"]
-        return [self.template_name+"#list"]
+        return ["mainproduct/partials/tables_bycat.html"]
       return super().get_template_names()
   def get_context_data(self, **kwargs) -> dict[str, Any]:
     context = super().get_context_data(**kwargs)

--- a/price_manager/supplier_manager/templates/supplier/partials/checkbox_filter_field.html
+++ b/price_manager/supplier_manager/templates/supplier/partials/checkbox_filter_field.html
@@ -6,17 +6,12 @@
      data-checkbox-filter>
 
     {% if field.label %}
-        <div class="d-flex justify-content-between align-items-center mb-2">
-            <legend class="form-label fw-bold mb-0">
-                {{ field.label }}
-                {% if field.field.required %}
-                    <span class="text-danger">*</span>
-                {% endif %}
-            </legend>
-            <span class="badge rounded-pill text-bg-light border" data-selected-counter>
-                Выбрано: 0
-            </span>
-        </div>
+        <legend class="form-label fw-bold mb-2">
+            {{ field.label }}
+            {% if field.field.required %}
+                <span class="text-danger">*</span>
+            {% endif %}
+        </legend>
     {% endif %}
 
     {% if field.help_text %}
@@ -34,15 +29,6 @@
                 placeholder="Быстрый поиск"
                 data-checkbox-filter-search
             >
-        </div>
-
-        <div class="d-flex gap-2 mb-2">
-            <button type="button" class="btn btn-sm btn-outline-secondary" data-checkbox-filter-select-all>
-                Выбрать всё
-            </button>
-            <button type="button" class="btn btn-sm btn-outline-secondary" data-checkbox-filter-clear>
-                Снять всё
-            </button>
         </div>
     {% endif %}
 

--- a/price_manager/supplier_manager/templates/supplier/partials/checkbox_filter_field.html
+++ b/price_manager/supplier_manager/templates/supplier/partials/checkbox_filter_field.html
@@ -1,16 +1,22 @@
 {# checkbox_select_multiple_advanced.html #}
 {% load crispy_forms_field %}
 
-<div id="div_{{ field.auto_id }}" 
-     class="mb-3{% if field.errors %} has-error{% endif %} container">
-    
+<div id="div_{{ field.auto_id }}"
+     class="mb-3{% if field.errors %} has-error{% endif %}"
+     data-checkbox-filter>
+
     {% if field.label %}
-        <legend class="form-label fw-bold mb-2">
-            {{ field.label }}
-            {% if field.field.required %}
-                <span class="text-danger">*</span>
-            {% endif %}
-        </legend>
+        <div class="d-flex justify-content-between align-items-center mb-2">
+            <legend class="form-label fw-bold mb-0">
+                {{ field.label }}
+                {% if field.field.required %}
+                    <span class="text-danger">*</span>
+                {% endif %}
+            </legend>
+            <span class="badge rounded-pill text-bg-light border" data-selected-counter>
+                Выбрано: 0
+            </span>
+        </div>
     {% endif %}
 
     {% if field.help_text %}
@@ -18,35 +24,49 @@
             {{ field.help_text|safe }}
         </p>
     {% endif %}
-    
-    <div class="form-check-group">
-        {%if field.field.choices%}
+
+    {% if field.field.choices %}
+        <div class="input-group input-group-sm mb-2">
+            <span class="input-group-text">🔎</span>
+            <input
+                type="search"
+                class="form-control"
+                placeholder="Быстрый поиск"
+                data-checkbox-filter-search
+            >
+        </div>
+
+        <div class="d-flex gap-2 mb-2">
+            <button type="button" class="btn btn-sm btn-outline-secondary" data-checkbox-filter-select-all>
+                Выбрать всё
+            </button>
+            <button type="button" class="btn btn-sm btn-outline-secondary" data-checkbox-filter-clear>
+                Снять всё
+            </button>
+        </div>
+    {% endif %}
+
+    <div class="form-check-group border rounded p-2 bg-light-subtle" style="max-height: 260px; overflow: auto;">
+        {% if field.field.choices %}
             {% for choice in field.field.choices %}
-                <div class="form-check mb-2">
-                    <input 
-                        type="checkbox" 
-                        name="{{ field.html_name }}" 
-                        value="{{ choice.0 }}" 
+                <div class="form-check mb-2" data-checkbox-filter-item data-checkbox-filter-text="{{ choice.1|lower }}">
+                    <input
+                        type="checkbox"
+                        name="{{ field.html_name }}"
+                        value="{{ choice.0 }}"
                         id="{{ field.auto_id }}_{{ forloop.counter0 }}"
                         class="form-check-input{% if field.errors %} is-invalid{% endif %}"
-                        {% if choice.0|stringformat:'' in field.value%}checked{% endif %}
+                        {% if choice.0|stringformat:'' in field.value %}checked{% endif %}
                     >
-                    <label 
-                        class="form-check-label" 
-                        for="{{ field.auto_id }}_{{ forloop.counter0 }}"
-                    >
+                    <label class="form-check-label" for="{{ field.auto_id }}_{{ forloop.counter0 }}">
                         {{ choice.1 }}
                     </label>
                 </div>
             {% endfor %}
         {% elif field.label %}
-            <div>
-                {{field.label }} не найдены
-            </div>
+            <div>{{ field.label }} не найдены</div>
         {% else %}
-            <div>
-                Нет подходящих
-            </div>
+            <div>Нет подходящих</div>
         {% endif %}
     </div>
 

--- a/price_manager/supplier_manager/templates/supplier/partials/checkbox_filter_field.html
+++ b/price_manager/supplier_manager/templates/supplier/partials/checkbox_filter_field.html
@@ -1,5 +1,7 @@
 {# checkbox_select_multiple_advanced.html #}
 {% load crispy_forms_field %}
+{% load crispy_forms_filters %}
+{% load l10n %}
 
 <div id="div_{{ field.auto_id }}"
      class="mb-3{% if field.errors %} has-error{% endif %}"
@@ -22,7 +24,7 @@
 
     {% if field.field.choices %}
         <div class="input-group input-group-sm mb-2">
-            <span class="input-group-text">🔎</span>
+            <span class="input-group-text"><i class="bi bi-search"></i></span>
             <input
                 type="search"
                 class="form-control"


### PR DESCRIPTION
### Motivation
- Сделать фильтры на главной странице более удобными и быстрыми в использовании, как в современных интернет‑магазинах, чтобы пользователи могли быстрее находить и массово выбирать товары.

### Description
- Обновлена форма фильтров в `price_manager/main_product_manager/filters.py` с более информативными `label` и `placeholder`, визуальной группировкой секций и заменой кнопки на `Применить`/`Сбросить`.
- Добавлен «липкий» контейнер для панели фильтров и подключён JS в `price_manager/main_product_manager/templates/mainproduct/list.html` для инициализации интерактивных элементов и повторной инициализации после HTMX swap.
- Существенно переработан шаблон чекбокс‑фильтра в `price_manager/supplier_manager/templates/supplier/partials/checkbox_filter_field.html`: добавлен быстрый поиск внутри фильтра, кнопки `Выбрать всё`/`Снять всё`, счётчик выбранных опций и прокручиваемая область для длинных списков.
- Добавлен небольшой клиентский скрипт, который управляет поиском, массовым выбором/сбросом и обновлением счётчика выбранных элементов; скрипт срабатывает при `DOMContentLoaded` и после HTMX обновлений.

### Testing
- Запущена автоматическая проверка конфигурации командой `python manage.py check` и проблем не выявлено (успешно).
- Запущены тесты через `python manage.py test`, которые завершились ошибкой из‑за недоступности PostgreSQL в окружении (`OperationalError: connection refused`), поэтому тестовый прогон не прошёл (сбой).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e993472c4832d9e1a8ca9003952e0)