### PR TITLE
Добавить страницу «Дубликаты» и объединение выбранных товаров

### DIFF
--- a/price_manager/core/templates/includes/header.html
+++ b/price_manager/core/templates/includes/header.html
@@ -24,6 +24,9 @@
           </a>
           <ul class="dropdown-menu">
             <li>
+              <a class="dropdown-item" href="{% url 'mainproduct-duplicates' %}">Дубликаты</a>
+            </li>
+            <li>
               <a class="dropdown-item" href="{% url 'blogapp:article-list' %}">Статьи</a>
             </li>
           </ul>

--- a/price_manager/main_product_manager/templates/mainproduct/duplicates.html
+++ b/price_manager/main_product_manager/templates/mainproduct/duplicates.html
@@ -1,0 +1,92 @@
+{% extends 'base.html' %}
+{% load crispy_forms_tags %}
+
+{% block title %}
+Дубликаты главного прайса
+{% endblock %}
+
+{% block body %}
+<div class="container-fluid p-4">
+  <h2 class="mb-3">Дубликаты товаров</h2>
+
+  <form method="get" class="card p-3 mb-3">
+    <h5 class="mb-3">Параметры сравнения</h5>
+    <div class="d-flex flex-wrap gap-4 align-items-center">
+      <div class="form-check">
+        <input class="form-check-input" type="checkbox" id="compare-article" name="article" {% if request.GET.article == 'on' %}checked{% endif %}>
+        <label class="form-check-label" for="compare-article">Сравнивать по артиклю</label>
+      </div>
+      <div class="form-check">
+        <input class="form-check-input" type="checkbox" id="compare-supplier" name="supplier" {% if request.GET.supplier == 'on' %}checked{% endif %}>
+        <label class="form-check-label" for="compare-supplier">Сравнивать по поставщику</label>
+      </div>
+      <div class="form-check">
+        <input class="form-check-input" type="checkbox" id="compare-name" name="name" {% if request.GET.name == 'on' %}checked{% endif %}>
+        <label class="form-check-label" for="compare-name">Сравнивать по названию</label>
+      </div>
+      <button type="submit" class="btn btn-primary">Найти дубликаты</button>
+    </div>
+  </form>
+
+  <div class="row">
+    <div class="col-3">
+      <div class="card p-3 position-sticky" style="top: 88px; max-height: calc(100vh - 110px); overflow:auto;">
+        {% crispy filter.form filter.form.helper %}
+      </div>
+    </div>
+    <div class="col-9">
+      {% if not selected_compare_fields %}
+        <div class="alert alert-info">Выберите хотя бы одно поле сравнения сверху.</div>
+      {% elif not duplicates_groups %}
+        <div class="alert alert-secondary">Дубликаты по выбранным параметрам не найдены.</div>
+      {% else %}
+        <form method="post">
+          {% csrf_token %}
+          <div class="d-flex justify-content-between align-items-center mb-3">
+            <p class="mb-0">Критерии сравнения: <strong>{{ comparison_labels|join:", " }}</strong>.</p>
+            <button type="submit" class="btn btn-success">Объединить выбранные товары</button>
+          </div>
+
+          {% for group in duplicates_groups %}
+            <div class="card mb-3">
+              <div class="card-header">
+                Группа дубликатов #{{ forloop.counter }} ({{ group|length }} шт.)
+              </div>
+              <div class="card-body p-0">
+                <div class="table-responsive">
+                  <table class="table table-hover mb-0">
+                    <thead>
+                      <tr>
+                        <th></th>
+                        <th>ID</th>
+                        <th>Артикул</th>
+                        <th>Поставщик</th>
+                        <th>Название</th>
+                        <th>Самый старый лог</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {% for product in group %}
+                        <tr>
+                          <td>
+                            <input class="form-check-input" type="checkbox" name="selected_products" value="{{ product.id }}">
+                          </td>
+                          <td>{{ product.id }}</td>
+                          <td>{{ product.article }}</td>
+                          <td>{{ product.supplier.name }}</td>
+                          <td>{{ product.name }}</td>
+                          <td>{% if product.oldest_log_at %}{{ product.oldest_log_at }}{% else %}—{% endif %}</td>
+                        </tr>
+                      {% endfor %}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            </div>
+          {% endfor %}
+        </form>
+      {% endif %}
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/price_manager/main_product_manager/tests.py
+++ b/price_manager/main_product_manager/tests.py
@@ -147,7 +147,7 @@ class BuildDuplicatesGroupsTests(TestCase):
             name='Makita DF',
         )
 
