### PR TITLE
Добавить кнопку «Объеденить все» на странице дубликатов

### DIFF
--- a/price_manager/main_product_manager/templates/mainproduct/duplicates.html
+++ b/price_manager/main_product_manager/templates/mainproduct/duplicates.html
@@ -44,7 +44,7 @@
             <p class="mb-0">Критерии сравнения: <strong>{{ comparison_labels|join:", " }}</strong>.</p>
             <div class="d-flex gap-2">
               <button type="submit" name="merge_mode" value="selected" class="btn btn-success">Объединить выбранные товары</button>
-              <button type="submit" name="merge_mode" value="all" class="btn btn-outline-success">Объеденить все</button>
+              <button type="submit" name="merge_mode" value="all" class="btn btn-outline-success">Объединить все</button>
             </div>
           </div>
           {% if id %}

--- a/price_manager/main_product_manager/templates/mainproduct/duplicates.html
+++ b/price_manager/main_product_manager/templates/mainproduct/duplicates.html
@@ -42,7 +42,10 @@
           {% csrf_token %}
           <div class="d-flex justify-content-between align-items-center mb-3">
             <p class="mb-0">Критерии сравнения: <strong>{{ comparison_labels|join:", " }}</strong>.</p>
-            <button type="submit" class="btn btn-success">Объединить выбранные товары</button>
+            <div class="d-flex gap-2">
+              <button type="submit" name="merge_mode" value="selected" class="btn btn-success">Объединить выбранные товары</button>
+              <button type="submit" name="merge_mode" value="all" class="btn btn-outline-success">Объеденить все</button>
+            </div>
           </div>
           {% if id %}
             <div hx-get="{% url "mainproduct-duplicate" id=id %}{% querystring %}" hx-trigger="load" hx-target="this"></div>

--- a/price_manager/main_product_manager/views.py
+++ b/price_manager/main_product_manager/views.py
@@ -303,7 +303,75 @@ class MainProductDuplicatesView(FilterView):
             return super().get(request, *args, **kwargs)
 
         return HttpResponseClientRedirect(f"{reverse('mainproduct-duplicates')}?{request.META['QUERY_STRING']}")
+    def _get_selected_compare_fields(self, request):
+        return [
+            field for field in self.COMPARISON_FIELD_LABELS.keys()
+            if request.GET.get('c' + field) == 'on'
+        ]
+
+    def _collect_duplicate_groups(self, request, selected_compare_fields):
+        if not selected_compare_fields:
+            return []
+        base_queryset = MainProductFilter(request.GET).qs.order_by('id')
+        first_product = base_queryset.first()
+        if first_product is None:
+            return []
+
+        groups = []
+        next_id = first_product.id
+        while next_id is not None:
+            next_id, buffer_queryset = get_dupes(next_id, selected_compare_fields, base_queryset)
+            if buffer_queryset is not None and buffer_queryset.count() >= 2:
+                groups.append(list(buffer_queryset.values_list('id', flat=True)))
+        return groups
+
     def post(self, request, *args, **kwargs):
+        selected_compare_fields = self._get_selected_compare_fields(request)
+        merge_mode = request.POST.get('merge_mode', 'selected')
+        if merge_mode == 'all':
+            if not selected_compare_fields:
+                messages.warning(request, 'Сначала выберите хотя бы одно поле сравнения.')
+                return redirect(f"{reverse('mainproduct-duplicates')}?{request.META['QUERY_STRING']}")
+
+            duplicate_groups = self._collect_duplicate_groups(request, selected_compare_fields)
+            if not duplicate_groups:
+                messages.info(request, 'Группы дубликатов по текущему фильтру не найдены.')
+                return redirect(f"{reverse('mainproduct-duplicates')}?{request.META['QUERY_STRING']}")
+
+            merged_groups = 0
+            deleted_products_total = 0
+            moved_supplier_products_total = 0
+            moved_logs_total = 0
+            processed_ids = set()
+
+            for group_ids in duplicate_groups:
+                clean_group_ids = [pid for pid in group_ids if pid not in processed_ids]
+                if len(clean_group_ids) < 2:
+                    continue
+                merged_data = merge_selected_main_products(clean_group_ids)
+                if merged_data is None:
+                    continue
+                _, deleted_products, moved_supplier_products, moved_logs = merged_data
+                merged_groups += 1
+                deleted_products_total += deleted_products
+                moved_supplier_products_total += moved_supplier_products
+                moved_logs_total += moved_logs
+                processed_ids.update(clean_group_ids)
+
+            if merged_groups == 0:
+                messages.info(request, 'Не удалось объединить найденные группы дубликатов.')
+            else:
+                messages.success(
+                    request,
+                    (
+                        f'Объединено групп: {merged_groups}. '
+                        f'Удалено дублей: {deleted_products_total}. '
+                        f'Перенесено товаров поставщиков: {moved_supplier_products_total}. '
+                        f'Перенесено логов: {moved_logs_total}.'
+                    ),
+                )
+            return redirect(f"{reverse('mainproduct-duplicates')}?{request.META['QUERY_STRING']}")
+
         selected_products = [int(pk) for pk in request.POST.getlist('selected_products') if pk.isdigit()]
         if len(selected_products) < 2:
             messages.warning(request, 'Выберите минимум два товара для объединения. Или хотя бы одну группу.')
