### PR TITLE
Handle missing supplier files in storage during import

### DIFF
--- a/price_manager/supplier_product_manager/functions.py
+++ b/price_manager/supplier_product_manager/functions.py
@@ -17,6 +17,13 @@ import pandas as pd
 import numpy as np
 from decimal import Decimal
 import re
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class SupplierFileStorageMissingError(FileNotFoundError):
+  """Файл настройки отсутствует в storage backend."""
 
 def resolve_conflicts(qs):
   def resolve(item):
@@ -57,14 +64,27 @@ def get_df(pk, recache=False)->pd.DataFrame|None:
     return None
   sf = SupplierFile.objects.filter(setting=pk).first()
   if not sf: return None
-  file = sf.file
-  if not file: return None
+  validated_file = sf.file
+  if not validated_file or not validated_file.name:
+    return None
+  if not validated_file.storage.exists(validated_file.name):
+    logger.error(
+      "Supplier file is missing in storage (setting_id=%s, file_name=%s)",
+      pk,
+      validated_file.name,
+    )
+    raise SupplierFileStorageMissingError(
+      f"Файл настройки отсутствует в media-хранилище: setting_id={pk}, file={validated_file.name}"
+    )
   if not DEBUG:
     cached_df=cache.get(f'setting<{pk}>::dataframe<{sf.pk}>::<{Setting.sheet_name}>')
     if not recache and not cached_df is None:
         return cached_df
-  df = pd.read_excel(file, engine='calamine', dtype=str, skiprows=setting.index_row, sheet_name=setting.sheet_name, index_col=None, na_values=['']).dropna(axis=0, how='all').dropna(axis=1, how='all')
-  file.close()
+  validated_file.open('rb')
+  try:
+    df = pd.read_excel(validated_file, engine='calamine', dtype=str, skiprows=setting.index_row, sheet_name=setting.sheet_name, index_col=None, na_values=['']).dropna(axis=0, how='all').dropna(axis=1, how='all')
+  finally:
+    validated_file.close()
   for column in df.columns:
     df[column] = df[column].str.replace(r'\s+', ' ', regex=True)
   if df.shape[0] == 0:
@@ -283,5 +303,3 @@ def load_setting(pk):
               missing_sps.update(**{column:None})
     setting.supplier.save()
     return sps
-
-

--- a/price_manager/supplier_product_manager/tasks.py
+++ b/price_manager/supplier_product_manager/tasks.py
@@ -7,7 +7,7 @@ from core.models import PersistentNotification
 from main_product_manager.functions import recalculate_search_vectors
 from main_product_manager.models import MainProduct
 
-from .functions import load_setting
+from .functions import load_setting, SupplierFileStorageMissingError
 from .filters import SupplierProductFilter
 from .models import (
     CopySupplierProductsToMainRun,
@@ -90,6 +90,28 @@ def process_supplier_file_import(setting_id: int, user_id: int) -> dict:
             "errors": errors_count,
             "duration_seconds": duration_seconds,
             "message": message,
+        }
+    except SupplierFileStorageMissingError as exc:
+        duration_seconds = round((timezone.now() - started_at).total_seconds(), 2)
+        error_message = (
+            f"Импорт «{setting.name}» завершен с ошибкой: обработано строк 0, ошибок 1, "
+            f"длительность {duration_seconds} сек. Причина: Файл настройки отсутствует в media-хранилище."
+        )
+        _append_supplier_file_log(supplier_file, f"{error_message} ({exc})")
+        if supplier_file:
+            supplier_file.status = SupplierFile.STATUS_ERROR
+            supplier_file.save(update_fields=["status"])
+        PersistentNotification.objects.create(
+            user_id=user_id,
+            level="danger",
+            message=error_message,
+        )
+        return {
+            "status": "error",
+            "processed_rows": 0,
+            "errors": 1,
+            "duration_seconds": duration_seconds,
+            "message": error_message,
         }
     except Exception as exc:
         duration_seconds = round((timezone.now() - started_at).total_seconds(), 2)


### PR DESCRIPTION
### Motivation
- Prevent unhandled errors when a configured supplier file record exists in the DB but the underlying file is missing from the media/storage backend and provide a clear diagnostic and user-facing message.

### Description
- Introduced `SupplierFileStorageMissingError` and a `logger` in `price_manager/supplier_product_manager/functions.py` to represent and log missing storage files.
- In `get_df` added validation of `sf.file` and `sf.file.name`, checked `validated_file.storage.exists(validated_file.name)`, logged the diagnostic (setting id and file name) and raised `SupplierFileStorageMissingError` when absent, and switched to opening the validated file with `validated_file.open('rb')` and a `try/finally`-ensured `close()` before calling `pd.read_excel`.
- Updated `price_manager/supplier_product_manager/tasks.py` to import `SupplierFileStorageMissingError` and to handle it separately in `process_supplier_file_import`, writing a precise log entry, marking the `SupplierFile` as error, and creating a `PersistentNotification` with a clear message like "Файл настройки отсутствует в media-хранилище.".

### Testing
- Ran `python -m compileall price_manager/supplier_product_manager/functions.py price_manager/supplier_product_manager/tasks.py` and compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e09c691830832db6a7f94a2c272493)