-        groups = build_duplicates_groups([p1, p2, p3], ['name'])
+        groups = build_duplicates_groups(MainProduct.objects.filter(id__in=[p1.id, p2.id, p3.id]), ['name'])
 
         self.assertEqual(len(groups), 1)
         self.assertEqual(sorted([product.id for product in groups[0]]), sorted([p1.id, p2.id]))
@@ -169,7 +169,7 @@ class BuildDuplicatesGroupsTests(TestCase):
             name='Milwaukee M12',
         )
 
-        groups = build_duplicates_groups([p1, p2, p3], ['article', 'name'])
+        groups = build_duplicates_groups(MainProduct.objects.filter(id__in=[p1.id, p2.id, p3.id]), ['article', 'name'])
 
         self.assertEqual(len(groups), 1)
         self.assertEqual(sorted([product.id for product in groups[0]]), sorted([p1.id, p2.id]))

--- a/price_manager/main_product_manager/tests.py
+++ b/price_manager/main_product_manager/tests.py
@@ -48,7 +48,7 @@ from django.utils import timezone
 from supplier_manager.models import Currency, Supplier
 from supplier_product_manager.models import SupplierProduct
 from .models import MainProduct, MainProductLog
-from .views import merge_selected_main_products
+from .views import build_duplicates_groups, merge_selected_main_products
 
 
 class MergeSelectedMainProductsTests(TestCase):
@@ -116,3 +116,60 @@ class MergeSelectedMainProductsTests(TestCase):
         result = merge_selected_main_products([product.id])
 
         self.assertIsNone(result)
+
+
+class BuildDuplicatesGroupsTests(TestCase):
+    def setUp(self):
+        self.currency = Currency.objects.create(name='KZT', value=1)
+        self.supplier = Supplier.objects.create(
+            name='Test supplier',
+            currency=self.currency,
+            price_update_rate='',
+            stock_update_rate='',
+            delivery_days_available=1,
+            delivery_days_navailable=2,
+        )
+
+    def test_groups_by_partial_name_match(self):
+        p1 = MainProduct.objects.create(
+            supplier=self.supplier,
+            article='A-1',
+            name='Bosch GSB 13',
+        )
+        p2 = MainProduct.objects.create(
+            supplier=self.supplier,
+            article='A-2',
+            name='Bosch GSB',
+        )
+        p3 = MainProduct.objects.create(
+            supplier=self.supplier,
+            article='A-3',
+            name='Makita DF',
+        )
+
+        groups = build_duplicates_groups([p1, p2, p3], ['name'])
+
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(sorted([product.id for product in groups[0]]), sorted([p1.id, p2.id]))
+
+    def test_groups_by_exact_fields_and_partial_name(self):
+        p1 = MainProduct.objects.create(
+            supplier=self.supplier,
+            article='A-1',
+            name='Milwaukee M12 Fuel',
+        )
+        p2 = MainProduct.objects.create(
+            supplier=self.supplier,
+            article='A-1',
+            name='Milwaukee M12',
+        )
+        p3 = MainProduct.objects.create(
+            supplier=self.supplier,
+            article='A-2',
+            name='Milwaukee M12',
+        )
+
+        groups = build_duplicates_groups([p1, p2, p3], ['article', 'name'])
+
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(sorted([product.id for product in groups[0]]), sorted([p1.id, p2.id]))

--- a/price_manager/main_product_manager/tests.py
+++ b/price_manager/main_product_manager/tests.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from django.test import TestCase
 
 from supplier_manager.models import Manufacturer, ManufacturerDict
@@ -41,3 +42,77 @@ class ManufacturerWidgetTests(TestCase):
 
         self.assertEqual(result.name, "Completely New Brand")
         self.assertEqual(Manufacturer.objects.count(), 1)
