### PR TITLE
Use latest SupplierFile by pk in dataframe helpers and add regression test

### DIFF
--- a/price_manager/supplier_product_manager/functions.py
+++ b/price_manager/supplier_product_manager/functions.py
@@ -45,8 +45,9 @@ def get_df_sheet_names(pk):
     В противном случае None
   '''
   file = None
-  if not SupplierFile.objects.filter(setting=pk).first(): return None
-  file = SupplierFile.objects.filter(setting=pk).first().file
+  sf = SupplierFile.objects.filter(setting=pk).order_by('-pk').first()
+  if not sf: return None
+  file = sf.file
   if not file: return None
   columns = pd.ExcelFile(file, engine='calamine').sheet_names
   file.close()
@@ -62,7 +63,7 @@ def get_df(pk, recache=False)->pd.DataFrame|None:
     setting = Setting.objects.get(pk=pk)
   except:
     return None
-  sf = SupplierFile.objects.filter(setting=pk).first()
+  sf = SupplierFile.objects.filter(setting=pk).order_by('-pk').first()
   if not sf: return None
   validated_file = sf.file
   if not validated_file or not validated_file.name:

--- a/price_manager/supplier_product_manager/tests.py
+++ b/price_manager/supplier_product_manager/tests.py
@@ -6,7 +6,7 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
 
 from supplier_manager.models import Currency, Supplier, Manufacturer
-from supplier_product_manager.functions import load_setting
+from supplier_product_manager.functions import get_df, get_df_sheet_names, load_setting
 from supplier_product_manager.models import Link, Setting, SupplierFile, SupplierProduct
 
 
@@ -95,6 +95,7 @@ class BasicLoadTests(TestCase):
         self.supplier.refresh_from_db()
         self.assertIsNotNone(self.supplier.stock_updated_at)
         self.assertIsNotNone(self.supplier.price_updated_at)
+
 
     def test_basicupload_article(self):
         setting = Setting.objects.create(
@@ -431,3 +432,66 @@ class BasicLoadTests(TestCase):
         self.supplier.refresh_from_db()
         self.assertIsNotNone(self.supplier.stock_updated_at)
         self.assertIsNotNone(self.supplier.price_updated_at)
+
+class SupplierFileSelectionTests(TestCase):
+    def setUp(self):
+        self.currency = Currency.objects.get(name="KZT")
+        self.supplier = Supplier.objects.create(
+            name="Test supplier for latest file",
+            currency=self.currency,
+            price_update_rate="Каждый день",
+            stock_update_rate="Каждый день",
+            delivery_days_available=1,
+            delivery_days_navailable=3,
+        )
+
+    def _create_supplier_file(
+        self,
+        setting: Setting,
+        dataframe: pd.DataFrame,
+        filename: str = "supplier.xlsx",
+        sheet_name: str = "Sheet1",
+        delete_existing: bool = True,
+    ):
+        if delete_existing:
+            setting.supplierfiles.all().delete()
+        excel_buffer = BytesIO()
+        with pd.ExcelWriter(excel_buffer, engine="openpyxl") as writer:
+            dataframe.to_excel(writer, index=False, sheet_name=sheet_name)
+        excel_buffer.seek(0)
+        uploaded_file = SimpleUploadedFile(
+            filename,
+            excel_buffer.read(),
+            content_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        )
+        return SupplierFile.objects.create(setting=setting, file=uploaded_file)
+
+    def test_get_df_and_sheet_names_use_latest_supplier_file(self):
+        setting = Setting.objects.create(
+            name="Latest file selection",
+            supplier=self.supplier,
+            sheet_name="LatestSheet",
+            create_new=True,
+        )
+
+        self._create_supplier_file(
+            setting=setting,
+            dataframe=pd.DataFrame([{"marker": "old"}]),
+            filename="old_file.xlsx",
+            sheet_name="OldSheet",
+            delete_existing=False,
+        )
+        self._create_supplier_file(
+            setting=setting,
+            dataframe=pd.DataFrame([{"marker": "new"}]),
+            filename="new_file.xlsx",
+            sheet_name="LatestSheet",
+            delete_existing=False,
+        )
+
+        df = get_df(setting.pk, recache=True)
+        self.assertIsNotNone(df)
+        self.assertEqual(df.iloc[0]["marker"], "new")
+
+        sheet_names = get_df_sheet_names(setting.pk)
+        self.assertEqual(sheet_names, ["LatestSheet"])


### PR DESCRIPTION
### Motivation
- Ensure dataframe helpers always use the most recent uploaded supplier file for a setting by selecting the SupplierFile with the highest `pk`.
- Normalize file-selection logic across the module so all helpers pick the same “actual” file when multiple files exist for one setting.

### Description
- Replaced occurrences of `SupplierFile.objects.filter(setting=pk).first()` with `SupplierFile.objects.filter(setting=pk).order_by('-pk').first()` in `get_df_sheet_names(pk)` and `get_df(pk, recache=False)` to pick the latest file by `pk` (file: `price_manager/supplier_product_manager/functions.py`).
- Ensured analogous lookups in the same module follow the same latest-by-`pk` logic where applicable.
- Added a regression unit test `SupplierFileSelectionTests.test_get_df_and_sheet_names_use_latest_supplier_file` that creates two `SupplierFile` records for a single `Setting` and verifies that `get_df()` and `get_df_sheet_names()` read from the newest file (file: `price_manager/supplier_product_manager/tests.py`).
- Updated test imports to include `get_df` and `get_df_sheet_names` and adjusted the test helper to allow creating multiple files for the same setting without removing previous ones.

### Testing
- Compiled the modified modules with `python -m compileall price_manager/supplier_product_manager/functions.py price_manager/supplier_product_manager/tests.py`, which succeeded.
- Attempted to run `python manage.py test supplier_product_manager.tests.SupplierFileSelectionTests -v 2`, but the test run failed in this environment due to a missing dependency (`ModuleNotFoundError: No module named 'celery'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0a06ea138832d94fd46ceba8b9c74)