### PR TITLE
Merge duplicate MainProduct entries by name (admin action + UI button)

### DIFF
--- a/price_manager/main_product_manager/admin.py
+++ b/price_manager/main_product_manager/admin.py
@@ -1,9 +1,13 @@
 from django.utils.safestring import mark_safe
 from django.contrib import admin
+from django.db.models import Count
+from django.db import transaction
+from django.contrib import messages
 from import_export.admin import ImportExportModelAdmin
 from import_export.formats.base_formats import CSV
 from .models import *
 from file_manager.models import FileModel
+from supplier_product_manager.models import SupplierProduct
 from import_export.formats import base_formats
 from .resources import *
 
@@ -37,8 +41,63 @@ class MainProductAdmin(ImportExportModelAdmin):
     list_display_links = ['id', 'name']
     search_fields = ['article', 'name', 'sku', 'stock']
     list_filter = ['supplier', 'manufacturer']
+    actions = ['resolve_conflicts']
+    
+    @admin.action(description="Разрешить конфликты форматирования")
+    def resolve_conflicts(self, request, queryset):
+      merged_groups, deleted_products, moved_supplier_products = merge_main_products_by_name(queryset)
+      if merged_groups:
+        messages.success(
+          request,
+          (
+            f"Объединено {merged_groups} групп дублей. "
+            f"Удалено {deleted_products} товаров главного прайса. "
+            f"Перенесено {moved_supplier_products} товаров поставщиков."
+          ),
+        )
+      else:
+        messages.info(request, "Дубли по названию не найдены.")
 
 @admin.register(MainProductLog)
 class MainProductLogAdmin(admin.ModelAdmin):
     list_display = ['update_time', 'main_product__name', 'price_type', 'price', 'stock']
     search_fields = ['main_product__name']
+
+
+def merge_main_products_by_name(queryset, **kwargs):
+  """Объединяет продукты главного прайса с одинаковым названием."""
+  duplicate_names = (
+    queryset
+    .values('name')
+    .annotate(products_count=Count('id'))
+    .filter(products_count__gt=1)
+    .values_list('name', flat=True)
+  )
+
+  merged_groups = 0
+  deleted_products = 0
+  moved_supplier_products = 0
+
+  with transaction.atomic():
+    for name in duplicate_names:
+      products = list(
+        MainProduct.objects
+        .filter(name=name)
+        .order_by('id')
+        .only('id')
+      )
+      if len(products) < 2:
+        continue
+
+      keep_product = products[0]
+      duplicate_ids = [product.id for product in products[1:]]
+      if not duplicate_ids:
+        continue
+
+      moved_supplier_products += SupplierProduct.objects.filter(
+        main_product_id__in=duplicate_ids
+      ).update(main_product=keep_product)
+      deleted_products += MainProduct.objects.filter(id__in=duplicate_ids).delete()[0]
+      merged_groups += 1
+
+  return (merged_groups, deleted_products, moved_supplier_products)

--- a/price_manager/main_product_manager/templates/mainproduct/partials/tables_bycat.html
+++ b/price_manager/main_product_manager/templates/mainproduct/partials/tables_bycat.html
@@ -6,14 +6,6 @@
     <div class="col-4 mb-3 d-flex justify-content-end gap-2">
       {% include "mainproduct/partials/fields_selector.html" %}
       <button type="button"
-              class="btn btn-outline-danger"
-              title="Объединить дубли по названию"
-              hx-get="{% url 'mainproducts-merge-by-name' %}"
-              hx-swap="none"
-              hx-confirm="Объединить товары главного прайса с одинаковым названием? Дубли будут удалены.">
-        Объединить дубли
-      </button>
-      <button type="button"
               class="btn btn-primary"
               title="Обновить"
               data-bs-toggle="modal"

--- a/price_manager/main_product_manager/templates/mainproduct/partials/tables_bycat.html
+++ b/price_manager/main_product_manager/templates/mainproduct/partials/tables_bycat.html
@@ -6,6 +6,14 @@
     <div class="col-4 mb-3 d-flex justify-content-end gap-2">
       {% include "mainproduct/partials/fields_selector.html" %}
       <button type="button"
+              class="btn btn-outline-danger"
+              title="Объединить дубли по названию"
+              hx-get="{% url 'mainproducts-merge-by-name' %}"
+              hx-swap="none"
+              hx-confirm="Объединить товары главного прайса с одинаковым названием? Дубли будут удалены.">
+        Объединить дубли
+      </button>
+      <button type="button"
               class="btn btn-primary"
               title="Обновить"
               data-bs-toggle="modal"

--- a/price_manager/main_product_manager/views.py
+++ b/price_manager/main_product_manager/views.py
@@ -19,6 +19,7 @@ from django.urls import reverse, reverse_lazy
 from typing import Optional, Any, Dict, Iterable
 from collections import defaultdict, OrderedDict
 from django.db.models import Count, Prefetch, F, Q, Value, Max, Subquery, OuterRef, IntegerField, ExpressionWrapper
+from django.db import transaction
 from django.contrib.postgres.search import SearchVector
 # Импорты из сторонних приложений
 from django_tables2 import SingleTableView, RequestConfig, SingleTableMixin
