### PR TITLE
Improve supplier product filter UX and faceted dictionary options

### DIFF
--- a/price_manager/supplier_product_manager/filters.py
+++ b/price_manager/supplier_product_manager/filters.py
@@ -2,6 +2,7 @@ from django import forms
 from django.db.models import Q
 from django.urls import reverse
 from django_filters import FilterSet, filters
+from django_filters.widgets import RangeWidget
 
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Div, Field, HTML, Layout, Submit
@@ -26,13 +27,13 @@ class SupplierProductFilter(FilterSet):
     field_name='manufacturer',
     queryset=Manufacturer.objects.none(),
     label='Производитель',
-    widget=forms.SelectMultiple(attrs={'class': 'form-select'}),
+    widget=forms.widgets.CheckboxSelectMultiple(),
   )
   discount = filters.ModelMultipleChoiceFilter(
     field_name='discount',
     queryset=Discount.objects.none(),
     label='Группа скидок',
-    widget=forms.SelectMultiple(attrs={'class': 'form-select'}),
+    widget=forms.widgets.CheckboxSelectMultiple(),
   )
 
   stock_min = filters.NumberFilter(field_name='stock', lookup_expr='gte', label='Остаток от')
@@ -44,7 +45,11 @@ class SupplierProductFilter(FilterSet):
   discount_price_min = filters.NumberFilter(field_name='discount_price', lookup_expr='gte', label='Цена со скидкой от')
   discount_price_max = filters.NumberFilter(field_name='discount_price', lookup_expr='lte', label='Цена со скидкой до')
 
-  updated_at = filters.DateFromToRangeFilter(field_name='updated_at', label='Обновлено')
+  updated_at = filters.DateFromToRangeFilter(
+    field_name='updated_at',
+    label='Обновлено',
+    widget=RangeWidget(attrs={'type': 'date', 'class': 'form-control'}),
+  )
   is_tied = filters.BooleanFilter(
     field_name='main_product',
     label='Связан с ГП',
@@ -89,19 +94,19 @@ class SupplierProductFilter(FilterSet):
       filter_name='category',
       model=Category,
       ids_key='category',
-      queryset=queryset,
+      queryset=self._apply_current_filters(queryset, excluded_key='category'),
     )
     self._setup_related_queryset(
       filter_name='manufacturer',
       model=Manufacturer,
       ids_key='manufacturer',
-      queryset=queryset,
+      queryset=self._apply_current_filters(queryset, excluded_key='manufacturer'),
     )
     self._setup_related_queryset(
       filter_name='discount',
       model=Discount,
       ids_key='discount',
-      queryset=queryset,
+      queryset=self._apply_current_filters(queryset, excluded_key='discount'),
     )
 
     self.form.helper = FormHelper(self.form)
