### PR TITLE
Fix CSRF_TRUSTED_ORIGINS parsing from environment

### DIFF
--- a/price_manager/price_manager/settings.py
+++ b/price_manager/price_manager/settings.py
@@ -184,7 +184,14 @@ AUTH_PASSWORD_VALIDATORS = [
 
 if not DEBUG:
 
-    CSRF_TRUSTED_ORIGINS=[os.environ.get('CSRF_TRUSTED_ORIGINS', 'http://localhost:8000')]
+    CSRF_TRUSTED_ORIGINS = [
+        origin.strip()
+        for origin in os.environ.get(
+            "CSRF_TRUSTED_ORIGINS",
+            "https://localhost:8000,http://localhost:8000",
+        ).split(",")
+        if origin.strip()
+    ]
 
     SECURE_SSL_REDIRECT = True
     SECURE_HSTS_SECONDS = 31536000  # 1 year


### PR DESCRIPTION
### Motivation
- Django expects `CSRF_TRUSTED_ORIGINS` to be a list of full origins, and the previous code produced a single string value which prevented supplying multiple origins via environment variables and could trigger origin-check failures in production.

### Description
- Update `price_manager/price_manager/settings.py` to parse `CSRF_TRUSTED_ORIGINS` from the environment as a comma-separated list, trimming whitespace and ignoring empty entries, and provide a sensible default including `https://localhost:8000` and `http://localhost:8000` while leaving existing production security flags unchanged.

### Testing
- Ran `python -m py_compile price_manager/price_manager/settings.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfb767a10c832db83cbef0643c36b1)