### PR TITLE
Массовое назначение категории на странице Главного прайса

### DIFF
--- a/price_manager/main_product_manager/forms.py
+++ b/price_manager/main_product_manager/forms.py
@@ -11,3 +11,16 @@ class MainProductForm(forms.ModelForm):
       'width',
       'depth',
     )
+
+
+class MainProductBulkCategoryForm(forms.Form):
+  category = forms.ModelChoiceField(
+    label='Категория',
+    queryset=Category.objects.all(),
+    required=True,
+    empty_label='Выберите категорию',
+  )
+
+  def __init__(self, *args, **kwargs):
+    super().__init__(*args, **kwargs)
+    self.fields['category'].queryset = Category.objects.all().order_by('tree_id', 'lft')

--- a/price_manager/main_product_manager/templates/mainproduct/partials/bulk_category_modal.html
+++ b/price_manager/main_product_manager/templates/mainproduct/partials/bulk_category_modal.html
@@ -1,0 +1,23 @@
+{% load crispy_forms_tags %}
+<div class="container p-4">
+  <h2 class="h4 mb-3">Добавить категорию</h2>
+  <p class="text-muted mb-4">
+    Выберите категорию, которая будет назначена всем товарам в текущей выборке: {{ products_count }} шт.
+  </p>
+  <form
+    method="post"
+    hx-post="{% url 'mainproduct-bulk-category' %}{% if query_string %}?{{ query_string }}{% endif %}"
+    hx-target="#modal-container .modal-content"
+    hx-swap="innerHTML">
+    {% csrf_token %}
+    {{ form|crispy }}
+    <div class="d-flex gap-2 mt-4">
+      <button class="btn btn-primary" type="submit">
+        Сохранить
+      </button>
+      <button class="btn btn-outline-secondary" type="button" data-bs-dismiss="modal">
+        Отмена
+      </button>
+    </div>
+  </form>
+</div>

--- a/price_manager/main_product_manager/templates/mainproduct/partials/tables_bycat.html
+++ b/price_manager/main_product_manager/templates/mainproduct/partials/tables_bycat.html
@@ -6,6 +6,16 @@
     <div class="col-4 mb-3 d-flex justify-content-end gap-2">
       {% include "mainproduct/partials/fields_selector.html" %}
       <button type="button"
+              class="btn btn-outline-primary"
+              title="Добавить категорию"
+              data-bs-toggle="modal"
+              data-bs-target="#modal-container"
+              hx-get="{% url 'mainproduct-bulk-category' %}{% querystring %}"
+              hx-target="#modal-container .modal-content"
+              hx-swap="innerHTML">
+        Добавить категорию
+      </button>
+      <button type="button"
               class="btn btn-primary"
               title="Обновить"
               data-bs-toggle="modal"

--- a/price_manager/main_product_manager/views.py
+++ b/price_manager/main_product_manager/views.py
@@ -211,6 +211,42 @@ class MainProductLogList(SingleTableView):
     return super().get(request, *args, **kwargs)
 
 
+class MainProductBulkCategoryView(FormView):
+  form_class = MainProductBulkCategoryForm
+  template_name = 'mainproduct/partials/bulk_category_modal.html'
+
+  def get(self, request, *args, **kwargs):
+    if not self.request.htmx:
+      return redirect(reverse('mainproducts'))
+    return super().get(request, *args, **kwargs)
+
+  def get_context_data(self, **kwargs):
+    context = super().get_context_data(**kwargs)
+    queryset = MainProductFilter(self.request.GET).qs
+    context['products_count'] = queryset.count()
+    context['query_string'] = self.request.GET.urlencode()
+    return context
+
+  def form_valid(self, form):
+    queryset = MainProductFilter(self.request.GET).qs
+    category = form.cleaned_data['category']
+    updated_ids = list(queryset.values_list('pk', flat=True))
+    updated_count = len(updated_ids)
+    if updated_count:
+      MainProduct.objects.filter(pk__in=updated_ids).update(category=category)
+      recalculate_search_vectors(
+        MainProduct.objects.filter(pk__in=updated_ids).select_related('supplier', 'category', 'manufacturer')
+      )
+    messages.success(
+      self.request,
+      f'Категория «{category.name}» назначена для {updated_count} товар(ов).'
+    )
+    url = reverse('mainproducts')
+    if self.request.GET:
+      url = f'{url}?{self.request.GET.urlencode()}'
+    return HttpResponseClientRedirect(url)
+
+
 class ResolveMainproduct(SingleTableMixin, FilterView):
   model = MainProduct
   filterset_class = MainProductFilter

--- a/price_manager/price_manager/urls.py
+++ b/price_manager/price_manager/urls.py
@@ -23,6 +23,7 @@ urlpatterns = [
 
     path('mainproduct/<int:id>/update', mp_views.MainProductUpdate.as_view(), name='main-product-update'),
     path('mainproduct/sync', mp_views.sync_main_products, name='mainproducts-sync'),
+    path('mainproduct/bulk-category', mp_views.MainProductBulkCategoryView.as_view(), name='mainproduct-bulk-category'),
     path('mainproduct/<int:pk>/info', mp_views.MainProductInfo.as_view(), name='mainproduct-info'),
     path('mainproduct/<int:pk>/update', mp_views.MainProductUpdate.as_view(), name='mainproduct-update'),
     path('mainproduct/<int:pk>/resolve', mp_views.ResolveMainproduct.as_view(), name='mainproduct-resolve'),


### PR DESCRIPTION
### Motivation
- Добавить возможность быстро привязать выбранную категорию ко всем товарам, которые видны в текущей фильтрованной выборке Главного прайса, через привычный UI-модал.
- Сделать операцию доступной из верхней панели страницы Главного прайса и выполнить обновление поисковых векторов для консистентного поиска после назначения категории.

### Description
- Добавлена форма `MainProductBulkCategoryForm` в `price_manager/main_product_manager/forms.py` для выбора категории и упорядочивания дерева категорий по `tree_id, lft`.
- Реализован `MainProductBulkCategoryView` (наследник `FormView`) в `price_manager/main_product_manager/views.py`, который берет текущую отфильтрованную выборку через `MainProductFilter`, массово обновляет поле `category` у найденных `MainProduct` и пересчитывает их search vectors через `recalculate_search_vectors`.
- Добавлена HTMX-модалка шаблона `price_manager/main_product_manager/templates/mainproduct/partials/bulk_category_modal.html` и кнопка `Добавить категорию` в `price_manager/main_product_manager/templates/mainproduct/partials/tables_bycat.html`, которые открывают модал с сохранением текущих фильтров (`querystring`).
- Зарегистрирован маршрут `mainproduct/bulk-category` в `price_manager/price_manager/urls.py` для показа модалки и обработки сабмита.

### Testing
- Выполнена компиляция кода с помощью `python -m compileall price_manager/main_product_manager price_manager/price_manager` и компиляция прошла успешно.
- Выполнена системная проверка Django через `python price_manager/manage.py check` и проверка прошла успешно.
- UI-скриншотов/ручного тестирования в браузере не было выполнено в этой сессии.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfae1d8cfc832d809702198eadcca4)