### PR TITLE
Introduce cacheable canonical `get_sps` payload for supplier import

### DIFF
--- a/price_manager/supplier_product_manager/functions.py
+++ b/price_manager/supplier_product_manager/functions.py
@@ -17,6 +17,24 @@ import pandas as pd
 import numpy as np
 from decimal import Decimal
 import re
+import hashlib
+import json
+
+SPS_CACHE_TTL_SECONDS = 60 * 30
+SPS_JSON_SCHEMA_VERSION = "1.0"
+SPS_JSON_FIELDS = (
+    "article",
+    "name",
+    "description",
+    "category",
+    "manufacturer",
+    "discount",
+    "stock",
+    "supplier_price",
+    "rrp",
+    "discount_price",
+)
+SPS_JSON_REQUIRED_FIELDS = ("article", "name")
 
 def resolve_conflicts(qs):
   def resolve(item):
@@ -158,18 +176,79 @@ def get_indicts(post, pk):
   return indicts
 
 
-def load_setting(pk):
-    '''
-        Возвращает обработанные товары ПП\\
-        Если не найден файл возвращает None
-    '''
-    setting = Setting.objects.get(pk=pk)
+def _get_setting_signature(setting: Setting) -> str:
+    supplier_file = setting.supplierfiles.order_by("-pk").first()
+    links = (
+        setting.links.prefetch_related("dicts")
+        .all()
+        .order_by("key", "value", "initial", "pk")
+    )
+    payload = {
+        "setting": {
+            "id": setting.pk,
+            "sheet_name": setting.sheet_name,
+            "ignore_name": setting.ignore_name,
+            "create_new": setting.create_new,
+            "index_row": setting.index_row,
+        },
+        "supplier_file": {
+            "id": supplier_file.pk if supplier_file else None,
+            "name": supplier_file.file.name if supplier_file and supplier_file.file else None,
+            "size": supplier_file.file.size if supplier_file and supplier_file.file else None,
+        },
+        "links": [
+            {
+                "key": link.key,
+                "value": link.value,
+                "initial": link.initial,
+                "dicts": list(
+                    link.dicts.all().order_by("key", "value", "pk").values_list("key", "value")
+                ),
+            }
+            for link in links
+        ],
+    }
+    encoded = json.dumps(payload, sort_keys=True, ensure_ascii=False, separators=(",", ":"))
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _get_sps_cache_key(setting: Setting, signature: str) -> str:
+    return f"setting<{setting.pk}>::sps::v<{SPS_JSON_SCHEMA_VERSION}>::sig<{signature}>"
+
+
+def _to_canonical_sps(df: pd.DataFrame) -> list[dict]:
+    records: list[dict] = []
+    for row in df.to_dict(orient="records"):
+        item = {field: row.get(field) for field in SPS_JSON_FIELDS}
+        records.append(item)
+    return records
+
+
+def get_sps(setting_or_pk: Setting | int, recache: bool = False) -> list[dict] | None:
+    """
+    Возвращает каноничные товары поставщика в JSON-виде:
+    required: article(str), name(str)
+    optional: description(str|null), category(str|null), manufacturer(str|null), discount(str|null),
+              stock(int|null), supplier_price(str|null), rrp(str|null), discount_price(str|null)
+    """
+    setting = (
+        setting_or_pk
+        if isinstance(setting_or_pk, Setting)
+        else Setting.objects.get(pk=setting_or_pk)
+    )
+    signature = _get_setting_signature(setting)
+    cache_key = _get_sps_cache_key(setting, signature)
+    if not DEBUG and not recache:
+        cached_payload = cache.get(cache_key)
+        if cached_payload is not None:
+            return cached_payload
+
     links = Link.objects.filter(setting=setting)
-    df = get_df(pk)
+    df = get_df(setting.pk)
     sps = SupplierProduct.objects.filter(supplier=setting.supplier)
     s_values = map(tuple, sps.values_list('article', 'name'))
     resolve_conflicts(sps)
-    if not links.filter(Q(value__isnull=False)|Q(initial__isnull=False)).exists():
+    if df is None or not links.filter(Q(value__isnull=False) | Q(initial__isnull=False)).exists():
         return None
     for link in links:
         if link.value == '' or link.value is None:
@@ -177,24 +256,26 @@ def load_setting(pk):
                 continue
             df[link.key] = link.initial
         else:
-            df = df.rename(columns={link.value : link.key})
+            df = df.rename(columns={link.value: link.key})
             if not link.initial == '' and not link.initial is None:
                 df[link.key] = df[link.key].fillna(link.initial)
