### PR TITLE
Trust X-Forwarded-Proto and use relative HTMX history URLs

### DIFF
--- a/price_manager/main_product_manager/views.py
+++ b/price_manager/main_product_manager/views.py
@@ -98,7 +98,7 @@ class MainPage(FilterView):
   def render_to_response(self, context, **response_kwargs):
     response = super().render_to_response(context, **response_kwargs)
     if self.request.htmx and self.request.GET.get('page', 1) == 1:
-      response['Hx-Push'] = self.request.build_absolute_uri()
+      response['Hx-Push'] = self.request.get_full_path()
     return response
 
 

--- a/price_manager/price_manager/settings.py
+++ b/price_manager/price_manager/settings.py
@@ -28,7 +28,7 @@ SECRET_KEY = os.environ.get('SECRET_KEY','django-insecure-q_sht-smtwbq$s_j8*f!u#
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.environ.get('DEBUG',True)
 
-ALLOWED_HOSTS = ["*"]
+ALLOWED_HOSTS = os.environ.get("ALLOWED_HOSTS", "*").split(",")
 
 
 # Application definition
@@ -189,9 +189,10 @@ if not DEBUG:
     SECURE_HSTS_SECONDS = 31536000  # 1 year
     SECURE_HSTS_INCLUDE_SUBDOMAINS = True
     SECURE_HSTS_PRELOAD = True
-    # If behind a proxy (Railway)
+    # If behind a proxy (Railway), trust forwarded protocol/host headers.
+    # Railway/edge proxy must send: X-Forwarded-Proto: https
     USE_X_FORWARDED_HOST = True
-    SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', None)
+    SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 else:
     DEBUG = True
 


### PR DESCRIPTION
### Motivation
- Ensure Django correctly detects client HTTPS when deployed behind Railway/reverse proxies so generated URLs (e.g., HTMX history) use `https` instead of `http`.
- Allow strict host validation to be configured for production deployments via environment variables.
- Avoid generating absolute `http://` URLs for client-side history manipulation by preferring relative paths.

### Description
- Update `SECURE_PROXY_SSL_HEADER` in `price_manager/price_manager/settings.py` to `('HTTP_X_FORWARDED_PROTO', 'https')` and add a comment that the edge proxy must forward `X-Forwarded-Proto: https`.
- Keep `USE_X_FORWARDED_HOST = True` to trust forwarded host headers when behind a proxy.
- Make `ALLOWED_HOSTS` environment-configurable by replacing the hardcoded `[

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfa8547960832d9df5084e7471ac2c)