### PR TITLE
Handle NULL/0 propagation in PP→GP sync for prices and stock

### DIFF
--- a/price_manager/main_product_manager/functions.py
+++ b/price_manager/main_product_manager/functions.py
@@ -1,9 +1,10 @@
 from django.db import transaction
 from django.db.models import Min, Max, F
 from django.core.cache import cache
-from django.db.models import Value, OuterRef, Subquery, Q, F, Sum
+from django.db.models import Value, OuterRef, Subquery, Q, F, Sum, IntegerField
 from django.utils import timezone
 from django.contrib.postgres.search import SearchVectorField, SearchVector 
+from django.db.models.functions import Coalesce
 
 from .models import MainProduct, MainProductLog, MP_PRICES
 from .tables import AVAILABLE_COLUMN_MAP, DEFAULT_VISIBLE_COLUMNS
@@ -110,10 +111,14 @@ def update_stocks():
   query = MainProduct.objects.filter(
     pk=OuterRef('pk')
     ).prefetch_related('supplierproducts').annotate(
-      new_stock=Sum(F('supplierproducts__stock'))).values('new_stock')
-  mps = MainProduct.objects.prefetch_related('supplierproducts').annotate(new_stock=Subquery(query))
-  mps = mps.filter(Q(stock__isnull=False)|Q(new_stock__isnull=False))
-  mps = mps.filter(~Q(stock=F('new_stock')))
+      new_stock=Coalesce(Sum(F('supplierproducts__stock')), Value(0), output_field=IntegerField())
+    ).values('new_stock')
+  mps = MainProduct.objects.prefetch_related('supplierproducts').annotate(
+    new_stock=Subquery(query, output_field=IntegerField())
+  )
+  mps = mps.annotate(
+    current_stock_safe=Coalesce('stock', Value(0), output_field=IntegerField())
+  ).filter(~Q(current_stock_safe=F('new_stock')))
   mps.bulk_update(mps, fields=['stock_updated_at'])
   print(mps.values_list('stock', 'new_stock'))
   mpls = map(lambda mp: MainProductLog(main_product=mp, stock=mp.new_stock),  mps)

--- a/price_manager/main_product_manager/tests.py
+++ b/price_manager/main_product_manager/tests.py
@@ -48,7 +48,7 @@ from django.utils import timezone
 from supplier_manager.models import Currency, Supplier
 from supplier_product_manager.models import SupplierProduct
 from .models import MainProduct, MainProductLog
-from .functions import merge_selected_main_products
+from .functions import merge_selected_main_products, update_stocks
 
 
 class MergeSelectedMainProductsTests(TestCase):
@@ -159,3 +159,60 @@ class DuplicateSelectionFlowTests(TestCase):
         self.assertEqual(moved_supplier_products, 0)
         self.assertEqual(moved_logs, 1)
         self.assertFalse(MainProduct.objects.filter(id=self.product_1.id).exists())
+
+
+class UpdateStocksNullSafeTests(TestCase):
+    def setUp(self):
+        self.currency = Currency.objects.get_or_create(name='KZT', value=1)[0]
+        self.supplier = Supplier.objects.create(
+            name='Stock supplier',
+            currency=self.currency,
+            price_update_rate='',
+            stock_update_rate='',
+            delivery_days_available=1,
+            delivery_days_navailable=2,
+        )
+
+    def test_updates_from_null_to_zero(self):
+        mp = MainProduct.objects.create(
+            supplier=self.supplier,
+            article='ST-1',
+            name='Null to zero',
+            stock=None,
+        )
+        SupplierProduct.objects.create(
+            main_product=mp,
+            supplier=self.supplier,
+            article='SP-ST-1',
+            name='Stock row',
+            stock=None,
+        )
+
+        updated_count = update_stocks()
+
+        mp.refresh_from_db()
+        self.assertEqual(updated_count, 1)
+        self.assertEqual(mp.stock, 0)
+        self.assertTrue(MainProductLog.objects.filter(main_product=mp, stock=0).exists())
+
+    def test_updates_from_positive_to_zero(self):
+        mp = MainProduct.objects.create(
+            supplier=self.supplier,
+            article='ST-2',
+            name='Positive to zero',
+            stock=7,
+        )
+        SupplierProduct.objects.create(
+            main_product=mp,
+            supplier=self.supplier,
+            article='SP-ST-2',
+            name='Stock row',
+            stock=None,
+        )
+
+        updated_count = update_stocks()
+
+        mp.refresh_from_db()
+        self.assertEqual(updated_count, 1)
+        self.assertEqual(mp.stock, 0)
+        self.assertTrue(MainProductLog.objects.filter(main_product=mp, stock=0).exists())

