### PR TITLE
Move supplier->main copying to background task with chunked processing

### DIFF
--- a/price_manager/supplier_product_manager/migrations/0006_copysupplierproductstomainrun.py
+++ b/price_manager/supplier_product_manager/migrations/0006_copysupplierproductstomainrun.py
@@ -1,0 +1,36 @@
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('supplier_manager', '0001_initial'),
+        ('supplier_product_manager', '0005_alter_supplierfile_status'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='CopySupplierProductsToMainRun',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('status', models.CharField(choices=[('started', 'Выполняется'), ('success', 'Успешно'), ('error', 'Ошибка')], db_index=True, default='started', max_length=16, verbose_name='Статус')),
+                ('filter_params', models.JSONField(blank=True, default=dict, verbose_name='Параметры фильтра')),
+                ('processed_count', models.PositiveIntegerField(default=0, verbose_name='Обработано записей')),
+                ('created_count', models.PositiveIntegerField(default=0, verbose_name='Создано новых записей ГП')),
+                ('updated_links_count', models.PositiveIntegerField(default=0, verbose_name='Обновлено связей')),
+                ('error', models.TextField(blank=True, null=True, verbose_name='Ошибка')),
+                ('started_at', models.DateTimeField(auto_now_add=True, verbose_name='Начало')),
+                ('finished_at', models.DateTimeField(blank=True, null=True, verbose_name='Окончание')),
+                ('supplier', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='copy_to_main_runs', to='supplier_manager.supplier', verbose_name='Поставщик')),
+                ('user', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='copy_to_main_runs', to=settings.AUTH_USER_MODEL, verbose_name='Пользователь')),
+            ],
+            options={
+                'verbose_name': 'Копирование товаров поставщика в ГП',
+                'verbose_name_plural': 'Копирование товаров поставщика в ГП',
+                'ordering': ('-started_at',),
+            },
+        ),
+    ]

--- a/price_manager/supplier_product_manager/models.py
+++ b/price_manager/supplier_product_manager/models.py
@@ -1,5 +1,6 @@
 from django.db import models
 from django.core.validators import FileExtensionValidator
+from django.conf import settings
 
 
 from main_product_manager.models import MainProduct
@@ -187,3 +188,47 @@ class SupplierFile(models.Model):
                                default=STATUS_QUEUED,
                                blank=True)
   logs = models.CharField(verbose_name="Журнал загрузки", null=True, blank=True)
+
+
+class CopySupplierProductsToMainRun(models.Model):
+  STATUS_STARTED = "started"
+  STATUS_SUCCESS = "success"
+  STATUS_ERROR = "error"
+
+  STATUS_CHOICES = [
+    (STATUS_STARTED, "Выполняется"),
+    (STATUS_SUCCESS, "Успешно"),
+    (STATUS_ERROR, "Ошибка"),
+  ]
+
+  supplier = models.ForeignKey(
+    Supplier,
+    verbose_name="Поставщик",
+    related_name="copy_to_main_runs",
+    on_delete=models.CASCADE,
+  )
+  user = models.ForeignKey(
+    settings.AUTH_USER_MODEL,
+    verbose_name="Пользователь",
+    related_name="copy_to_main_runs",
+    on_delete=models.CASCADE,
+  )
+  status = models.CharField(
+    verbose_name="Статус",
+    max_length=16,
+    choices=STATUS_CHOICES,
+    default=STATUS_STARTED,
+    db_index=True,
+  )
+  filter_params = models.JSONField(verbose_name="Параметры фильтра", default=dict, blank=True)
+  processed_count = models.PositiveIntegerField(verbose_name="Обработано записей", default=0)
+  created_count = models.PositiveIntegerField(verbose_name="Создано новых записей ГП", default=0)
+  updated_links_count = models.PositiveIntegerField(verbose_name="Обновлено связей", default=0)
+  error = models.TextField(verbose_name="Ошибка", null=True, blank=True)
+  started_at = models.DateTimeField(verbose_name="Начало", auto_now_add=True)
+  finished_at = models.DateTimeField(verbose_name="Окончание", null=True, blank=True)
+
+  class Meta:
+    ordering = ("-started_at",)
+    verbose_name = "Копирование товаров поставщика в ГП"
+    verbose_name_plural = "Копирование товаров поставщика в ГП"

--- a/price_manager/supplier_product_manager/tasks.py
+++ b/price_manager/supplier_product_manager/tasks.py
@@ -1,10 +1,20 @@
 from celery import shared_task
+from django.db.models import Q
+from django.http import QueryDict
 from django.utils import timezone
 
 from core.models import PersistentNotification
+from main_product_manager.functions import recalculate_search_vectors
+from main_product_manager.models import MainProduct
 
 from .functions import load_setting
-from .models import Setting, SupplierFile
+from .filters import SupplierProductFilter
+from .models import (
+    CopySupplierProductsToMainRun,
+    Setting,
+    SupplierFile,
+    SupplierProduct,
+)
 
 
 def _append_supplier_file_log(supplier_file: SupplierFile | None, message: str) -> None:
