### PR TITLE
Add merge workflow for ResolveMainproduct using MainProductTable

### DIFF
--- a/price_manager/main_product_manager/templates/mainproduct/partials/resolve_list.html
+++ b/price_manager/main_product_manager/templates/mainproduct/partials/resolve_list.html
@@ -1,12 +1,19 @@
 
 {% partialdef list inline %}
   <div id="mainproducts-block" class="row gap-2 p-4">
-    
+
     <div class="col-3">
       {% include "mainproduct/partials/filter.html" %}
     </div>
     <div class="col-8">
-      {% include 'mainproduct/partials/tables_bycat.html' %}
+      <form
+        hx-post="{% url 'mainproduct-resolve' pk=resolve_target_pk %}"
+        hx-target="#modal-container .modal-content"
+        hx-swap="innerHTML"
+      >
+        {% csrf_token %}
+        {% include 'mainproduct/partials/tables_bycat.html' with resolve_mode=True %}
+      </form>
     </div>
   </div>
 {% endpartialdef %}

--- a/price_manager/main_product_manager/templates/mainproduct/partials/tables_bycat.html
+++ b/price_manager/main_product_manager/templates/mainproduct/partials/tables_bycat.html
@@ -5,16 +5,22 @@
     <h1 class="mb-4 col-8">Главный прайс</h1>
     <div class="col-4 mb-3 d-flex justify-content-end gap-2">
       {% include "mainproduct/partials/fields_selector.html" %}
-      <button type="button"
-              class="btn btn-primary"
-              title="Обновить"
-              data-bs-toggle="modal"
-              data-bs-target="#modal-container"
-              hx-get="{% url 'mainproducts-sync'%}"
-              hx-target="#modal-container .modal-content"
-              hx-swap="innerHTML">
-        Обновить
-      </button>
+      {% if resolve_mode %}
+        <button type="submit" class="btn btn-primary" title="Объединить">
+          Объединить
+        </button>
+      {% else %}
+        <button type="button"
+                class="btn btn-primary"
+                title="Обновить"
+                data-bs-toggle="modal"
+                data-bs-target="#modal-container"
+                hx-get="{% url 'mainproducts-sync'%}"
+                hx-target="#modal-container .modal-content"
+                hx-swap="innerHTML">
+          Обновить
+        </button>
+      {% endif %}
     </div>
   </div>
   {% if categories or has_nulled %}
@@ -29,7 +35,7 @@
             </span>
           </div>
           <div
-          hx-get="{% url "mainproduct-table-nocat"%}{% querystring%}"
+          hx-get="{% if resolve_mode %}{% url "mainproductresolve-table-nocat" %}{% querystring resolve_target_pk=resolve_target_pk %}{% else %}{% url "mainproduct-table-nocat"%}{% querystring%}{% endif %}"
           hx-trigger="load"
           hx-swap="outerHTML">
               <span class="placeholder col-12 placeholder-lg bg-light">
@@ -63,7 +69,7 @@
               </span>
             </div>
             <div 
-            hx-get="{% url "mainproduct-table-bycat" category_pk=category.pk %}{% querystring %}"
+            hx-get="{% if resolve_mode %}{% url "mainproductresolve-table-bycat" category_pk=category.pk %}{% querystring resolve_target_pk=resolve_target_pk %}{% else %}{% url "mainproduct-table-bycat" category_pk=category.pk %}{% querystring %}{% endif %}"
             hx-trigger="load"
             hx-swap="outerHTML">
               <span class="placeholder col-12 placeholder-lg bg-light">


### PR DESCRIPTION
### Motivation
- Provide a resolve (связать/объединить) workflow that lets a user select main-prices to merge into a target main product and move supplier products accordingly.

### Description
- Replaced resolve table with `MainProductTable` in `MainProductResolveTableView` and enabled resolve-mode flags passed to the table (`enable_merge`, `resolve_target_pk`, `selected_columns`, `url`).
- Added a `merge_select` checkbox column and `render_merge_select` to `MainProductTable` with support for disabling the checkbox for the target product. 
- Implemented POST handling in `ResolveMainproduct` to accept `merge_ids`, move all `SupplierProduct` rows from selected main products to the target `MainProduct`, delete the source `MainProduct` records inside a transaction, and return user messages.
- Updated templates: wrapped resolve UI in a form that posts to `mainproduct-resolve`, added the `Объединить` button in `tables_bycat.html`, and wired resolve-specific endpoints and `resolve_target_pk` propagation.

### Testing
- Ran `python price_manager/manage.py check` and it completed successfully with no system check issues. 
- Attempted to start the dev server (`runserver`) to validate UI rendering, but it failed due to missing/unavailable local PostgreSQL (`connection refused`), so full runtime validation could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69918ad97df0832d84d591f987c37d6a)