### PR TITLE
Add automatic Docker backup restore

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,11 @@ services:
       db:
         condition: service_healthy
         restart: true
+      db_restore:
+        condition: service_completed_successfully
     env_file:
       - .env
+
   db:
     image: postgres:17
     container_name: postgres_db
@@ -25,10 +28,23 @@ services:
       test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
       interval: 10s
       retries: 5
-
       start_period: 30s
       timeout: 10s
 
+  db_restore:
+    image: postgres:17
+    depends_on:
+      db:
+        condition: service_healthy
+    env_file:
+      - .env
+    volumes:
+      - .:/workspace:ro
+      - restore_state:/restore-state
+      - ./docker/db/restore.sh:/restore.sh:ro
+    entrypoint: ["/bin/sh", "/restore.sh"]
+    restart: "no"
 
 volumes:
   postgres_db:
+  restore_state:

--- a/docker/db/restore.sh
+++ b/docker/db/restore.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+set -eu
+
+BACKUP_FILE="/workspace/backup.backup"
+MARKER_FILE="/restore-state/backup_restored"
+
+if [ ! -f "$BACKUP_FILE" ]; then
+  echo "Backup file $BACKUP_FILE not found, skipping restore."
+  exit 0
+fi
+
+if [ -f "$MARKER_FILE" ]; then
+  echo "Backup restore already completed earlier, skipping."
+  exit 0
+fi
+
+echo "Waiting for database to accept connections..."
+until pg_isready -h db -U "$POSTGRES_USER" -d "$POSTGRES_DB"; do
+  sleep 2
+done
+
+echo "Restoring backup from $BACKUP_FILE..."
+PGPASSWORD="$POSTGRES_PASSWORD" pg_restore \
+  --clean \
+  --verbose \
+  --no-owner \
+  --host=db \
+  --username="$POSTGRES_USER" \
+  --dbname="$POSTGRES_DB" \
+  "$BACKUP_FILE"
+
+touch "$MARKER_FILE"
+echo "Backup restore completed."

--- a/price_manager/entrypoint.sh
+++ b/price_manager/entrypoint.sh
@@ -3,9 +3,6 @@
 # echo "Applying migrations ..."
 # python manage.py migrate
 
-# docker cp ".\backup.backup" postgres_db:/
-# docker exec -it postgres_db /bin/bash
-# pg_restore --clean --verbose -U priceuser -d pricemanager ./backup.backup
 
 echo "Starting server..."
 python manage.py runserver 0.0.0.0:8000


### PR DESCRIPTION
### Motivation
- Автоматизировать восстановление базы из бэкапа при старте контейнеров вместо ручных `docker cp`/`docker exec` действий.
- Обеспечить последовательный порядок запуска так, чтобы приложение `web` ждал завершения восстановления БД.
- Избежать повторных восстановлений на последующих стартах с помощью маркера состояния.

### Description
- Добавлен одноразовый сервис `db_restore` в `docker-compose.yml`, который ждёт здорового `db` и выполняет скрипт восстановления перед запуском `web`.
- Добавлен скрипт `docker/db/restore.sh`, который ждёт готовности БД, запускает `pg_restore --clean --verbose` с `PGPASSWORD` и использует файл-маркер в томе `restore_state` для пропуска повторных восстановлений.
- Обновлён `price_manager/entrypoint.sh` для удаления старых комментариев с ручными командами восстановления, так как восстановление теперь выполняется отдельным сервисом.
- Добавлен том `restore_state` в `docker-compose.yml` для хранения маркера выполненного восстановления.

### Testing
- Выполнена проверка синтаксиса скрипта восстановления через `sh -n docker/db/restore.sh` и она прошла успешно.
- Выполнена проверка синтаксиса точки входа через `sh -n price_manager/entrypoint.sh` и она прошла успешно.
- Попытка выполнить `docker compose config` не удалась в среде из-за отсутствия `docker` CLI, поэтому схема Compose не была валидирована здесь.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc062cfc5c832d9392b19d2194acd3)