@@ -103,3 +113,161 @@ def process_supplier_file_import(setting_id: int, user_id: int) -> dict:
 def process_setting_upload(setting_id: int, user_id: int) -> dict:
     """Совместимость со старым названием задачи."""
     return process_supplier_file_import(setting_id, user_id)
+
+
+def _restore_querydict(filter_params: dict | None) -> QueryDict:
+    query_dict = QueryDict("", mutable=True)
+    if not filter_params:
+        return query_dict
+    for key, value in filter_params.items():
+        if isinstance(value, list):
+            query_dict.setlist(key, [str(v) for v in value if v is not None])
+        elif value is not None:
+            query_dict[key] = str(value)
+    return query_dict
+
+
+def _chunked(iterable, chunk_size: int):
+    chunk = []
+    for item in iterable:
+        chunk.append(item)
+        if len(chunk) >= chunk_size:
+            yield chunk
+            chunk = []
+    if chunk:
+        yield chunk
+
+
+@shared_task
+def copy_supplier_products_to_main_task(
+    supplier_id: int,
+    filter_params: dict | None,
+    user_id: int,
+    run_id: int | None = None,
+    batch_size: int = 1000,
+) -> dict:
+    started_at = timezone.now()
+    run = None
+
+    if run_id:
+        run = CopySupplierProductsToMainRun.objects.filter(pk=run_id).first()
+        if run:
+            run.status = CopySupplierProductsToMainRun.STATUS_STARTED
+            run.error = None
+            run.save(update_fields=["status", "error"])
+
+    try:
+        query_data = _restore_querydict(filter_params)
+        products_qs = (
+            SupplierProductFilter(query_data, pk=supplier_id)
+            .qs.select_related("main_product", "supplier", "manufacturer", "category")
+            .filter(supplier_id=supplier_id)
+            .order_by("pk")
+        )
+
+        created_count = products_qs.filter(main_product__isnull=True).count()
+        processed_count = 0
+        updated_links_count = 0
+        touched_main_product_ids = set()
+
+        for batch in _chunked(products_qs.iterator(chunk_size=batch_size), batch_size):
+            processed_count += len(batch)
+            keys = {(sp.article, sp.name) for sp in batch}
+            if not keys:
+                continue
+
+            sp_by_key = {(sp.article, sp.name): sp for sp in batch}
+            mps_to_create = [
+                MainProduct(
+                    supplier_id=supplier_id,
+                    article=article,
+                    name=name,
+                    description=sp_by_key[(article, name)].description,
+                    manufacturer=sp_by_key[(article, name)].manufacturer,
+                    category=sp_by_key[(article, name)].category,
+                )
+                for article, name in keys
+            ]
+            MainProduct.objects.bulk_create(
+                mps_to_create,
+                update_conflicts=True,
+                unique_fields=["supplier", "article", "name"],
+                update_fields=["manufacturer", "category", "description"],
+                batch_size=batch_size,
+            )
+
+            key_filter = Q()
+            for article, name in keys:
+                key_filter |= Q(article=article, name=name)
+            mps = MainProduct.objects.filter(supplier_id=supplier_id).filter(key_filter)
+            mp_by_key = {(mp.article, mp.name): mp.id for mp in mps}
+
+            supplier_products_to_update = []
+            for sp in batch:
+                mp_id = mp_by_key.get((sp.article, sp.name))
+                if not mp_id:
+                    continue
+                touched_main_product_ids.add(mp_id)
+                if sp.main_product_id != mp_id:
+                    sp.main_product_id = mp_id
+                    supplier_products_to_update.append(sp)
+
+            if supplier_products_to_update:
+                SupplierProduct.objects.bulk_update(
+                    supplier_products_to_update,
+                    fields=["main_product"],
+                    batch_size=batch_size,
+                )
+                updated_links_count += len(supplier_products_to_update)
+
+        for ids_chunk in _chunked(list(touched_main_product_ids), batch_size):
+            recalculate_search_vectors(MainProduct.objects.filter(pk__in=ids_chunk))
+
+        duration_seconds = round((timezone.now() - started_at).total_seconds(), 2)
+        message = (
+            f"Копирование товаров поставщика завершено: обработано {processed_count}, "
+            f"создано новых {created_count}, обновлено связей {updated_links_count}, "
+            f"длительность {duration_seconds} сек."
+        )
+
+        if run:
+            run.status = CopySupplierProductsToMainRun.STATUS_SUCCESS
+            run.processed_count = processed_count
+            run.created_count = created_count
+            run.updated_links_count = updated_links_count
+            run.finished_at = timezone.now()
+            run.save(
+                update_fields=[
+                    "status",
+                    "processed_count",
+                    "created_count",
+                    "updated_links_count",
+                    "finished_at",
+                ]
+            )
+
+        PersistentNotification.objects.create(
+            user_id=user_id,
+            level="success",
+            message=message,
+        )
+        return {
+            "status": "ok",
+            "processed_count": processed_count,
+            "created_count": created_count,
+            "updated_links_count": updated_links_count,
+            "duration_seconds": duration_seconds,
+            "message": message,
+        }
+    except Exception as exc:
+        if run:
+            run.status = CopySupplierProductsToMainRun.STATUS_ERROR
+            run.error = str(exc)
+            run.finished_at = timezone.now()
+            run.save(update_fields=["status", "error", "finished_at"])
+        PersistentNotification.objects.create(
+            user_id=user_id,
+            level="danger",
+            message=f"Ошибка копирования товаров поставщика: {exc}",
+        )
+        raise