+
+from django.utils import timezone
+
+from supplier_manager.models import Currency, Supplier
+from supplier_product_manager.models import SupplierProduct
+from .models import MainProduct, MainProductLog
+from .views import merge_selected_main_products
+
+
+class MergeSelectedMainProductsTests(TestCase):
+    def setUp(self):
+        self.currency = Currency.objects.create(name='KZT', value=1)
+        self.supplier = Supplier.objects.create(
+            name='Test supplier',
+            currency=self.currency,
+            price_update_rate='',
+            stock_update_rate='',
+            delivery_days_available=1,
+            delivery_days_navailable=2,
+        )
+
+    def test_merges_products_using_oldest_log_as_original(self):
+        older_product = MainProduct.objects.create(
+            supplier=self.supplier,
+            article='A-1',
+            name='Дрель',
+        )
+        newer_product = MainProduct.objects.create(
+            supplier=self.supplier,
+            article='A-2',
+            name='Дрель',
+        )
+
+        MainProductLog.objects.create(
+            main_product=older_product,
+            update_time=timezone.now() - timedelta(days=10),
+            stock=5,
+        )
+        MainProductLog.objects.create(
+            main_product=newer_product,
+            update_time=timezone.now() - timedelta(days=1),
+            stock=2,
+        )
+
+        SupplierProduct.objects.create(
+            main_product=newer_product,
+            supplier=self.supplier,
+            article='SP-1',
+            name='Позиция поставщика',
+        )
+
+        keep_product, deleted_products, moved_supplier_products, moved_logs = merge_selected_main_products(
+            [older_product.id, newer_product.id]
+        )
+
+        self.assertEqual(keep_product.id, older_product.id)
+        self.assertEqual(deleted_products, 1)
+        self.assertEqual(moved_supplier_products, 1)
+        self.assertEqual(moved_logs, 1)
+        self.assertFalse(MainProduct.objects.filter(id=newer_product.id).exists())
+        self.assertTrue(
+            SupplierProduct.objects.filter(main_product=older_product, article='SP-1').exists()
+        )
+
+    def test_returns_none_when_less_than_two_products_selected(self):
+        product = MainProduct.objects.create(
+            supplier=self.supplier,
+            article='A-1',
+            name='Один товар',
+        )
+
+        result = merge_selected_main_products([product.id])
+
+        self.assertIsNone(result)

--- a/price_manager/main_product_manager/views.py
+++ b/price_manager/main_product_manager/views.py
@@ -51,6 +51,76 @@ import pandas as pd
 import re
 import math
 
+
+def _normalize_compare_string(value: Optional[str]) -> str:
+  return re.sub(r'\s+', ' ', (value or '').strip().lower())
+
+
+def _names_partially_match(left_name: Optional[str], right_name: Optional[str]) -> bool:
+  left_normalized = _normalize_compare_string(left_name)
+  right_normalized = _normalize_compare_string(right_name)
+  if not left_normalized or not right_normalized:
+    return False
+  return (
+    left_normalized in right_normalized
+    or right_normalized in left_normalized
+  )
+
+
+def build_duplicates_groups(
+  products: list['MainProduct'],
+  selected_compare_fields: list[str],
+) -> list[list['MainProduct']]:
+  if not selected_compare_fields:
+    return []
+
+  if 'name' not in selected_compare_fields:
+    grouped_products: OrderedDict[tuple, list[MainProduct]] = OrderedDict()
+    for product in products:
+      group_key = tuple(getattr(product, field) for field in selected_compare_fields)
+      grouped_products.setdefault(group_key, []).append(product)
+    return [group for group in grouped_products.values() if len(group) > 1]
+
+  exact_fields = [field for field in selected_compare_fields if field != 'name']
+  grouped_by_exact_fields: OrderedDict[tuple, list[MainProduct]] = OrderedDict()
+  for product in products:
+    group_key = tuple(getattr(product, field) for field in exact_fields)
+    grouped_by_exact_fields.setdefault(group_key, []).append(product)
+
+  duplicates_groups: list[list[MainProduct]] = []
+  for exact_group_products in grouped_by_exact_fields.values():
+    if len(exact_group_products) < 2:
+      continue
+
+    visited = set()
+    for index, product in enumerate(exact_group_products):
+      if index in visited:
+        continue
+
+      stack = [index]
+      component_indexes = []
+      while stack:
+        current_index = stack.pop()
+        if current_index in visited:
+          continue
+        visited.add(current_index)
+        component_indexes.append(current_index)
+
+        current_product = exact_group_products[current_index]
+        for other_index, other_product in enumerate(exact_group_products):
+          if other_index in visited:
+            continue
+          if _names_partially_match(current_product.name, other_product.name):
+            stack.append(other_index)
+
+      if len(component_indexes) > 1:
+        duplicates_groups.append([
+          exact_group_products[component_index]
+          for component_index in sorted(component_indexes)
+        ])
+
+  return duplicates_groups
+
 class MainPage(FilterView):
   model = MainProduct
   filterset_class = MainProductFilter