-    if not 'article' in df.columns: return None
+    if not 'article' in df.columns:
+        return None
     for link in links:
-        if not link.key in df.columns: continue
+        if not link.key in df.columns:
+            continue
         for dict in link.dicts.all():
-                df[link.key] = df[link.key].str.replace(dict.key, dict.value)
-                df = df.loc[:,[link.key for link in links if not link.key=='' and link.key in df.columns]]
+            df[link.key] = df[link.key].str.replace(dict.key, dict.value)
+            df = df.loc[:, [link.key for link in links if not link.key == '' and link.key in df.columns]]
         if link.key in df.columns and link.key in SP_NUMBERS:
-            print(df[link.key].head())
             df[link.key] = pd.to_numeric(df[link.key], errors='coerce')
-            print(df[link.key].head())
             df[link.key] = df[link.key].apply(lambda val: val if val >= 0 else None)
 
-    # to do: добавить проверку на наличие каких либо столбцов кроме артикула и названия если есть применять если нет то нет
     df = df.dropna(subset=['article'])
-    df = df.dropna(subset=[link.key for link in links if not link.key=='article' and not link.key =='name' and link.key in df.columns], how='all')
+    df = df.dropna(
+        subset=[link.key for link in links if not link.key == 'article' and not link.key == 'name' and link.key in df.columns],
+        how='all'
+    )
 
     if not 'name' in df.columns:
         if setting.create_new:
@@ -216,22 +297,42 @@ def load_setting(pk):
         df = _df
 
     df = df.dropna(subset=['name'])
+    df = df.replace({pd.NA: None, float('nan'): None, '': None, 'NaN': None})
 
-    df = df.replace({pd.NA: None, float('nan'): None, '': None, 'NaN':None})
-  
     if not setting.create_new:
         mask = df[['article', 'name']].apply(tuple, axis=1).isin(s_values)
         df = df[mask]
-    
-
-
 
     df = df.drop_duplicates(subset=['article', 'name'], keep='first')
+    for required_field in SPS_JSON_REQUIRED_FIELDS:
+        if required_field not in df.columns:
+            return None
+    payload = _to_canonical_sps(df)
+    if not DEBUG:
+        cache.set(cache_key, payload, timeout=SPS_CACHE_TTL_SECONDS)
+    return payload
+
+
+def load_setting(pk):
+    '''
+        Возвращает обработанные товары ПП\\
+        Если не найден файл возвращает None
+    '''
+    setting = Setting.objects.get(pk=pk)
+    links = Link.objects.filter(setting=setting)
+    sps_payload = get_sps(setting)
+    if sps_payload is None:
+        return None
+    df = pd.DataFrame(sps_payload)
 
     if 'manufacturer' in df.columns:
-        df['manufacturer'] = df['manufacturer'].apply(lambda s: Manufacturer.objects.get_or_create(name=s)[0] if s else None)
+        df['manufacturer'] = df['manufacturer'].apply(
+            lambda s: Manufacturer.objects.get_or_create(name=s)[0] if s else None
+        )
     if 'discount' in df.columns:
-        df['discount'] = df['discount'].apply(lambda s: Discount.objects.get_or_create(supplier=setting.supplier, name=s)[0] if s else None)
+        df['discount'] = df['discount'].apply(
+            lambda s: Discount.objects.get_or_create(supplier=setting.supplier, name=s)[0] if s else None
+        )
     if 'category' in df.columns:
         def _get_category(value):
             if not value:
@@ -283,5 +384,3 @@ def load_setting(pk):
               missing_sps.update(**{column:None})
     setting.supplier.save()
     return sps
-
-

--- a/price_manager/supplier_product_manager/templates/supplier_product/setting_update.html
+++ b/price_manager/supplier_product_manager/templates/supplier_product/setting_update.html
@@ -1,4 +1,5 @@
 <div class="container p-5">
+  {{ sps_json_schema|json_script:"sps-json-schema" }}
   <form 
     method="POST"
     hx-post="{% url "setting-update" pk=setting.pk %}"

--- a/price_manager/supplier_product_manager/tests.py
+++ b/price_manager/supplier_product_manager/tests.py
@@ -2,11 +2,12 @@ from io import BytesIO
 from decimal import Decimal
 
 import pandas as pd
+from django.core.cache import cache
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from supplier_manager.models import Currency, Supplier, Manufacturer
-from supplier_product_manager.functions import load_setting
+from supplier_product_manager.functions import get_sps, load_setting
 from supplier_product_manager.models import Link, Setting, SupplierFile, SupplierProduct
 
 