--- a/price_manager/supplier_product_manager/views.py
+++ b/price_manager/supplier_product_manager/views.py
@@ -27,7 +27,7 @@ from crispy_forms.utils import render_crispy_form
 from product_price_manager.models import PriceManager, PriceTag
 from core.functions import extract_initial_from_post
 from supplier_manager.forms import SupplierForm
-from .models import DictItem, SupplierFile
+from .models import CopySupplierProductsToMainRun, DictItem, SupplierFile
 from .forms import *
 from .tables import *
 from .filters import *
@@ -38,7 +38,7 @@ import pandas as pd
 import re
 
 from .functions import *
-from .tasks import process_supplier_file_import
+from .tasks import process_supplier_file_import, copy_supplier_products_to_main_task
 
 class SupplierDetail(SingleTableMixin, FilterView):
   '''
@@ -90,18 +90,20 @@ def copy_to_main(request, pk, state):
   if state == 0:
     url = reverse('supplier-copymain', kwargs={'pk':pk, 'state':1})
     return render(request, 'supplier_product/partials/load_partial.html', {'url':url})
-  products = SupplierProductFilter(request.GET,pk=pk).qs.select_related('main_product', 'supplier').filter(supplier=pk)
-  to_create = products.filter(main_product__isnull=True).count()
-  def get_mp(sp: SupplierProduct):
-    mp = MainProduct(supplier=sp.supplier, article=sp.article, name=sp.name, description=sp.description, manufacturer=sp.manufacturer, category=sp.category)
-    sp.main_product = mp
-    return mp
-  mp_map = map(get_mp, products)
-  mp_list = MainProduct.objects.bulk_create(mp_map, update_conflicts=True, unique_fields=['supplier', 'article', 'name'], update_fields=['manufacturer', 'category', 'description'])
-  mps = MainProduct.objects.filter(pk__in=[mp.pk for mp in mp_list])
-  products.bulk_update(products, fields=['main_product'])
-  recalculate_search_vectors(mps)
-  messages.info(request, f'Обработано товаров ГП {len(mps)}. Создано новых: {to_create}')
+  filter_params = dict(request.GET.lists())
+  copy_run = CopySupplierProductsToMainRun.objects.create(
+    supplier_id=pk,
+    user=request.user,
+    status=CopySupplierProductsToMainRun.STATUS_STARTED,
+    filter_params=filter_params,
+  )
+  copy_supplier_products_to_main_task.delay(
+    supplier_id=pk,
+    filter_params=filter_params,
+    user_id=request.user.pk,
+    run_id=copy_run.pk,
+  )
+  messages.info(request, 'Копирование товаров в ГП запущено в фоне. Уведомление придет после завершения.')
   return HttpResponseClientRedirect(reverse('supplier-detail', kwargs={'pk':pk}))
 
 # Обработка настройки


### PR DESCRIPTION
### Motivation
- Уменьшить время отклика и нагрузку при копировании товаров поставщика в ГП, чтобы операцию можно было выполнять в фоне и воспроизводить фильтр вне HTTP-запроса.
- Обеспечить устойчивую обработку больших наборов данных через чанки и отдельно пересчет векторов поиска.
- Добавить минимальный трекинг прогресса/статуса запуска и оповещение пользователя по завершении.

### Description
- Вынесена логика из `copy_to_main` в новую Celery-задачу `copy_supplier_products_to_main_task(...)`, а во view оставлен только шаг подтверждения и постановка задачи в очередь с сериализованными `filter_params` (`dict(request.GET.lists())`).
- Добавлена модель `CopySupplierProductsToMainRun` для трекинга запуска (поля: `status`, `filter_params`, счетчики, `started_at`, `finished_at`, `error`) и создана миграция `0006_copysupplierproductstomainrun.py`.
- Задача выполняет пакетную обработку: итерация по queryset через `iterator(chunk_size=...)`, `bulk_create(..., batch_size=...)` для `MainProduct`, `bulk_update(..., batch_size=...)` для `SupplierProduct`, и отдельный проход по чанкам для `recalculate_search_vectors`.
- По завершении (успех/ошибка) задача обновляет запись запуска и создает `PersistentNotification` для пользователя.

### Testing
- Выполнена проверочная компиляция Python-модулей с `python -m compileall price_manager/supplier_product_manager price_manager/main_product_manager` и ошибок синтаксиса не обнаружено (успех).
- Попытка `python manage.py makemigrations supplier_product_manager` не прошла в текущем окружении из-за отсутствия пакета `celery`, поэтому миграция для новой модели была подготовлена вручную (ограничение окружения).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfb4a95a10832d813ed89a717cb391)