@@ -116,22 +121,24 @@ class SupplierProductFilter(FilterSet):
       'class': 'card p-3',
     }
     self.form.helper.layout = Layout(
-      HTML('<h6 class="mb-2">Текстовые поля</h6>'),
+      HTML('<details class="mb-3" open><summary class="fw-semibold mb-2">Текстовые поля</summary>'),
       Div(
         Field('article', label_class='mt-2'),
         Field('name', label_class='mt-2'),
         Field('description', label_class='mt-2'),
         css_class='mb-3',
       ),
-      HTML('<h6 class="mb-2">Справочники</h6>'),
+      HTML('</details>'),
+      HTML('<details class="mb-3" open><summary class="fw-semibold mb-2">Справочники</summary>'),
       Div(
-        Field('category', css_class='form-select'),
-        Field('manufacturer', css_class='form-select'),
-        Field('discount', css_class='form-select'),
+        Field('category', template='supplier/partials/category_filter_field.html'),
+        Field('manufacturer', template='core/includes/checkbox_field.html'),
+        Field('discount', template='core/includes/checkbox_field.html'),
         Field('is_tied', css_class='form-select'),
         css_class='mb-3',
       ),
-      HTML('<h6 class="mb-2">Числовые значения</h6>'),
+      HTML('</details>'),
+      HTML('<details class="mb-3" open><summary class="fw-semibold mb-2">Числовые значения</summary>'),
       Div(
         Div(Field('stock_min'), Field('stock_max'), css_class='row d-flex flex-column gap-2'),
         Div(Field('supplier_price_min'), Field('supplier_price_max'), css_class='row d-flex flex-column gap-2'),
@@ -139,11 +146,13 @@ class SupplierProductFilter(FilterSet):
         Div(Field('discount_price_min'), Field('discount_price_max'), css_class='row d-flex flex-column gap-2'),
         css_class='row g-2 mb-3',
       ),
-      HTML('<h6 class="mb-2">Дата обновления</h6>'),
+      HTML('</details>'),
+      HTML('<details class="mb-3" open><summary class="fw-semibold mb-2">Дата обновления</summary>'),
       Div(
         Field('updated_at'),
         css_class='mb-3',
       ),
+      HTML('</details>'),
       Div(
         Submit('action', 'Поиск', css_class='btn btn-primary btn-md'),
         HTML('''
@@ -167,3 +176,56 @@ class SupplierProductFilter(FilterSet):
     if selected_ids:
       base_queryset = model.objects.filter(Q(pk__in=base_queryset) | Q(pk__in=selected_ids)).distinct().order_by('name')
     self.filters[filter_name].field.queryset = base_queryset
+
+  def _apply_current_filters(self, queryset, excluded_key=None):
+    data = self.data
+
+    def get_value(name):
+      if excluded_key == name:
+        return None
+      value = data.get(name)
+      return value.strip() if isinstance(value, str) else value
+
+    def get_list(name):
+      if excluded_key == name:
+        return []
+      return [value for value in data.getlist(name) if value]
+
+    for field_name in ('article', 'name', 'description'):
+      value = get_value(field_name)
+      if value:
+        queryset = queryset.filter(**{f'{field_name}__icontains': value})
+
+    for relation in ('category', 'manufacturer', 'discount'):
+      ids = get_list(relation)
+      if ids:
+        queryset = queryset.filter(**{f'{relation}__in': ids})
+
+    range_filters = (
+      ('stock', 'stock_min', 'stock_max'),
+      ('supplier_price', 'supplier_price_min', 'supplier_price_max'),
+      ('rrp', 'rrp_min', 'rrp_max'),
+      ('discount_price', 'discount_price_min', 'discount_price_max'),
+    )
+    for field_name, min_name, max_name in range_filters:
+      min_value = get_value(min_name)
+      max_value = get_value(max_name)
+      if min_value:
+        queryset = queryset.filter(**{f'{field_name}__gte': min_value})
+      if max_value:
+        queryset = queryset.filter(**{f'{field_name}__lte': max_value})
+
+    updated_after = get_value('updated_at_after')
+    updated_before = get_value('updated_at_before')
+    if updated_after:
+      queryset = queryset.filter(updated_at__date__gte=updated_after)
+    if updated_before:
+      queryset = queryset.filter(updated_at__date__lte=updated_before)
+
+    is_tied = get_value('is_tied')
+    if is_tied == 'true':
+      queryset = queryset.filter(main_product__isnull=False)
+    elif is_tied == 'false':
+      queryset = queryset.filter(main_product__isnull=True)
+
+    return queryset

--- a/price_manager/supplier_product_manager/tests.py
+++ b/price_manager/supplier_product_manager/tests.py
@@ -2,11 +2,15 @@ from io import BytesIO
 from decimal import Decimal
 
 import pandas as pd
+from django import forms
 from django.core.cache import cache
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.http import QueryDict
 from django.test import TestCase, override_settings
+from django.utils import timezone
 
-from supplier_manager.models import Currency, Supplier, Manufacturer
+from supplier_manager.models import Category, Currency, Discount, Supplier, Manufacturer
+from supplier_product_manager.filters import SupplierProductFilter
 from supplier_product_manager.functions import (
     auto_detect_link_keys,
     get_sps,
@@ -556,3 +560,64 @@ class AutoDetectLinkKeysTests(TestCase):
     def test_does_not_duplicate_same_target_key(self):
         detected = auto_detect_link_keys(["Цена", "Цена со скидкой"])
         self.assertEqual(detected, ["supplier_price", "discount_price"])
+
+
+class SupplierProductFilterTests(TestCase):
+    def setUp(self):
+        self.currency = Currency.objects.get(name="KZT")
+        self.supplier = Supplier.objects.create(
+            name="Filter supplier",
+            currency=self.currency,
+            price_update_rate="Каждый день",
+            stock_update_rate="Каждый день",
+            delivery_days_available=1,
+            delivery_days_navailable=3,
+        )
+        self.category_a = Category.objects.create(name="Категория A")
+        self.category_b = Category.objects.create(name="Категория B")
+        self.manufacturer_a = Manufacturer.objects.create(name="Производитель A")
+        self.manufacturer_b = Manufacturer.objects.create(name="Производитель B")
+        self.discount_a = Discount.objects.create(name="Скидка A")
+        self.discount_b = Discount.objects.create(name="Скидка B")
+
+        SupplierProduct.objects.create(
+            supplier=self.supplier,
+            article="A1",
+            name="Товар A1",
+            category=self.category_a,
+            manufacturer=self.manufacturer_a,
+            discount=self.discount_a,
+            updated_at=timezone.now(),
+        )
+        SupplierProduct.objects.create(
+            supplier=self.supplier,
+            article="B1",
+            name="Товар B1",
+            category=self.category_b,
+            manufacturer=self.manufacturer_b,
+            discount=self.discount_b,
+            updated_at=timezone.now(),
+        )
+
+    def test_related_querysets_are_limited_by_other_filters(self):
+        data = QueryDict("category=%s" % self.category_a.pk, mutable=True)
+        filterset = SupplierProductFilter(
+            data=data,
+            queryset=SupplierProduct.objects.all(),
+            pk=self.supplier.pk,
+        )
+
+        manufacturer_ids = list(filterset.filters["manufacturer"].field.queryset.values_list("pk", flat=True))
+        discount_ids = list(filterset.filters["discount"].field.queryset.values_list("pk", flat=True))
+
+        self.assertEqual(manufacturer_ids, [self.manufacturer_a.pk])
+        self.assertEqual(discount_ids, [self.discount_a.pk])
+
+    def test_filter_uses_checkbox_widgets_for_dict_filters(self):
+        filterset = SupplierProductFilter(
+            data=QueryDict("", mutable=True),
+            queryset=SupplierProduct.objects.filter(supplier=self.supplier),
+            pk=self.supplier.pk,
+        )
+        self.assertIsInstance(filterset.filters["manufacturer"].field.widget, forms.CheckboxSelectMultiple)
+        self.assertIsInstance(filterset.filters["discount"].field.widget, forms.CheckboxSelectMultiple)


### PR DESCRIPTION
### Motivation
- Сделать фильтр товаров поставщика более удобным для пользователя: деревья категорий, чекбоксы со поиском для справочников, корректный ввод дат и сворачиваемые группы.
- Ограничить варианты справочников (производители, группы скидок, категории) только теми записями, которые доступны для текущего набора фильтров (faceted filtering).
- Обеспечить автоматическое тестирование ключевых изменений поведения фильтра.

### Description
- Перенёс рендер поля `category` на шаблон `supplier/partials/category_filter_field.html` (дерево категорий) и использовал его в layout фильтра.
- Заменил `manufacturer` и `discount` с `SelectMultiple` на `CheckboxSelectMultiple` и подключил `core/includes/checkbox_field.html`, который содержит строку поиска для чекбоксов.
- Исправил ввод для диапазона `updated_at` на нативные `type="date"` через `DateFromToRangeFilter` + `RangeWidget`.
- Группы полей фильтра (`Текстовые поля`, `Справочники`, `Числовые значения`, `Дата обновления`) сделал сворачиваемыми через `details/summary` для компактности UI.
- Добавил логику `_apply_current_filters`, которая применяет все активные фильтры (кроме текущего) к queryset товаров и затем формирует queryset опций справочников, чтобы показывать только релевантные варианты; при этом выбранные значения сохраняются в списке опций.
- Добавил тесты `SupplierProductFilterTests` в `price_manager/supplier_product_manager/tests.py`, которые проверяют ограничение queryset для справочников и использование виджетов чекбоксов.

### Testing
- Проверка синтаксиса: `python -m py_compile price_manager/supplier_product_manager/filters.py price_manager/supplier_product_manager/tests.py` — успешно.
- Запуск тестов через `pytest` (`python -m pytest ... -k "SupplierProductFilterTests"`) прервался на этапе импорта Django из-за отсутствия настроек (`DJANGO_SETTINGS_MODULE` не установлен) и завершился с ошибкой конфигурации.
- Запуск тестов через Django `manage.py test supplier_product_manager.tests.SupplierProductFilterTests` не выполнился в CI-окружении из-за отсутствующей зависимости `celery` (ModuleNotFoundError), поэтому полное выполнение тестов в текущем окружении невозможно.
- Юнит-тесты добавлены и готовы к выполнению в нормальном Django CI (требуется окружение с Django settings и установленными зависимостями).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2059a1294832da6fdae3216c7ae7e)