@@ -319,10 +387,7 @@ class MainProductDuplicatesView(FilterView):
             selection_query = f"{selection_query}&{request.META['QUERY_STRING']}"
         return redirect(f"{reverse('mainproduct-duplicate-select-keep')}?{selection_query}")
     def get_filterset_kwargs(self, filterset_class):
-        selected_compare_fields = [
-            field for field in self.COMPARISON_FIELD_LABELS.keys()
-            if self.request.GET.get('c' + field) == 'on'
-        ]
+        selected_compare_fields = self._get_selected_compare_fields(self.request)
         kwargs = super().get_filterset_kwargs(filterset_class)
         kwargs['url'] = f"{reverse('mainproduct-duplicates')}?{'&'.join(['c' + lable + '=on' for lable in selected_compare_fields])}"
         kwargs['hx_target']=None
@@ -333,10 +398,7 @@ class MainProductDuplicatesView(FilterView):
         context = super().get_context_data(**kwargs)
         qs = self.filterset.qs.order_by('id').first()
         context["id"] = qs.id if not qs is None else None
-        selected_compare_fields = [
-                field for field in COMPARISON_FIELD_LABELS.keys()
-                if self.request.GET.get('c' + field) == 'on'
-            ]
+        selected_compare_fields = self._get_selected_compare_fields(self.request)
         context['selected_compare_fields'] = selected_compare_fields
         context['comparison_labels'] = [
             COMPARISON_FIELD_LABELS[field] for field in selected_compare_fields


### PR DESCRIPTION
### Motivation
- Упростить обработку найденных дубликатов одним кликом и позволить массово объединять все группы дубликатов с учётом выбранных критериев сравнения и активных фильтров.

### Description
- В шаблон `mainproduct/duplicates.html` добавлена кнопка `name="merge_mode" value="all"` рядом с существующей кнопкой объединения выбранных товаров для запуска массового режима.
- В `MainProductDuplicatesView` добавлены вспомогательные методы `._get_selected_compare_fields(request)` и `._collect_duplicate_groups(request, selected_compare_fields)` для определения активных полей сравнения и сбора всех групп дубликатов по текущему фильтру.
- Добавлена обработка режима `merge_mode='all'` в `post`, которая проходит по всем группам дубликатов, вызывает `merge_selected_main_products` для каждой группы, аккумулирует статистику по удалённым товарам/перенесённым записям и показывает итоговое сообщение пользователю.
- Переписаны места, где вычисляются выбранные поля сравнения, чтобы использовать новый метод и убрать дублирование (в `get_filterset_kwargs` и `get_context_data`).

### Testing
- Выполнена проверка синтаксиса/компиляции с помощью `python -m compileall price_manager/main_product_manager/views.py price_manager/main_product_manager/templates/mainproduct/duplicates.html`, которая прошла успешно.
- Попытка запустить тесты `python manage.py test main_product_manager.tests -v 1` завершилась ошибкой среды из-за отсутствия переменной окружения базы данных (`POSTGRES_DB`), поэтому модульные тесты в CI-среде не были выполнены.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce2d84713c832dabfcc5c70c1ffabf)