### PR TITLE
Orchestrate main products sync with Celery chain and final notification

### DIFF
--- a/price_manager/main_product_manager/tasks.py
+++ b/price_manager/main_product_manager/tasks.py
@@ -1,27 +1,75 @@
-from celery import shared_task
+from celery import chain, shared_task
 
+from core.models import PersistentNotification
 from core.task_runner import execute_locked_task
+from django.contrib.auth import get_user_model
+from supplier_manager.models import Category
 from product_price_manager.models import update_prices
 
-from .functions import update_logs, update_stocks
+from .functions import recalculate_search_vectors, update_logs, update_stocks
+from .models import MainProduct
+
+
+def _build_step_result(payload: dict | None) -> dict:
+    if payload is None:
+        return {"status": "success", "updated_count": 0, "duration_ms": 0}
+    return {
+        "status": payload.get("status", "success"),
+        "updated_count": int(payload.get("updated_count", 0) or 0),
+        "duration_ms": int(payload.get("duration_ms", 0) or 0),
+    }
+
+
+def _append_step(stats: dict | None, step_name: str, payload: dict | None) -> dict:
+    next_stats = dict(stats or {})
+    steps = dict(next_stats.get("steps") or {})
+    steps[step_name] = _build_step_result(payload)
+    next_stats["steps"] = steps
+    return next_stats
+
+
+@shared_task(name="main_product_manager.rebuild_categories")
+def rebuild_categories_task(stats: dict | None = None) -> dict:
+    payload = execute_locked_task(
+        task_name="main_product_manager.rebuild_categories",
+        lock_ttl=60 * 10,
+        runner=Category.objects.rebuild,
+    )
+    return _append_step(stats, "rebuild_categories", payload)
+
+
+@shared_task(name="main_product_manager.recalculate_vectors_missing")
+def recalculate_vectors_missing_task(stats: dict | None = None) -> dict:
+    def _runner():
+        queryset = MainProduct.objects.filter(search_vector__isnull=True)
+        return recalculate_search_vectors(queryset) or 0
+
+    payload = execute_locked_task(
+        task_name="main_product_manager.recalculate_vectors_missing",
+        lock_ttl=60 * 20,
+        runner=_runner,
+    )
+    return _append_step(stats, "recalculate_vectors_missing", payload)
 
 
 @shared_task(name="main_product_manager.update_prices")