@@ -292,27 +362,13 @@ class MainProductDuplicatesView(FilterView):
 
     duplicates_groups: list[list[MainProduct]] = []
     if selected_compare_fields:
-      base_queryset = context['filter'].qs.order_by('id')
-      grouped_values = (
-        base_queryset
-        .values(*selected_compare_fields)
-        .annotate(products_count=Count('id'))
-        .filter(products_count__gt=1)
+      products = list(
+        context['filter'].qs
+        .select_related('supplier', 'manufacturer', 'category')
+        .annotate(oldest_log_at=Min('mp_log__update_time'))
+        .order_by(F('oldest_log_at').asc(nulls_last=True), 'id')
       )
-
-      for group_data in grouped_values:
-        query = Q()
-        for field in selected_compare_fields:
-          query &= Q(**{field: group_data[field]})
-        duplicates_groups.append(
-          list(
-            base_queryset
-            .filter(query)
-            .select_related('supplier', 'manufacturer', 'category')
-            .annotate(oldest_log_at=Min('mp_log__update_time'))
-            .order_by(F('oldest_log_at').asc(nulls_last=True), 'id')
-          )
-        )
+      duplicates_groups = build_duplicates_groups(products, selected_compare_fields)
 
     context['duplicates_groups'] = duplicates_groups
     context['comparison_labels'] = [

--- a/price_manager/main_product_manager/views.py
+++ b/price_manager/main_product_manager/views.py
@@ -17,9 +17,10 @@ from django.views.generic import (View,
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.urls import reverse, reverse_lazy
 from typing import Optional, Any, Dict, Iterable
-from collections import defaultdict, OrderedDict
-from django.db.models import Count, Prefetch, F, Q, Value, Max, Min, Subquery, OuterRef, IntegerField, ExpressionWrapper
+from collections import defaultdict
+from django.db.models import Count, Prefetch, F, Q, Value, Max, Min, Subquery, OuterRef, IntegerField, ExpressionWrapper, Exists
 from django.db import transaction
+from django.db.models.functions import Lower, Trim, StrIndex
 from django.contrib.postgres.search import SearchVector
 # Импорты из сторонних приложений
 from django_tables2 import SingleTableView, RequestConfig, SingleTableMixin
@@ -67,57 +68,100 @@ def _names_partially_match(left_name: Optional[str], right_name: Optional[str]) 
   )
 
 
+def _build_name_pair_query(products: list['MainProduct']) -> list[list['MainProduct']]:
+  duplicates_groups: list[list[MainProduct]] = []
+  visited_ids = set()
+  product_by_id = {product.id: product for product in products}
+
+  for product in products:
+    if product.id in visited_ids:
+      continue
+
+    stack = [product.id]
+    component_ids = set()
+    while stack:
+      current_id = stack.pop()
+      if current_id in component_ids:
+        continue
+      component_ids.add(current_id)
+      current_product = product_by_id[current_id]
+
+      for candidate in products:
+        if candidate.id in component_ids:
+          continue
+        if _names_partially_match(current_product.normalized_name, candidate.normalized_name):
+          stack.append(candidate.id)
+
+    if len(component_ids) > 1:
+      visited_ids.update(component_ids)
+      duplicates_groups.append([
+        product_by_id[product_id] for product_id in sorted(component_ids)
+      ])
+
+  return duplicates_groups
+
+
 def build_duplicates_groups(
-  products: list['MainProduct'],
+  base_queryset,
   selected_compare_fields: list[str],
 ) -> list[list['MainProduct']]:
   if not selected_compare_fields:
     return []
 
   if 'name' not in selected_compare_fields:
-    grouped_products: OrderedDict[tuple, list[MainProduct]] = OrderedDict()
-    for product in products:
-      group_key = tuple(getattr(product, field) for field in selected_compare_fields)
-      grouped_products.setdefault(group_key, []).append(product)
-    return [group for group in grouped_products.values() if len(group) > 1]
+    grouped_values = (
+      base_queryset
+      .values(*selected_compare_fields)
+      .annotate(products_count=Count('id'))
+      .filter(products_count__gt=1)
+    )
+
+    duplicates_groups = []
+    for group_data in grouped_values:
+      query = Q()
+      for field in selected_compare_fields:
+        query &= Q(**{field: group_data[field]})
+      duplicates_groups.append(list(base_queryset.filter(query)))
+    return duplicates_groups
 
   exact_fields = [field for field in selected_compare_fields if field != 'name']
-  grouped_by_exact_fields: OrderedDict[tuple, list[MainProduct]] = OrderedDict()
-  for product in products:
-    group_key = tuple(getattr(product, field) for field in exact_fields)
-    grouped_by_exact_fields.setdefault(group_key, []).append(product)
+  grouped_values = (
+    base_queryset
+    .values(*exact_fields)
+    .annotate(products_count=Count('id'))
+    .filter(products_count__gt=1)
+  )
 
   duplicates_groups: list[list[MainProduct]] = []
-  for exact_group_products in grouped_by_exact_fields.values():
-    if len(exact_group_products) < 2:
-      continue
+  for group_data in grouped_values:
+    group_query = Q()
+    for field in exact_fields:
+      group_query &= Q(**{field: group_data[field]})
 
-    visited = set()
-    for index, product in enumerate(exact_group_products):
-      if index in visited:
-        continue
+    group_queryset = base_queryset.filter(group_query)
 
-      stack = [index]
-      component_indexes = []
-      while stack:
-        current_index = stack.pop()
-        if current_index in visited:
-          continue
-        visited.add(current_index)
-        component_indexes.append(current_index)
+    related_products = MainProduct.objects.annotate(
+      normalized_name=Lower(Trim(F('name')))
+    ).filter(group_query).exclude(pk=OuterRef('pk'))
 
-        current_product = exact_group_products[current_index]
-        for other_index, other_product in enumerate(exact_group_products):
-          if other_index in visited:
-            continue
-          if _names_partially_match(current_product.name, other_product.name):
-            stack.append(other_index)
+    has_partial_name_match = Exists(
+      related_products.annotate(
+        reverse_match_position=StrIndex(OuterRef('normalized_name'), F('normalized_name')),
+      ).filter(
+        Q(normalized_name__contains=OuterRef('normalized_name')) |
+        Q(reverse_match_position__gt=0)
+      )
+    )
 
-      if len(component_indexes) > 1:
-        duplicates_groups.append([
-          exact_group_products[component_index]
-          for component_index in sorted(component_indexes)
-        ])
+    group_products = list(
+      group_queryset
+      .annotate(normalized_name=Lower(Trim(F('name'))))
+      .annotate(has_partial_name_match=has_partial_name_match)
+      .filter(has_partial_name_match=True)
+    )
+
+    if len(group_products) > 1:
+      duplicates_groups.extend(_build_name_pair_query(group_products))
 
   return duplicates_groups
 
@@ -362,13 +406,13 @@ class MainProductDuplicatesView(FilterView):
 
     duplicates_groups: list[list[MainProduct]] = []
     if selected_compare_fields:
-      products = list(
+      base_queryset = (
         context['filter'].qs
         .select_related('supplier', 'manufacturer', 'category')
         .annotate(oldest_log_at=Min('mp_log__update_time'))
         .order_by(F('oldest_log_at').asc(nulls_last=True), 'id')
       )
-      duplicates_groups = build_duplicates_groups(products, selected_compare_fields)
+      duplicates_groups = build_duplicates_groups(base_queryset, selected_compare_fields)
 
     context['duplicates_groups'] = duplicates_groups
     context['comparison_labels'] = [

--- a/price_manager/main_product_manager/views.py
+++ b/price_manager/main_product_manager/views.py
@@ -18,7 +18,7 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.urls import reverse, reverse_lazy
 from typing import Optional, Any, Dict, Iterable
 from collections import defaultdict, OrderedDict
-from django.db.models import Count, Prefetch, F, Q, Value, Max, Subquery, OuterRef, IntegerField, ExpressionWrapper
+from django.db.models import Count, Prefetch, F, Q, Value, Max, Min, Subquery, OuterRef, IntegerField, ExpressionWrapper
 from django.db import transaction
 from django.contrib.postgres.search import SearchVector
 # Импорты из сторонних приложений
@@ -240,4 +240,131 @@ class ResolveMainproduct(SingleTableMixin, FilterView):
       context["pk"] = self.kwargs.get('pk')
       context["bound"] = self.request.GET.get('bound', None) is not None
       return context
+
+
+class MainProductDuplicatesView(FilterView):
+  model = MainProduct
+  filterset_class = MainProductFilter
+  template_name = 'mainproduct/duplicates.html'
+
+  COMPARISON_FIELD_LABELS = {
+    'article': 'артиклю',
+    'supplier': 'поставщику',
+    'name': 'названию',
+  }
+
+  def get_filterset_kwargs(self, filterset_class):
+    kwargs = super().get_filterset_kwargs(filterset_class)
+    kwargs['url'] = reverse_lazy('mainproduct-duplicates')
+    return kwargs
+
+  def post(self, request, *args, **kwargs):
+    selected_products = [int(pk) for pk in request.POST.getlist('selected_products') if pk.isdigit()]
+    if len(selected_products) < 2:
+      messages.warning(request, 'Выберите минимум два товара для объединения.')
+      return redirect(reverse_lazy('mainproduct-duplicates'))
+
+    merged_data = merge_selected_main_products(selected_products)
+    if merged_data is None:
+      messages.warning(request, 'Не удалось объединить выбранные товары.')
+      return redirect(reverse_lazy('mainproduct-duplicates'))
+
+    keep_product, deleted_products, moved_supplier_products, moved_logs = merged_data
+    messages.success(
+      request,
+      (
+        f'Товары объединены в "{keep_product.name}" (ID: {keep_product.id}). '
+        f'Удалено дублей: {deleted_products}. '
+        f'Перенесено товаров поставщиков: {moved_supplier_products}. '
+        f'Перенесено логов: {moved_logs}.'
+      ),
+    )
+    return redirect(reverse_lazy('mainproduct-duplicates'))
+
+  def get_context_data(self, **kwargs) -> dict[str, Any]:
+    context = super().get_context_data(**kwargs)
+
+    selected_compare_fields = [
+      field for field in self.COMPARISON_FIELD_LABELS.keys()
+      if self.request.GET.get(field) == 'on'
+    ]
+    context['selected_compare_fields'] = selected_compare_fields
+
+    duplicates_groups: list[list[MainProduct]] = []
+    if selected_compare_fields:
+      base_queryset = context['filter'].qs.order_by('id')
+      grouped_values = (
+        base_queryset
+        .values(*selected_compare_fields)
+        .annotate(products_count=Count('id'))
+        .filter(products_count__gt=1)
+      )
+
+      for group_data in grouped_values:
+        query = Q()
+        for field in selected_compare_fields:
+          query &= Q(**{field: group_data[field]})
+        duplicates_groups.append(
+          list(
+            base_queryset
+            .filter(query)
+            .select_related('supplier', 'manufacturer', 'category')
+            .annotate(oldest_log_at=Min('mp_log__update_time'))
+            .order_by(F('oldest_log_at').asc(nulls_last=True), 'id')
+          )
+        )
+
+    context['duplicates_groups'] = duplicates_groups
+    context['comparison_labels'] = [
+      self.COMPARISON_FIELD_LABELS[field] for field in selected_compare_fields
+    ]
+    return context
+
+
+def merge_selected_main_products(selected_ids: list[int]):
+  products = list(
+    MainProduct.objects
+    .filter(id__in=selected_ids)
+    .annotate(oldest_log_at=Min('mp_log__update_time'))
+    .order_by(F('oldest_log_at').asc(nulls_last=True), 'id')
+  )
+  if len(products) < 2:
+    return None
+
+  keep_product = products[0]
+  duplicate_ids = [product.id for product in products[1:]]
+  if not duplicate_ids:
+    return None
+
+  with transaction.atomic():
+    moved_supplier_products = SupplierProduct.objects.filter(
+      main_product_id__in=duplicate_ids
+    ).update(main_product=keep_product)
+
+    duplicate_logs = MainProductLog.objects.filter(
+      main_product_id__in=duplicate_ids,
+    ).values(
+      'update_time',
+      'price',
+      'price_type',
+      'stock',
+    )
+
+    moved_logs = MainProductLog.objects.bulk_create(
+      [
+        MainProductLog(
+          update_time=log['update_time'],
+          main_product=keep_product,
+          price=log['price'],
+          price_type=log['price_type'],
+          stock=log['stock'],
+        )
+        for log in duplicate_logs
+      ],
+      ignore_conflicts=True,
+    )
+
+    deleted_products = MainProduct.objects.filter(id__in=duplicate_ids).delete()[0]
+
+  return (keep_product, deleted_products, moved_supplier_products, len(moved_logs))
   

--- a/price_manager/price_manager/urls.py
+++ b/price_manager/price_manager/urls.py
@@ -26,6 +26,7 @@ urlpatterns = [
     path('mainproduct/<int:pk>/info', mp_views.MainProductInfo.as_view(), name='mainproduct-info'),
     path('mainproduct/<int:pk>/update', mp_views.MainProductUpdate.as_view(), name='mainproduct-update'),
     path('mainproduct/<int:pk>/resolve', mp_views.ResolveMainproduct.as_view(), name='mainproduct-resolve'),
+    path('mainproduct/duplicates/', mp_views.MainProductDuplicatesView.as_view(), name='mainproduct-duplicates'),
     path('mainproduct/<int:pk>/detail', mp_views.MainProductDetail.as_view(), name='mainproduct-detail'),
     path('mainproduct/<int:pk>/pricetags', ppm_views.PriceTagList.as_view(), name='pricetag-list'),
     path('mainproduct/<int:pk>/logs', mp_views.MainProductLogList.as_view(), name='mainproductlog-list'),


### PR DESCRIPTION
### Motivation
- Нужно предоставить интерфейс для поиска и разрешения дублей в главном прайсе с возможностью выбирать критерии сравнения и объединять группы товаров в один.

### Description
- Добавлен `MainProductDuplicatesView` (class-based `FilterView`) с подключением `MainProductFilter` и URL `mainproduct/duplicates/` для страницы дублей. 
- Добавлен шаблон `mainproduct/duplicates.html`, который отображает чекбоксы сравнения (`артикул`, `поставщик`, `название`), фильтр и отдельную таблицу для каждой группы дублей с чекбоксами выбора товаров.
- Реализована функция `merge_selected_main_products`, которая в транзакции выбирает оригинал как продукт с самым старым логом, переносит `SupplierProduct` на оригинал, копирует логи дублей к оригиналу и удаляет дубли; добавлен POST-обработчик вью для объединения выбранных товаров и сообщений в UI.
- Добавлена ссылка на страницу «Дубликаты» в верхнем меню и юнит-тесты для логики объединения (`merge_selected_main_products`).

### Testing
- `python manage.py check` — успешно (система проверок Django не выявила ошибок). 
- `python manage.py test main_product_manager.tests` — не удалось выполнить из-за отсутствия подключения к PostgreSQL в окружении (ошибка `connection refused` на `127.0.0.1:5432`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2664aeef4832d89a5f0a3a8ed48e4)