### PR TITLE
Persist SupplierDetail column selection per user

### DIFF
--- a/price_manager/supplier_product_manager/functions.py
+++ b/price_manager/supplier_product_manager/functions.py
@@ -6,6 +6,7 @@ from django.core.cache import cache
 from .models import (SupplierFile, Setting, Link, 
                      SupplierProduct, Manufacturer, Discount, Category,
                      SP_NUMBERS, SP_PRICES)
+from .tables import SP_AVAILABLE_COLUMN_MAP, SP_DEFAULT_VISIBLE_COLUMNS
 from main_product_manager.models import MainProduct
 from main_product_manager.functions import recalculate_search_vectors
 
@@ -22,6 +23,7 @@ import json
 import logging
 
 SPS_CACHE_TTL_SECONDS = 60 * 30
+CACHE_TTL = 60 * 60 * 24 * 30  # 30 дней
 SPS_JSON_SCHEMA_VERSION = "1.0"
 SPS_JSON_FIELDS = (
     "article",
@@ -38,6 +40,29 @@ SPS_JSON_FIELDS = (
 SPS_JSON_REQUIRED_FIELDS = ("article", "name")
 
 logger = logging.getLogger(__name__)
+
+
+def _cache_key(user_id: int) -> str:
+  return f"supplierdetail:selected_columns:user:{user_id}"
+
+
+def normalize_columns(columns):
+  valid = [column for column in columns if column in SP_AVAILABLE_COLUMN_MAP]
+  return valid or SP_DEFAULT_VISIBLE_COLUMNS
+
+
+def save_user_sp_columns(user, columns):
+  normalized_columns = normalize_columns(columns)
+  if not user.is_authenticated:
+    return normalized_columns
+  cache.set(_cache_key(user.id), normalized_columns, CACHE_TTL)
+  return normalized_columns
+
+
+def load_user_sp_columns(user):
+  if not user.is_authenticated:
+    return SP_DEFAULT_VISIBLE_COLUMNS
+  return cache.get(_cache_key(user.id), SP_DEFAULT_VISIBLE_COLUMNS)
 
 AUTO_LINK_ALIASES = {
     "article": ("article", "артикул", "код", "sku", "vendorcode"),

--- a/price_manager/supplier_product_manager/views.py
+++ b/price_manager/supplier_product_manager/views.py
@@ -71,15 +71,26 @@ class SupplierDetail(SingleTableMixin, FilterView):
     return redirect(f"{reverse('supplier-detail', kwargs={'pk': self.supplier.pk})}#supplier-settings")
   def get_table_data(self):
     return super().get_table_data().filter(supplier=self.supplier)
-  def get_table(self, **kwargs):
+  def _resolve_selected_columns(self):
+    if hasattr(self, '_selected_columns'):
+      return self._selected_columns
     selected_columns = self.request.GET.getlist('columns')
+    if selected_columns:
+      selected_columns = save_user_sp_columns(self.request.user, selected_columns)
+    else:
+      selected_columns = load_user_sp_columns(self.request.user)
+    if not selected_columns:
+      selected_columns = SP_DEFAULT_VISIBLE_COLUMNS
+    self._selected_columns = selected_columns
+    return self._selected_columns
+  def get_table(self, **kwargs):
+    selected_columns = self._resolve_selected_columns()
     return super().get_table(**kwargs, selected_columns=selected_columns)
   def get_context_data(self, **kwargs):
     context = super().get_context_data(**kwargs)
     context['supplier'] = self.supplier
     context['column_groups'] = SP_AVAILABLE_COLUMN_GROUPS
-    selected_columns = self.request.GET.getlist('columns')
-    context['selected_columns'] = selected_columns if selected_columns else SP_DEFAULT_VISIBLE_COLUMNS
+    context['selected_columns'] = self._resolve_selected_columns()
     context['supplier_form'] = SupplierForm(instance=self.supplier)
     pms = PriceManager.objects.filter(supplier=self.supplier)
     context['pricemanagers'] = pms


### PR DESCRIPTION
### Motivation

- Сделать выбор видимых колонок на странице поставщика персистентным по пользователю, чтобы при HTMX-перерисовках и переключении вкладок выбор не сбрасывался на дефолт.
- Привести поведение `SupplierDetail` к похожему механизму, который уже используется для главного прайса, с сохранением нормализованного набора колонок в кэше.

### Description

- Добавлены хелперы в `supplier_product_manager/functions.py`: ` _cache_key(user_id)` с namespace `supplierdetail`, `normalize_columns(columns)` (основанная на `SP_AVAILABLE_COLUMN_MAP`), `save_user_sp_columns(user, columns)` и `load_user_sp_columns(user)` и импортированы `SP_AVAILABLE_COLUMN_MAP` и `SP_DEFAULT_VISIBLE_COLUMNS`.
- В `supplier_product_manager/views.py` в `SupplierDetail` введён метод `_resolve_selected_columns()` который принимает `GET columns`, сохраняет их через `save_user_sp_columns` при наличии, или загружает через `load_user_sp_columns` при отсутствии, гарантирует fallback на `SP_DEFAULT_VISIBLE_COLUMNS` и кэширует результат на время обработки запроса.
- `get_table()` и `get_context_data()` теперь используют единый итоговый набор колонок из `_resolve_selected_columns()`, что обеспечивает корректное состояние чекбоксов в dropdown и единообразие отображения таблицы.

### Testing

- Выполнена компиляция изменённых модулей командой `python -m compileall price_manager/supplier_product_manager/functions.py price_manager/supplier_product_manager/views.py` и она завершилась успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2003bb3f4832db26dc97c60757205)