-def update_prices_task() -> dict:
-    return execute_locked_task(
+def update_prices_task(stats: dict | None = None) -> dict:
+    payload = execute_locked_task(
         task_name="main_product_manager.update_prices",
         lock_ttl=60 * 30,
         runner=update_prices,
     )
+    return _append_step(stats, "update_prices", payload)
 
 
 @shared_task(name="main_product_manager.update_stocks")
-def update_stocks_task() -> dict:
-    return execute_locked_task(
+def update_stocks_task(stats: dict | None = None) -> dict:
+    payload = execute_locked_task(
         task_name="main_product_manager.update_stocks",
         lock_ttl=60 * 15,
         runner=update_stocks,
     )
+    return _append_step(stats, "update_stocks", payload)
 
 
 @shared_task(name="main_product_manager.update_logs")
@@ -31,3 +79,59 @@ def update_logs_task() -> dict:
         lock_ttl=60 * 20,
         runner=update_logs,
     )
+
+
+@shared_task(name="main_product_manager.notify_sync_main_products")
+def notify_sync_main_products_task(stats: dict, user_id: int) -> dict:
+    steps = stats.get("steps", {})
+    total_updated = sum(step.get("updated_count", 0) for step in steps.values())
+    total_duration = sum(step.get("duration_ms", 0) for step in steps.values())
+    has_errors = any(step.get("status") == "error" for step in steps.values())
+    has_skipped = any(step.get("status") == "skipped" for step in steps.values())
+
+    lines = [
+        "Синхронизация главных товаров завершена.",
+        f"Шагов выполнено: {len(steps)}.",
+        f"Обновлено записей: {total_updated}.",
+        f"Длительность: {round(total_duration / 1000, 2)} сек.",
+        "",
+        "Детали:",
+    ]
+    for name, step in steps.items():
+        lines.append(
+            f"• {name}: статус={step.get('status')}, "
+            f"updated={step.get('updated_count', 0)}, "
+            f"duration={round(step.get('duration_ms', 0) / 1000, 2)} сек."
+        )
+
+    level = "success"
+    if has_errors:
+        level = "danger"
+    elif has_skipped:
+        level = "warning"
+
+    if get_user_model().objects.filter(pk=user_id).exists():
+        PersistentNotification.objects.create(
+            user_id=user_id,
+            level=level,
+            message="\n".join(lines),
+        )
+
+    return {
+        "status": "ok",
+        "level": level,
+        "total_updated": total_updated,
+        "total_duration_ms": total_duration,
+        "steps": steps,
+    }
+
+
+def sync_main_products_task(user_id: int):
+    workflow = chain(
+        rebuild_categories_task.s(),
+        recalculate_vectors_missing_task.s(),
+        update_prices_task.s(),
+        update_stocks_task.s(),
+        notify_sync_main_products_task.s(user_id=user_id),
+    )
+    return workflow.apply_async()

--- a/price_manager/main_product_manager/views.py
+++ b/price_manager/main_product_manager/views.py
@@ -43,7 +43,7 @@ from .forms import *
 from .tables import *
 from .filters import *
 from .functions import *
-from product_price_manager.views import update_prices
+from .tasks import sync_main_products_task
 from supplier_product_manager.views import UploadSupplierFile
 
 # Импорты сторонних библиотек
@@ -153,15 +153,9 @@ class MainProductTableView(SingleTableView):
 # Обработка продуктов главного прайса
 
 def sync_main_products(request, **kwargs):
-  """Обновляет остатки и применяет наценки в MainProduct из SupplierProduct"""
-  Category.objects.rebuild()
-  messages.info(
-    request, 
-    f"Векторы поиска обновлены у {recalculate_search_vectors(MainProduct.objects.filter(search_vector__isnull=True)) or 0} товаров")
-  count, dcount = update_prices()
-  messages.info(request, f"Цены обновлены у {count} товаров. Обнулены у {dcount} товаров.")
-  messages.info(request, f"Остатки обновлены у {update_stocks()} товаров")
-  
+  """Запускает асинхронную синхронизацию MainProduct."""
+  sync_main_products_task(request.user.id)
+  messages.info(request, "Синхронизация запущена")
   return HttpResponseClientRedirect(reverse('mainproducts'))
 
 


### PR DESCRIPTION
### Motivation
- Provide a single orchestration entrypoint to run the main-products synchronization as an ordered background workflow. 
- Split the monolithic sync into focused subtasks to allow stepwise locking, reporting and retries. 
- Surface an aggregated result to the initiating user via `PersistentNotification` and keep the HTTP view lightweight.

### Description
- Added orchestration helpers and step aggregation helpers (`_build_step_result`, `_append_step`) and new subtasks in `main_product_manager.tasks`: `rebuild_categories_task`, `recalculate_vectors_missing_task`, adapted `update_prices_task` and `update_stocks_task` to accept/return step `stats`, and `notify_sync_main_products_task` to aggregate results and create a `PersistentNotification` for the user. 
- Implemented `sync_main_products_task(user_id)` which composes the subtasks into a Celery `chain` and enqueues it with `apply_async()` to run the workflow (`rebuild_categories_task -> recalculate_vectors_missing_task -> update_prices_task -> update_stocks_task -> notify_sync_main_products_task`). 
- Updated imports to use `PersistentNotification`, `get_user_model`, `Category`, and `MainProduct`, and used `recalculate_search_vectors` in the dedicated vector-recalculation step. 
- Simplified the `sync_main_products` view to only enqueue `sync_main_products_task(request.user.id)` and show the message "Синхронизация запущена".

### Testing
- Ran Python compilation on the modified modules with `python -m compileall price_manager/main_product_manager/tasks.py price_manager/main_product_manager/views.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfb42cf990832d96a613393898a2de)