### PR TITLE
Автоподбор связок столбцов при смене index_row и при отсутствии ручных связок

### DIFF
--- a/price_manager/supplier_product_manager/functions.py
+++ b/price_manager/supplier_product_manager/functions.py
@@ -39,9 +39,74 @@ SPS_JSON_REQUIRED_FIELDS = ("article", "name")
 
 logger = logging.getLogger(__name__)
 
+AUTO_LINK_ALIASES = {
+    "article": ("article", "артикул", "код", "sku", "vendorcode"),
+    "name": ("name", "название", "наименование", "товар"),
+    "description": ("description", "описание"),
+    "category": ("category", "категория", "группа", "раздел"),
+    "manufacturer": ("manufacturer", "brand", "бренд", "производитель"),
+    "discount": ("discount", "скидка", "группа скидок"),
+    "stock": ("stock", "остаток", "количество", "наличие", "qty"),
+    "supplier_price": ("supplierprice", "supplier_price", "цена поставщика", "закупочная цена", "price"),
+    "rrp": ("rrp", "ррц", "розничная цена"),
+    "discount_price": ("discountprice", "discount_price", "цена со скидкой", "скидочная цена"),
+}
+
 
 class SupplierFileStorageMissingError(FileNotFoundError):
   """Файл настройки отсутствует в storage backend."""
+
+
+def _normalize_column_name(value: str | None) -> str:
+  if value is None:
+    return ""
+  normalized = re.sub(r"[\W_]+", "", str(value).strip().lower())
+  return normalized
+
+
+def auto_detect_link_keys(columns) -> list[str | None]:
+  """
+  Возвращает список ключей LINK для списка столбцов.
+  Один ключ назначается не более одного раза.
+  """
+  normalized_columns = [_normalize_column_name(column) for column in columns]
+  detected_keys: list[str | None] = [None] * len(normalized_columns)
+  used_keys: set[str] = set()
+
+  alias_map = {
+    key: {_normalize_column_name(alias) for alias in aliases if alias}
+    for key, aliases in AUTO_LINK_ALIASES.items()
+  }
+
+  for key, verbose_name in LINKS.items():
+    if key == "":
+      continue
+    alias_map.setdefault(key, set()).add(_normalize_column_name(verbose_name))
+    alias_map[key].add(_normalize_column_name(key))
+
+  for idx, column_name in enumerate(normalized_columns):
+    if not column_name:
+      continue
+    for key, aliases in alias_map.items():
+      if key in used_keys:
+        continue
+      if column_name in aliases:
+        detected_keys[idx] = key
+        used_keys.add(key)
+        break
+
+  for idx, column_name in enumerate(normalized_columns):
+    if detected_keys[idx] is not None or not column_name:
+      continue
+    for key, aliases in alias_map.items():
+      if key in used_keys:
+        continue
+      if any(alias and alias in column_name for alias in aliases):
+        detected_keys[idx] = key
+        used_keys.add(key)
+        break
+
+  return detected_keys
 
 def resolve_conflicts(qs):
   def resolve(item):

--- a/price_manager/supplier_product_manager/tests.py
+++ b/price_manager/supplier_product_manager/tests.py
@@ -7,7 +7,13 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase, override_settings
 
 from supplier_manager.models import Currency, Supplier, Manufacturer
-from supplier_product_manager.functions import get_sps, get_df, get_df_sheet_names, load_setting
+from supplier_product_manager.functions import (
+    auto_detect_link_keys,
+    get_sps,
+    get_df,
+    get_df_sheet_names,
+    load_setting,
+)
 from supplier_product_manager.models import Link, Setting, SupplierFile, SupplierProduct
 
 
@@ -537,3 +543,16 @@ class SupplierFileSelectionTests(TestCase):
 
         sheet_names = get_df_sheet_names(setting.pk)
         self.assertEqual(sheet_names, ["LatestSheet"])
+
+
+class AutoDetectLinkKeysTests(TestCase):
+    def test_detects_standard_ru_columns(self):
+        detected = auto_detect_link_keys(["Артикул", "Название", "Цена", "РРЦ", "Остаток", "Производитель"])
+        self.assertEqual(
+            detected,
+            ["article", "name", "supplier_price", "rrp", "stock", "manufacturer"],
+        )
+
+    def test_does_not_duplicate_same_target_key(self):
+        detected = auto_detect_link_keys(["Цена", "Цена со скидкой"])
+        self.assertEqual(detected, ["supplier_price", "discount_price"])

--- a/price_manager/supplier_product_manager/views.py
+++ b/price_manager/supplier_product_manager/views.py
@@ -295,7 +295,21 @@ class SettingUpdate(UpdateView):
     if not link_formset.is_valid() :
       messages.error(self.request, f'Что-то пошло не так')
       return HttpResponseClientRefresh()
-    keys = [item['key'] for item in link_formset.cleaned_data if not item['key'] is None and not item['key']=='']
+
+    selected_keys = [
+      item['key'] for item in link_formset.cleaned_data
+      if item['key'] is not None and item['key'] != ''
+    ]
+    if change or not selected_keys:
+      detected_keys = auto_detect_link_keys(df.columns)
+      for idx, detected_key in enumerate(detected_keys):
+        link_formset.cleaned_data[idx]['key'] = detected_key
+      selected_keys = [
+        item['key'] for item in link_formset.cleaned_data
+        if item['key'] is not None and item['key'] != ''
+      ]
+
+    keys = selected_keys
     if not len(set(keys)) == len(keys):
       messages.error(self.request, f'Неоднозначная связь: Столбец\\знаение')
       return self.form_invalid(form)


### PR DESCRIPTION
### Motivation
- Упростить привязку столбцов файла поставщика к внутренним полям, автоматически назначая подходящие ключи связок при смене `index_row` или если пользователь не выбрал ни одной связки.

### Description
- Добавлен набор алиасов `AUTO_LINK_ALIASES` и функция `_normalize_column_name` для нормализации заголовков и поддержки RU/EN вариантов; реализована публичная функция `auto_detect_link_keys(columns)` в `price_manager/supplier_product_manager/functions.py`.
- Внедрена логика автоподбора в обработку сохранения настройки (`SettingUpdate.form_valid`) в `price_manager/supplier_product_manager/views.py`, которая срабатывает при `index_row` изменён или если не было выбранных вручную ключей и затем заполняет `link_formset.cleaned_data` детектированными ключами.
- Добавлены тесты `AutoDetectLinkKeysTests` в `price_manager/supplier_product_manager/tests.py`, проверяющие детектирование стандартных русскоязычных колонок и отсутствие дублирования назначения одного ключа для похожих заголовков.

### Testing
- Скомпилированы изменённые файлы командой `python -m compileall price_manager/supplier_product_manager/functions.py price_manager/supplier_product_manager/views.py price_manager/supplier_product_manager/tests.py` и компиляция прошла успешно.
- Попытка запустить `pytest` для тестов автодетекта (`python -m pytest price_manager/supplier_product_manager/tests.py -k "AutoDetectLinkKeysTests"`) завершилась ошибкой сбора тестов из-за незаданных Django настроек (`DJANGO_SETTINGS_MODULE`) в среде выполнения, поэтому тесты не были выполнены в `pytest`.
- Попытка запустить `manage.py test supplier_product_manager.tests.AutoDetectLinkKeysTests` завершилась ошибкой окружения из-за отсутствующей зависимости `celery`, поэтому тесты не были выполнены через Django test runner.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0d821e618832d86a7c3765ae22140)