--- a/price_manager/product_price_manager/models.py
+++ b/price_manager/product_price_manager/models.py
@@ -9,7 +9,7 @@ from django.db.models import (F, ExpressionWrapper,
                               Q, DecimalField,
                               OuterRef, Subquery, Prefetch,
                               Case, When)
-from django.db.models.functions import Ceil
+from django.db.models.functions import Ceil, Coalesce
 from django.utils import timezone
 
 # Импорты сторонних библиотек
@@ -187,7 +187,7 @@ class PriceManager(models.Model):
       filtered_source_price = (
         products.filter(main_product=OuterRef('pk'))
         .values('main_product')
-        .annotate(source_price=Min(price_manager.source))
+        .annotate(source_price=Max(Coalesce(price_manager.source, Value(0))))
         .values('source_price')[:1]
       )
       mps = mps.annotate(source_price=Subquery(filtered_source_price, output_field=DecimalField()))
@@ -403,13 +403,11 @@ class PriceTag(models.Model):
     if self.source == 'fixed_price':
       return self.fixed_price
     if self.source in SP_PRICES:
-      prices = self.mp.supplierproducts.filter(
-        **{f'{self.source}__isnull':False}
-      ).values_list(self.source, flat=True)
-      prices = list(prices)
+      prices = list(self.mp.supplierproducts.values_list(self.source, flat=True))
       if not prices:
         return None
-      return self.get_aggfunc()(prices) * self.mp.supplier.currency.value
+      normalized_prices = [price if price is not None else Decimal('0') for price in prices]
+      return self.get_aggfunc()(normalized_prices) * self.mp.supplier.currency.value
     if self.source in MP_PRICES:
       return getattr(self.mp, self.source)
     return None

--- a/price_manager/product_price_manager/models.py
+++ b/price_manager/product_price_manager/models.py
@@ -187,7 +187,7 @@ class PriceManager(models.Model):
       filtered_source_price = (
         products.filter(main_product=OuterRef('pk'))
         .values('main_product')
-        .annotate(source_price=Max(Coalesce(price_manager.source, Value(0))))
+        .annotate(source_price=Max(Coalesce(F(price_manager.source), Value(Decimal('0')), output_field=DecimalField())))
         .values('source_price')[:1]
       )
       mps = mps.annotate(source_price=Subquery(filtered_source_price, output_field=DecimalField()))

--- a/price_manager/product_price_manager/tests.py
+++ b/price_manager/product_price_manager/tests.py
@@ -267,6 +267,78 @@ class PriceTagAndPriceManagerRuntimeTests(TestCase):
         self.assertIsNotNone(mp.price_updated_at)
         self.assertEqual(mp.basic_price, Decimal('200'))
 
+
+    def test_pricetag_sp_source_treats_null_as_zero(self):
+        mp = self.create_mp('M-NULL', 'NULL source')
+        SupplierProduct.objects.create(
+            main_product=mp,
+            supplier=self.supplier,
+            article='S-NULL-1',
+            name='SP null',
+            supplier_price=None,
+        )
+        pt = PriceTag.objects.create(
+            mp=mp,
+            source='supplier_price',
+            dest='basic_price',
+            markup=Decimal('0'),
+            increase=Decimal('0'),
+        )
+
+        self.assertEqual(pt.get_sprice(), Decimal('0'))
+        self.assertEqual(pt.get_dprice(), Decimal('0'))
+
+    def test_pricemanager_apply_sets_zero_when_only_null_source_prices(self):
+        mp = self.create_mp('M-ZERO', 'Zero price apply', basic_price=Decimal('999'))
+        SupplierProduct.objects.create(
+            main_product=mp,
+            supplier=self.supplier,
+            article='S-ZERO-1',
+            name='SP null',
+            supplier_price=None,
+        )
+        manager = PriceManager.objects.create(
+            name='PM-ZERO-FROM-NULL',
+            supplier=self.supplier,
+            source='supplier_price',
+            dest='basic_price',
+            markup=Decimal('0'),
+            increase=Decimal('0'),
+        )
+
+        manager.apply()
+        mp.refresh_from_db()
+        self.assertEqual(mp.basic_price, Decimal('0'))
+
+    def test_pricemanager_with_duplicate_supplier_products_prefers_positive_value(self):
+        mp = self.create_mp('M-DUP', 'Duplicate rows', basic_price=Decimal('777'))
+        SupplierProduct.objects.create(
+            main_product=mp,
+            supplier=self.supplier,
+            article='S-DUP-1',
+            name='SP zero',
+            supplier_price=Decimal('0'),
+        )
+        SupplierProduct.objects.create(
+            main_product=mp,
+            supplier=self.supplier,
+            article='S-DUP-2',
+            name='SP positive',
+            supplier_price=Decimal('12'),
+        )
+        manager = PriceManager.objects.create(
+            name='PM-DUP-POSITIVE',
+            supplier=self.supplier,
+            source='supplier_price',
+            dest='basic_price',
+            markup=Decimal('0'),
+            increase=Decimal('0'),
+        )
+
+        manager.apply()
+        mp.refresh_from_db()
+        self.assertEqual(mp.basic_price, Decimal('24'))
+
     def test_no_crash_when_source_price_missing(self):
         mp = self.create_mp('M-5', 'Missing source')
         SupplierProduct.objects.create(
@@ -284,9 +356,12 @@ class PriceTagAndPriceManagerRuntimeTests(TestCase):
             increase=Decimal('5'),
         )
 
