### PR TITLE
Move supplier setting upload to background Celery task

### DIFF
--- a/price_manager/supplier_product_manager/tasks.py
+++ b/price_manager/supplier_product_manager/tasks.py
@@ -1,0 +1,59 @@
+from celery import shared_task
+
+from core.models import PersistentNotification
+
+from .functions import load_setting
+from .models import Setting
+
+
+@shared_task
+def process_setting_upload(setting_id: int, user_id: int) -> dict:
+    """
+    Фоновая загрузка товаров поставщика по настройке.
+    """
+    try:
+        setting = Setting.objects.get(pk=setting_id)
+    except Setting.DoesNotExist:
+        return {"status": "error", "message": f"Настройка #{setting_id} не найдена"}
+
+    supplier_file = setting.supplierfiles.order_by("-pk").first()
+    if supplier_file:
+        supplier_file.status = 0
+        supplier_file.logs = "Загрузка запущена"
+        supplier_file.save(update_fields=["status", "logs"])
+
+    try:
+        products = load_setting(setting_id)
+        if products is None:
+            message = f"Загрузка файла через настройку «{setting.name}»: нет связок."
+            status = -1
+        else:
+            message = (
+                f"Загрузка файла через настройку «{setting.name}» завершена. "
+                f"Обработано {len(products)} товаров."
+            )
+            status = 1
+
+        if supplier_file:
+            supplier_file.status = status
+            supplier_file.logs = message
+            supplier_file.save(update_fields=["status", "logs"])
+
+        PersistentNotification.objects.create(
+            user_id=user_id,
+            level="success" if status == 1 else "warning",
+            message=message,
+        )
+        return {"status": "ok", "message": message}
+    except Exception as exc:
+        error_message = f"Ошибка фоновой загрузки настройки «{setting.name}»: {exc}"
+        if supplier_file:
+            supplier_file.status = -1
+            supplier_file.logs = error_message
+            supplier_file.save(update_fields=["status", "logs"])
+        PersistentNotification.objects.create(
+            user_id=user_id,
+            level="danger",
+            message=error_message,
+        )
+        raise

--- a/price_manager/supplier_product_manager/views.py
+++ b/price_manager/supplier_product_manager/views.py
@@ -38,6 +38,7 @@ import pandas as pd
 import re
 
 from .functions import *
+from .tasks import process_setting_upload
 
 class SupplierDetail(SingleTableMixin, FilterView):
   '''
@@ -159,11 +160,13 @@ def setting_upload(request, pk, state):
     url = reverse('setting-upload', kwargs={'pk':pk, 'state':1})
     return render(request, 'supplier_product/partials/load_partial.html', {'url':url})
   if setting.is_bound():
-    products = load_setting(pk)
-    if products is None:
-      messages.info(request, "Нет связок")
-    else:
-      messages.info(request, f"Загрузка файла через настройку {setting.name}. Обработано {len(products)} товаров.")
+    supplier_file = setting.supplierfiles.order_by('-pk').first()
+    if supplier_file:
+      supplier_file.status = 0
+      supplier_file.logs = "Загрузка запущена"
+      supplier_file.save(update_fields=['status', 'logs'])
+    process_setting_upload.delay(pk, request.user.pk)
+    messages.info(request, f"Запущена фоновая загрузка через настройку {setting.name}")
   else:
     messages.error(request, f'Не указано поле артикула и\\или наименования')
   return HttpResponseClientRefresh()


### PR DESCRIPTION
## Summary
- moved supplier setting file processing from synchronous view execution to a Celery task
- added `process_setting_upload` shared task in `supplier_product_manager.tasks`
- updated `setting_upload` view to enqueue the task instead of calling `load_setting` directly

## Details
- task now:
  - resolves `Setting` by id
  - marks the latest related `SupplierFile` as started
  - runs `load_setting` in background
  - stores final status/logs on `SupplierFile`
  - creates `PersistentNotification` for the initiating user with success/warning/error result
- view now immediately returns after enqueueing and shows a toast that background processing started

## Why
Long-running file imports were blocking request/response cycle. Moving heavy processing to Celery makes upload initiation fast and avoids request timeout risk.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfadef04e0832db72e0809641954f8)