@@ -431,3 +432,43 @@ class BasicLoadTests(TestCase):
         self.supplier.refresh_from_db()
         self.assertIsNotNone(self.supplier.stock_updated_at)
         self.assertIsNotNone(self.supplier.price_updated_at)
+
+
+@override_settings(DEBUG=False)
+class GetSpsCacheTests(BasicLoadTests):
+    def setUp(self):
+        super().setUp()
+        cache.clear()
+
+    def test_get_sps_uses_cache_and_invalidates_on_setting_change(self):
+        setting = Setting.objects.create(
+            name="Кэширование sps",
+            supplier=self.supplier,
+            sheet_name="Sheet1",
+            create_new=True,
+        )
+        Link.objects.create(setting=setting, key="article", value="Артикул")
+        Link.objects.create(setting=setting, key="name", value="Название")
+        Link.objects.create(setting=setting, key="supplier_price", value="Цена")
+
+        self._create_supplier_file(
+            setting,
+            pd.DataFrame([{"Артикул": "А-1", "Название": "Товар 1", "Цена": "10"}]),
+        )
+
+        first_payload = get_sps(setting.pk)
+        self.assertEqual(first_payload[0]["supplier_price"], 10.0)
+
+        self._create_supplier_file(
+            setting,
+            pd.DataFrame([{"Артикул": "А-1", "Название": "Товар 1", "Цена": "50"}]),
+        )
+        cached_payload = get_sps(setting.pk)
+        self.assertEqual(cached_payload[0]["supplier_price"], 10.0)
+
+        price_link = Link.objects.get(setting=setting, key="supplier_price")
+        price_link.value = None
+        price_link.initial = "7"
+        price_link.save()
+        recached_payload = get_sps(setting.pk)
+        self.assertEqual(recached_payload[0]["supplier_price"], 7.0)

--- a/price_manager/supplier_product_manager/views.py
+++ b/price_manager/supplier_product_manager/views.py
@@ -292,6 +292,12 @@ class SettingUpdate(UpdateView):
     post = self.request.POST
     context['links'] = get_indicts(post, pk)
     context["link_formset"] = get_linkformset(post, pk)
+    context["sps_json_schema"] = {
+      "version": SPS_JSON_SCHEMA_VERSION,
+      "fields": list(SPS_JSON_FIELDS),
+      "required": list(SPS_JSON_REQUIRED_FIELDS),
+      "optional": [field for field in SPS_JSON_FIELDS if field not in SPS_JSON_REQUIRED_FIELDS],
+    }
     return context
 
 class SettingList(SingleTableView):


### PR DESCRIPTION
### Motivation
- Separate and standardize supplier-product payload generation so UI and backend share a single canonical JSON format and caching can be applied. 
- Improve performance by caching the canonical SPS payload and provide deterministic invalidation when setting/file/link/dicts change.

### Description
- Added `get_sps(...)` in `supplier_product_manager.functions` that accepts a `Setting|pk`, produces a canonical JSON-ready list of supplier product dicts (fields fixed by `SPS_JSON_FIELDS`) and reads/writes cache using a key that embeds a configuration signature and schema version. 
- Implemented signature-based cache invalidation: `_get_setting_signature(...)` hashes `Setting` attributes + active `SupplierFile` metadata + `Link`/`DictItem` data so any change rotates the cache key; TTL is controlled by `SPS_CACHE_TTL_SECONDS`. 
- Replaced the inline product-generation part of `load_setting` with a call to `get_sps(...)` while preserving `load_setting`'s external behaviour and downstream processing (DB `bulk_create`, stock/price timestamps). 
- Exposed the canonical schema constants (`SPS_JSON_SCHEMA_VERSION`, `SPS_JSON_FIELDS`, `SPS_JSON_REQUIRED_FIELDS`) to the `SettingUpdate` view context and rendered them into the template via `json_script` so the UI can consume the same schema.
- Added tests exercising `get_sps` caching behaviour (cache hit + invalidation on setting/link changes) in `supplier_product_manager/tests.py`.

### Testing
- Ran syntax/compile check with `python -m py_compile price_manager/supplier_product_manager/functions.py price_manager/supplier_product_manager/views.py price_manager/supplier_product_manager/tests.py` which succeeded. 
- Attempted Django test execution (`python -m pytest ...` and `python manage.py test ...`) but the full test run could not be started in this environment due to missing runtime configuration/dependencies (`DJANGO_SETTINGS_MODULE` / `celery`), so the new test could not be executed end-to-end here.
- Added unit test coverage for `get_sps` cache behaviour in `supplier_product_manager/tests.py` (intended to run under a configured Django test environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e097e0f274832dbfecafa9716bf41b)