-        self.assertIsNone(pt.get_sprice())
-        self.assertIsNone(pt.get_dprice())
-        self.assertIsNone(pt.get_mp())
+        self.assertEqual(pt.get_sprice(), Decimal('0'))
+        self.assertEqual(pt.get_dprice(), Decimal('5'))
+
+        changed_mp = pt.get_mp()
+        self.assertIsNotNone(changed_mp)
+        self.assertEqual(changed_mp.basic_price, Decimal('5'))
 
 
 class PriceManagerNameGenerationTests(TestCase):

--- a/price_manager/supplier_product_manager/functions.py
+++ b/price_manager/supplier_product_manager/functions.py
@@ -272,12 +272,12 @@ def load_setting(pk):
 
     if 'stock' in df.columns:
         setting.supplier.stock_updated_at = timezone.now()
-        missing_sps.update(stock=None)
+        missing_sps.update(stock=0)
     if not set(SP_PRICES).intersection(set(df.columns)) == set():
         setting.supplier.price_updated_at = timezone.now()
         for column in df.columns:
            if column in SP_PRICES:
-              missing_sps.update(**{column:None})
+              missing_sps.update(**{column:0})
     setting.supplier.save()
     return sps
 


### PR DESCRIPTION
### Motivation
- Ensure PP→GP synchronization treats `NULL` and `0` consistently so that supplier `NULL`/empty prices and stocks are interpreted as `0` and always propagate to MainProduct instead of leaving `NULL` or retaining old values. 
- Prevent regressive behavior when multiple SupplierProduct duplicates exist for one MainProduct by defining a clear aggregation rule for duplicates (prefer positive values, otherwise 0). 

### Description
- Make supplier-price aggregation NULL-safe in `PriceManager` by using `MAX(COALESCE(..., Value(0)))` when computing `source_price` so `NULL` is treated as `0` and positive values win across duplicates (`price_manager/product_price_manager/models.py`).
- Normalize supplier price lists in `PriceTag.get_sprice()` to replace `None` with `Decimal('0')` before aggregation so an existing but NULL row yields zero rather than `None` (`price_manager/product_price_manager/models.py`).
- Make stock synchronization NULL-safe in `update_stocks()` by computing `new_stock = COALESCE(SUM(...), 0)` and comparing with `COALESCE(stock, 0)` so `NULL→0` and `N→0` transitions always update and produce `MainProductLog` entries (`price_manager/main_product_manager/functions.py`).
- During supplier file load, set missing numeric fields on missing SupplierProduct rows to `0` (for `stock` and SP price columns) instead of `None` to keep DB values consistent with the new NULL-as-zero semantics (`price_manager/supplier_product_manager/functions.py`).
- Add/adjust tests covering NULL/0 scenarios and duplicate handling: new tests in `product_price_manager/tests.py` for `PriceTag`/`PriceManager` NULL→0 and duplicate preference rules, and tests in `main_product_manager/tests.py` (`UpdateStocksNullSafeTests`) for `NULL→0` and `N→0` stock updates.

### Testing
- Ran Python syntax/bytecode checks with `python -m compileall` for all modified files which completed successfully. 
- Attempted to run pytest for the new test classes with `python -m pytest price_manager/product_price_manager/tests.py::PriceTagAndPriceManagerRuntimeTests price_manager/main_product_manager/tests.py::UpdateStocksNullSafeTests`, but pytest collected no items due to Django settings not being initialized in this environment. 
- Attempted to run Django tests with `python manage.py test ...`, but test execution failed because the environment is missing runtime dependency `celery`, so full Django test execution could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0c4109d90832d8c3329cfa4226736)