@@ -147,6 +148,57 @@ def sync_main_products(request, **kwargs):
   messages.info(request, f"Цены обновлены у {count} товаров. Обнулены у {dcount} товаров.")
   messages.info(request, f"Остатки обновлены у {update_stocks()} товаров")
   
+  return HttpResponseClientRedirect(reverse('mainproducts'))
+
+
+def merge_main_products_by_name(request, **kwargs):
+  """Объединяет продукты главного прайса с одинаковым названием."""
+  duplicate_names = (
+    MainProduct.objects
+    .values('name')
+    .annotate(products_count=Count('id'))
+    .filter(products_count__gt=1)
+    .values_list('name', flat=True)
+  )
+
+  merged_groups = 0
+  deleted_products = 0
+  moved_supplier_products = 0
+
+  with transaction.atomic():
+    for name in duplicate_names:
+      products = list(
+        MainProduct.objects
+        .filter(name=name)
+        .order_by('id')
+        .only('id')
+      )
+      if len(products) < 2:
+        continue
+
+      keep_product = products[0]
+      duplicate_ids = [product.id for product in products[1:]]
+      if not duplicate_ids:
+        continue
+
+      moved_supplier_products += SupplierProduct.objects.filter(
+        main_product_id__in=duplicate_ids
+      ).update(main_product=keep_product)
+      deleted_products += MainProduct.objects.filter(id__in=duplicate_ids).delete()[0]
+      merged_groups += 1
+
+  if merged_groups:
+    messages.success(
+      request,
+      (
+        f"Объединено {merged_groups} групп дублей. "
+        f"Удалено {deleted_products} товаров главного прайса. "
+        f"Перенесено {moved_supplier_products} товаров поставщиков."
+      ),
+    )
+  else:
+    messages.info(request, "Дубли по названию не найдены.")
+
   return HttpResponseClientRedirect(reverse('mainproducts'))
 
 

--- a/price_manager/price_manager/urls.py
+++ b/price_manager/price_manager/urls.py
@@ -25,7 +25,6 @@ urlpatterns = [
 
     path('mainproduct/<int:id>/update', mp_views.MainProductUpdate.as_view(), name='main-product-update'),
     path('mainproduct/sync', mp_views.sync_main_products, name='mainproducts-sync'),
-    path('mainproduct/merge-by-name', mp_views.merge_main_products_by_name, name='mainproducts-merge-by-name'),
     path('mainproduct/<int:pk>/info', mp_views.MainProductInfo.as_view(), name='mainproduct-info'),
     path('mainproduct/<int:pk>/update', mp_views.MainProductUpdate.as_view(), name='mainproduct-update'),
     path('mainproduct/<int:pk>/resolve', mp_views.ResolveMainproduct.as_view(), name='mainproduct-resolve'),

--- a/price_manager/price_manager/urls.py
+++ b/price_manager/price_manager/urls.py
@@ -25,6 +25,7 @@ urlpatterns = [
 
     path('mainproduct/<int:id>/update', mp_views.MainProductUpdate.as_view(), name='main-product-update'),
     path('mainproduct/sync', mp_views.sync_main_products, name='mainproducts-sync'),
+    path('mainproduct/merge-by-name', mp_views.merge_main_products_by_name, name='mainproducts-merge-by-name'),
     path('mainproduct/<int:pk>/info', mp_views.MainProductInfo.as_view(), name='mainproduct-info'),
     path('mainproduct/<int:pk>/update', mp_views.MainProductUpdate.as_view(), name='mainproduct-update'),
     path('mainproduct/<int:pk>/resolve', mp_views.ResolveMainproduct.as_view(), name='mainproduct-resolve'),
@@ -91,4 +92,3 @@ urlpatterns = [
     path("toasts/", views.toast_messages, name="toast-messages"),
 
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
-


### PR DESCRIPTION
### Motivation
- Provide an admin action to deduplicate `MainProduct` records that share the same `name`, leaving a single canonical product and reassigning all supplier products to it.

### Description
- Added view `merge_main_products_by_name` in `price_manager/main_product_manager/views.py` that finds duplicate `MainProduct.name` groups, keeps the lowest-`id` record, reassigns related `SupplierProduct` rows and deletes duplicate `MainProduct` rows inside a `transaction.atomic()` block.
- Registered route `path('mainproduct/merge-by-name', mp_views.merge_main_products_by_name, name='mainproducts-merge-by-name')` in `price_manager/price_manager/urls.py`.
- Added a button to the main products page `price_manager/main_product_manager/templates/mainproduct/partials/tables_bycat.html` labeled "Объединить дубли" which triggers the action via HTMX with confirmation (`hx-confirm`).
- Minor import: added `from django.db import transaction` and show result to user via `messages`.

### Testing
- Ran `python price_manager/manage.py check` which completed successfully with no system-check errors.
- Attempted to run the development server (`python price_manager/manage.py runserver`) for a UI smoke test but it failed due to no PostgreSQL connection on `localhost:5432`, so end-to-end UI verification in this environment was not possible.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991843b8978832d91d1a7cc7e8d1eee)