### PR TITLE
Apply fixed_price rules after markups in update_prices

### DIFF
--- a/price_manager/main_product_manager/tables.py
+++ b/price_manager/main_product_manager/tables.py
@@ -229,13 +229,14 @@ class CategoryListTable(tables.Table):
       }
 
 class MainProductLogTable(tables.Table):
-  event = tables.Column(verbose_name='Тип изменения', empty_values=(), orderable=False)
-  value = tables.Column(verbose_name='Новое значение', empty_values=(), orderable=False)
-  summary = tables.Column(verbose_name='Комментарий', empty_values=(), orderable=False)
+  record_type = tables.Column(
+    accessor='record_type',
+    verbose_name='Тип записи',
+  )
 
   class Meta:
     model = MainProductLog
-    fields = ['update_time', 'event', 'value', 'summary']
+    fields = ['update_time', 'record_type', 'price_type', 'price', 'stock']
     template_name = 'django_tables2/bootstrap5.html'
     attrs = {
       'class': 'clickable-rows table table-auto table-striped table-hover align-middle mb-0'
@@ -245,22 +246,22 @@ class MainProductLogTable(tables.Table):
   def render_update_time(self, value):
     return timezone.localtime(value).strftime('%d.%m.%Y %H:%M')
 
-  def render_event(self, record):
-    if record.price_type:
-      return format_html(
-        '<span class="badge text-bg-primary">Цена: {}</span>',
-        PRICE_TYPES.get(record.price_type, record.price_type)
-      )
+  def render_record_type(self, value):
+    if value == 'price':
+      return format_html('<span class="badge text-bg-primary">Тип цены</span>')
     return format_html('<span class="badge text-bg-success">Остаток</span>')
 
-  def render_value(self, record):
-    if record.price_type:
-      return format_html('<strong>{:.2f} тг</strong>', record.price or 0)
-    return format_html('<strong>{}</strong> шт.', record.stock if record.stock is not None else 0)
+  def render_price_type(self, value):
+    if not value:
+      return '—'
+    return PRICE_TYPES.get(value, value)
 
-  def render_summary(self, record):
-    if record.price_type:
-      return 'Обновлена цена товара'
-    if record.stock == 0:
-      return format_html('<span class="text-danger">Товара нет в наличии</span>')
-    return format_html('<span class="text-success">Товар в наличии</span>')
+  def render_price(self, value):
+    if value is None:
+      return '—'
+    return f'{value:.2f} тг'
+
+  def render_stock(self, value):
+    if value is None:
+      return '—'
+    return f'{value} шт.'

--- a/price_manager/main_product_manager/tables.py
+++ b/price_manager/main_product_manager/tables.py
@@ -229,11 +229,38 @@ class CategoryListTable(tables.Table):
       }
 
 class MainProductLogTable(tables.Table):
+  event = tables.Column(verbose_name='Тип изменения', empty_values=(), orderable=False)
+  value = tables.Column(verbose_name='Новое значение', empty_values=(), orderable=False)
+  summary = tables.Column(verbose_name='Комментарий', empty_values=(), orderable=False)
+
   class Meta:
     model = MainProductLog
-    fields = ['update_time', 'stock', 'price_type', 'price']
+    fields = ['update_time', 'event', 'value', 'summary']
     template_name = 'django_tables2/bootstrap5.html'
     attrs = {
-      'class': 'clickable-rows table table-auto table-stripped table-hover'
+      'class': 'clickable-rows table table-auto table-striped table-hover align-middle mb-0'
       }
     paginate=False
+
+  def render_update_time(self, value):
+    return timezone.localtime(value).strftime('%d.%m.%Y %H:%M')
+
+  def render_event(self, record):
+    if record.price_type:
+      return format_html(
+        '<span class="badge text-bg-primary">Цена: {}</span>',
+        PRICE_TYPES.get(record.price_type, record.price_type)
+      )
+    return format_html('<span class="badge text-bg-success">Остаток</span>')
+
+  def render_value(self, record):
+    if record.price_type:
+      return format_html('<strong>{:.2f} тг</strong>', record.price or 0)
+    return format_html('<strong>{}</strong> шт.', record.stock if record.stock is not None else 0)
+
+  def render_summary(self, record):
+    if record.price_type:
+      return 'Обновлена цена товара'
+    if record.stock == 0:
+      return format_html('<span class="text-danger">Товара нет в наличии</span>')
+    return format_html('<span class="text-success">Товар в наличии</span>')

--- a/price_manager/main_product_manager/templates/mainproduct/partials/detail.html
+++ b/price_manager/main_product_manager/templates/mainproduct/partials/detail.html
@@ -1,18 +1,40 @@
-<div class="row gap-3">
-  <div class="col-7">
-    <div class="card row p-4">
-      <h1>
-        {{mainproduct.name}}
-      </h1>
-      <div>
-        <p class="">Индивидуальный номер: {% if  mainproduct.sku%}{{mainproduct.sku}}{% else %}Отсутствует.{% endif %}</p>
-        <p class="">Базовая цена: {% if  mainproduct.basic_price%}{{mainproduct.basic_price}} тг.{% else %}Отсутствует.{% endif %}</p>
-        <p class="">Себестоимость: {% if  mainproduct.prime_cost%}{{mainproduct.prime_cost}} тг.{% else %}Отсутствует.{% endif %}</p>
-        <p class="">Цена ИМ: {% if mainproduct.m_price %}{{mainproduct.m_price}} тг.{% else %}Отсутствует.{% endif %}</p>
-        <p class="">Последнее обновление: {% if mainproduct.price_updated_at %}{{mainproduct.price_updated_at}}{% else %}Отсутствует.{% endif %}</p>
+<div class="row g-3">
+  <div class="col-lg-8">
+    <div class="card shadow-sm border-0 p-4">
+      <h1 class="h3 mb-2">{{mainproduct.name}}</h1>
+      <div class="d-flex flex-wrap gap-2 mb-3">
+        <span class="badge text-bg-light">Артикул: {{ mainproduct.article }}</span>
+        <span class="badge text-bg-light">SKU: {% if mainproduct.sku %}{{ mainproduct.sku }}{% else %}—{% endif %}</span>
+        <span class="badge text-bg-light">Поставщик: {{ mainproduct.supplier }}</span>
       </div>
-      
-      <div>
+
+      <div class="row g-3 mb-3">
+        <div class="col-md-4">
+          <div class="border rounded-3 p-3 h-100 bg-body-tertiary">
+            <div class="text-muted small">Базовая цена</div>
+            <div class="fw-semibold fs-5">{% if mainproduct.basic_price %}{{mainproduct.basic_price}} тг{% else %}—{% endif %}</div>
+          </div>
+        </div>
+        <div class="col-md-4">
+          <div class="border rounded-3 p-3 h-100 bg-body-tertiary">
+            <div class="text-muted small">Себестоимость</div>
+            <div class="fw-semibold fs-5">{% if mainproduct.prime_cost %}{{mainproduct.prime_cost}} тг{% else %}—{% endif %}</div>
+          </div>
+        </div>
+        <div class="col-md-4">
+          <div class="border rounded-3 p-3 h-100 bg-body-tertiary">
+            <div class="text-muted small">Цена ИМ</div>
+            <div class="fw-semibold fs-5">{% if mainproduct.m_price %}{{mainproduct.m_price}} тг{% else %}—{% endif %}</div>
+          </div>
+        </div>
+      </div>
+
+      <p class="small text-muted mb-3">
+        Последнее обновление цены:
+        {% if mainproduct.price_updated_at %}{{mainproduct.price_updated_at}}{% else %}Отсутствует{% endif %}
+      </p>
+
+      <div class="d-flex flex-wrap gap-2">
         <button type="button"
                 class="btn btn-primary"
                 title="Изменить"
@@ -38,7 +60,7 @@
       </div>
     </div>
     <div id="mainproduct-logs" 
-        class="row mt-2"
+        class="row mt-3"
         hx-get="{% url 'mainproductlog-list' pk=mainproduct.pk %}" 
         hx-trigger="load" 
         hx-swap="innerHTML">
@@ -46,7 +68,7 @@
     </div>
   </div>
   <div id="mainproduct-pricetags" 
-    class="col-4 card p-4"
+    class="col-lg-4 card p-4 shadow-sm border-0"
     hx-get="{% url 'pricetag-list' pk=mainproduct.pk %}" 
     hx-trigger="load" 
     hx-swap="innerHTML">

--- a/price_manager/main_product_manager/templates/mainproduct/partials/logs.html
+++ b/price_manager/main_product_manager/templates/mainproduct/partials/logs.html
@@ -1,6 +1,18 @@
 
 {% load django_tables2 %}
 
-<div class="container p-4 card">
-{% render_table table %}
+<div class="card shadow-sm border-0">
+  <div class="card-body border-bottom d-flex flex-wrap justify-content-between align-items-center gap-2">
+    <div>
+      <h5 class="mb-1">История изменений цены и остатков</h5>
+      <p class="text-muted mb-0 small">Новые записи сверху — так проще отслеживать последние изменения.</p>
+    </div>
+    <div class="d-flex gap-2">
+      <span class="badge text-bg-primary">Изменение цены</span>
+      <span class="badge text-bg-success">Изменение остатка</span>
+    </div>
+  </div>
+  <div class="table-responsive" style="max-height: 420px;">
+    {% render_table table %}
+  </div>
 </div>

--- a/price_manager/main_product_manager/templates/mainproduct/partials/logs.html
+++ b/price_manager/main_product_manager/templates/mainproduct/partials/logs.html
@@ -3,7 +3,42 @@
 
 <div class="card shadow-sm border-0 p-3">
   <h5 class="mb-1">История изменений</h5>
-  <p class="text-muted mb-3 small">Для сортировки нажмите на заголовок столбца «Тип записи».</p>
+  <p class="text-muted mb-3 small">Фильтруйте по строке, типу цены и изменениям остатков.</p>
+  <form class="row g-2 mb-3"
+        hx-get="{% url 'mainproductlog-list' pk=mainproduct_pk %}"
+        hx-target="#mainproduct-logs"
+        hx-swap="innerHTML"
+        hx-trigger="change, keyup delay:350ms from:#row-query">
+    <div class="col-md-4">
+      <input id="row-query"
+             type="text"
+             name="row_query"
+             class="form-control form-control-sm"
+             placeholder="Фильтр по строкам..."
+             value="{{ row_query }}">
+    </div>
+    <div class="col-md-3">
+      <select name="price_type" class="form-select form-select-sm">
+        <option value="">Все типы цен</option>
+        {% for value, label in price_type_options %}
+          <option value="{{ value }}" {% if selected_price_type == value %}selected{% endif %}>{{ label }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div class="col-md-3">
+      <select name="log_type" class="form-select form-select-sm">
+        <option value="all" {% if selected_log_type == 'all' %}selected{% endif %}>Все записи</option>
+        <option value="price" {% if selected_log_type == 'price' %}selected{% endif %}>Только изменения цен</option>
+        <option value="stock" {% if selected_log_type == 'stock' %}selected{% endif %}>Только изменения остатков</option>
+      </select>
+    </div>
+    <div class="col-md-2 d-flex align-items-center">
+      <div class="form-check">
+        <input class="form-check-input" type="checkbox" name="stock_changes_only" id="stockOnly" {% if stock_changes_only %}checked{% endif %}>
+        <label class="form-check-label small" for="stockOnly">Только остатки</label>
+      </div>
+    </div>
+  </form>
   <div class="table-responsive">
     {% render_table table %}
   </div>

--- a/price_manager/main_product_manager/templates/mainproduct/partials/logs.html
+++ b/price_manager/main_product_manager/templates/mainproduct/partials/logs.html
@@ -1,18 +1,10 @@
 
 {% load django_tables2 %}
 
-<div class="card shadow-sm border-0">
-  <div class="card-body border-bottom d-flex flex-wrap justify-content-between align-items-center gap-2">
-    <div>
-      <h5 class="mb-1">История изменений цены и остатков</h5>
-      <p class="text-muted mb-0 small">Новые записи сверху — так проще отслеживать последние изменения.</p>
-    </div>
-    <div class="d-flex gap-2">
-      <span class="badge text-bg-primary">Изменение цены</span>
-      <span class="badge text-bg-success">Изменение остатка</span>
-    </div>
-  </div>
-  <div class="table-responsive" style="max-height: 420px;">
+<div class="card shadow-sm border-0 p-3">
+  <h5 class="mb-1">История изменений</h5>
+  <p class="text-muted mb-3 small">Для сортировки нажмите на заголовок столбца «Тип записи».</p>
+  <div class="table-responsive">
     {% render_table table %}
   </div>
 </div>

--- a/price_manager/main_product_manager/views.py
+++ b/price_manager/main_product_manager/views.py
@@ -26,6 +26,7 @@ from django_tables2 import SingleTableView, RequestConfig, SingleTableMixin
 from django_filters.views import FilterView, FilterMixin
 from django.core.paginator import Paginator
 from django.http import HttpResponse
+from decimal import Decimal, InvalidOperation
 
 from dal import autocomplete
 from django_htmx.http import HttpResponseClientRedirect, HttpResponseClientRefresh, retarget
@@ -205,7 +206,7 @@ class MainProductLogList(SingleTableView):
   table_class = MainProductLogTable
   template_name = 'mainproduct/partials/logs.html'
   def get_queryset(self):
-    return (
+    qs = (
       super().get_queryset()
       .filter(main_product=self.kwargs.get('pk', None))
       .annotate(
@@ -216,6 +217,57 @@ class MainProductLogList(SingleTableView):
       )
       .order_by('-update_time')
     )
+    log_type = self.request.GET.get('log_type', 'all')
+    selected_price_type = self.request.GET.get('price_type', '')
+    stock_changes_only = self.request.GET.get('stock_changes_only') == 'on'
+    row_query = (self.request.GET.get('row_query') or '').strip()
+
+    if log_type == 'price':
+      qs = qs.filter(price_type__isnull=False)
+    elif log_type == 'stock':
+      qs = qs.filter(price_type__isnull=True, stock__isnull=False)
+
+    if selected_price_type:
+      qs = qs.filter(price_type=selected_price_type)
+
+    if stock_changes_only:
+      qs = qs.filter(price_type__isnull=True, stock__isnull=False)
+
+    if row_query:
+      query = Q()
+      matched_price_types = [
+        price_type for price_type, label in PRICE_TYPES.items()
+        if row_query.lower() in label.lower()
+      ]
+      if matched_price_types:
+        query |= Q(price_type__in=matched_price_types)
+      if 'остат' in row_query.lower():
+        query |= Q(price_type__isnull=True, stock__isnull=False)
+      try:
+        parsed_number = Decimal(row_query.replace(',', '.'))
+        query |= Q(price=parsed_number)
+      except InvalidOperation:
+        pass
+      if row_query.isdigit():
+        query |= Q(stock=int(row_query))
+      if query:
+        qs = qs.filter(query)
+      else:
+        qs = qs.none()
+    return qs
+
+  def get_context_data(self, **kwargs):
+    context = super().get_context_data(**kwargs)
+    context['mainproduct_pk'] = self.kwargs.get('pk')
+    context['selected_log_type'] = self.request.GET.get('log_type', 'all')
+    context['selected_price_type'] = self.request.GET.get('price_type', '')
+    context['stock_changes_only'] = self.request.GET.get('stock_changes_only') == 'on'
+    context['row_query'] = (self.request.GET.get('row_query') or '').strip()
+    context['price_type_options'] = [
+      (price_type, label) for price_type, label in PRICE_TYPES.items() if price_type
+    ]
+    return context
+
   def get(self, request, *args, **kwargs):
     if not self.request.htmx:
       return redirect(reverse('mainproduct-info', kwargs=self.kwargs))

--- a/price_manager/main_product_manager/views.py
+++ b/price_manager/main_product_manager/views.py
@@ -18,7 +18,7 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.urls import reverse, reverse_lazy
 from typing import Optional, Any, Dict, Iterable
 from collections import defaultdict, OrderedDict
-from django.db.models import Count, Prefetch, F, Q, Value, Max, Min, Subquery, OuterRef, IntegerField, ExpressionWrapper
+from django.db.models import Count, Prefetch, F, Q, Value, Max, Min, Subquery, OuterRef, IntegerField, ExpressionWrapper, Case, When
 from django.db import transaction
 from django.contrib.postgres.search import SearchVector
 # Импорты из сторонних приложений
@@ -205,7 +205,17 @@ class MainProductLogList(SingleTableView):
   table_class = MainProductLogTable
   template_name = 'mainproduct/partials/logs.html'
   def get_queryset(self):
-    return super().get_queryset().filter(main_product=self.kwargs.get('pk', None))
+    return (
+      super().get_queryset()
+      .filter(main_product=self.kwargs.get('pk', None))
+      .annotate(
+        record_type=Case(
+          When(price_type__isnull=False, then=Value('price')),
+          default=Value('stock'),
+        )
+      )
+      .order_by('-update_time')
+    )
   def get(self, request, *args, **kwargs):
     if not self.request.htmx:
       return redirect(reverse('mainproduct-info', kwargs=self.kwargs))

--- a/price_manager/product_price_manager/models.py
+++ b/price_manager/product_price_manager/models.py
@@ -460,6 +460,8 @@ def update_prices():
     count += pm.apply()
   for pm in pms.filter(time_query).filter(source__in=MP_PRICES):
     count += pm.apply()
+  for pm in pms.filter(time_query).filter(source='fixed_price'):
+    count += pm.apply()
   dmps = map(lambda pt: pt.deprecate(),PriceTag.objects.filter(p_manager__isnull=True).filter(~Q(time_query)).select_related('mp'))
   deprecated_mps = [_ for _ in dmps if _]
   if deprecated_mps:
@@ -472,5 +474,9 @@ def update_prices():
   mp_mps = [_ for _ in mps if _]
   if mp_mps:
     count += MainProduct.objects.bulk_update(mp_mps, fields=[*MP_PRICES, 'price_updated_at'])
+  mps = map(lambda pt: pt.get_mp(),PriceTag.objects.filter(p_manager__isnull=True).filter(time_query).filter(source='fixed_price').select_related('mp'))
+  fixed_mps = [_ for _ in mps if _]
+  if fixed_mps:
+    count += MainProduct.objects.bulk_update(fixed_mps, fields=[*MP_PRICES, 'price_updated_at'])
 
   return (count, dcount)

--- a/price_manager/product_price_manager/models.py
+++ b/price_manager/product_price_manager/models.py
@@ -400,7 +400,7 @@ class PriceTag(models.Model):
     return max
 
   def get_sprice(self):
-    if self.source == 'fixed_price':
+    if self.source in ('fixed_price', None):
       return self.fixed_price
     if self.source in SP_PRICES:
       prices = list(self.mp.supplierproducts.values_list(self.source, flat=True))

--- a/price_manager/product_price_manager/models.py
+++ b/price_manager/product_price_manager/models.py
@@ -448,6 +448,20 @@ class PriceTag(models.Model):
 
 
 def update_prices():
+  def get_updated_mps(pricetags):
+    updated_mps = {}
+    for pt in pricetags.select_related('mp'):
+      updated_mp = pt.get_mp()
+      if not updated_mp:
+        continue
+      if updated_mp.pk not in updated_mps:
+        updated_mps[updated_mp.pk] = updated_mp
+        continue
+      target_mp = updated_mps[updated_mp.pk]
+      setattr(target_mp, pt.dest, getattr(updated_mp, pt.dest))
+      target_mp.price_updated_at = updated_mp.price_updated_at
+    return list(updated_mps.values())
+
   count = 0
   dcount = 0
   
@@ -466,16 +480,19 @@ def update_prices():
   deprecated_mps = [_ for _ in dmps if _]
   if deprecated_mps:
     dcount += MainProduct.objects.bulk_update(deprecated_mps, fields=[*MP_PRICES, 'price_updated_at'])
-  mps = map(lambda pt: pt.get_mp(),PriceTag.objects.filter(p_manager__isnull=True).filter(time_query).filter(source__in=SP_PRICES).select_related('mp'))
-  sp_mps = [_ for _ in mps if _]
+  sp_mps = get_updated_mps(
+    PriceTag.objects.filter(p_manager__isnull=True).filter(time_query).filter(source__in=SP_PRICES)
+  )
   if sp_mps:
     count += MainProduct.objects.bulk_update(sp_mps, fields=[*MP_PRICES, 'price_updated_at'])
-  mps = map(lambda pt: pt.get_mp(),PriceTag.objects.filter(p_manager__isnull=True).filter(time_query).filter(source__in=MP_PRICES).select_related('mp'))
-  mp_mps = [_ for _ in mps if _]
+  mp_mps = get_updated_mps(
+    PriceTag.objects.filter(p_manager__isnull=True).filter(time_query).filter(source__in=MP_PRICES)
+  )
   if mp_mps:
     count += MainProduct.objects.bulk_update(mp_mps, fields=[*MP_PRICES, 'price_updated_at'])
-  mps = map(lambda pt: pt.get_mp(),PriceTag.objects.filter(p_manager__isnull=True).filter(time_query).filter(source='fixed_price').select_related('mp'))
-  fixed_mps = [_ for _ in mps if _]
+  fixed_mps = get_updated_mps(
+    PriceTag.objects.filter(p_manager__isnull=True).filter(time_query).filter(Q(source='fixed_price')|Q(source__isnull=True))
+  )
   if fixed_mps:
     count += MainProduct.objects.bulk_update(fixed_mps, fields=[*MP_PRICES, 'price_updated_at'])
 

--- a/price_manager/product_price_manager/templates/price_manager/partials/pricemanager_form.html
+++ b/price_manager/product_price_manager/templates/price_manager/partials/pricemanager_form.html
@@ -45,7 +45,7 @@
                             name="{{ form.discounts.html_name }}"
                             value="{{ discount.pk }}"
                             id="discount_{{ discount.pk }}"
-                            {% if discount.pk|stringformat:"s" in selected_discount_ids %}checked{% endif %}>
+                            {% if discount.pk in selected_discount_ids %}checked{% endif %}>
                           <label class="form-check-label" for="discount_{{ discount.pk }}">
                             {{ discount.name }}
                           </label>

--- a/price_manager/product_price_manager/templates/price_manager/partials/pricemanager_form.html
+++ b/price_manager/product_price_manager/templates/price_manager/partials/pricemanager_form.html
@@ -37,24 +37,22 @@
                       placeholder="Поиск группы скидок"
                       data-discount-search>
                     <div class="border rounded p-2" style="max-height: 220px; overflow-y: auto;" data-discount-options>
-                      {% with selected_discounts=form.discounts.value %}
-                        {% for discount in form.fields.discounts.queryset %}
-                          <div class="form-check mb-2" data-discount-option data-discount-name="{{ discount.name|lower }}">
-                            <input
-                              class="form-check-input"
-                              type="checkbox"
-                              name="{{ form.discounts.html_name }}"
-                              value="{{ discount.pk }}"
-                              id="discount_{{ discount.pk }}"
-                              {% if selected_discounts and discount.pk|stringformat:"s" in selected_discounts %}checked{% endif %}>
-                            <label class="form-check-label" for="discount_{{ discount.pk }}">
-                              {{ discount.name }}
-                            </label>
-                          </div>
-                        {% empty %}
-                          <div class="text-muted small">Нет доступных групп скидок.</div>
-                        {% endfor %}
-                      {% endwith %}
+                      {% for discount in form.fields.discounts.queryset %}
+                        <div class="form-check mb-2" data-discount-option data-discount-name="{{ discount.name|lower }}">
+                          <input
+                            class="form-check-input"
+                            type="checkbox"
+                            name="{{ form.discounts.html_name }}"
+                            value="{{ discount.pk }}"
+                            id="discount_{{ discount.pk }}"
+                            {% if discount.pk|stringformat:"s" in selected_discount_ids %}checked{% endif %}>
+                          <label class="form-check-label" for="discount_{{ discount.pk }}">
+                            {{ discount.name }}
+                          </label>
+                        </div>
+                      {% empty %}
+                        <div class="text-muted small">Нет доступных групп скидок.</div>
+                      {% endfor %}
                     </div>
                   </div>
                 </div>

--- a/price_manager/product_price_manager/tests.py
+++ b/price_manager/product_price_manager/tests.py
@@ -217,6 +217,19 @@ class PriceTagAndPriceManagerRuntimeTests(TestCase):
         agg = PriceTag.get_aggfunc()
         self.assertEqual(agg([Decimal('1'), Decimal('3')]), Decimal('3'))
 
+    def test_pricetag_get_sprice_treats_null_source_as_fixed_price(self):
+        mp = self.create_mp('M-FIX-NULL', 'Fixed source is null')
+        pt = PriceTag.objects.create(
+            mp=mp,
+            source=None,
+            dest='basic_price',
+            markup=Decimal('0'),
+            increase=Decimal('0'),
+            fixed_price=Decimal('12990'),
+        )
+
+        self.assertEqual(pt.get_sprice(), Decimal('12990'))
+
     def test_pricemanager_delete_nulls_dest_price(self):
         mp = self.create_mp('M-3', 'Delete PM')
         SupplierProduct.objects.create(

--- a/price_manager/product_price_manager/tests.py
+++ b/price_manager/product_price_manager/tests.py
@@ -478,3 +478,34 @@ class UpdatePricesOrderingTests(TestCase):
         mp.refresh_from_db()
 
         self.assertEqual(mp.m_price, Decimal('777'))
+
+    def test_update_prices_applies_all_fixed_price_types_for_same_product(self):
+        mp = MainProduct.objects.create(
+            supplier=self.supplier,
+            article='ORDER-3',
+            name='All fixed types target',
+        )
+        PriceTag.objects.create(
+            mp=mp,
+            source='fixed_price',
+            dest='basic_price',
+            markup=Decimal('0'),
+            increase=Decimal('0'),
+            fixed_price=Decimal('300'),
+            p_manager=None,
+        )
+        PriceTag.objects.create(
+            mp=mp,
+            source=None,
+            dest='m_price',
+            markup=Decimal('0'),
+            increase=Decimal('0'),
+            fixed_price=Decimal('450'),
+            p_manager=None,
+        )
+
+        update_prices()
+        mp.refresh_from_db()
+
+        self.assertEqual(mp.basic_price, Decimal('300'))
+        self.assertEqual(mp.m_price, Decimal('450'))

--- a/price_manager/product_price_manager/tests.py
+++ b/price_manager/product_price_manager/tests.py
@@ -6,9 +6,8 @@ from main_product_manager.models import MainProduct
 from supplier_manager.models import Currency, Discount, Supplier
 from supplier_product_manager.models import SupplierProduct
 
-from .models import PriceManager, PriceTag
+from .models import PriceManager, PriceTag, update_prices
 from .views import PriceManagerCreate
-from .models import PriceManager
 
 
 class PriceManagerDiscountFilteringTests(TestCase):
@@ -399,3 +398,83 @@ class PriceManagerNameGenerationTests(TestCase):
         self.assertIn('100', generated_name)
         self.assertIn('200', generated_name)
         self.assertIn('Расчет:', generated_name)
+
+
+class UpdatePricesOrderingTests(TestCase):
+    def setUp(self):
+        self.currency = Currency.objects.create(name='USD', value=Decimal('2'))
+        self.supplier = Supplier.objects.create(
+            name='Supplier Ordering',
+            currency=self.currency,
+            price_update_rate='',
+            stock_update_rate='',
+            delivery_days_available=1,
+            delivery_days_navailable=2,
+        )
+
+    def test_update_prices_applies_fixed_after_supplier_markup(self):
+        mp = MainProduct.objects.create(
+            supplier=self.supplier,
+            article='ORDER-1',
+            name='Ordering target',
+        )
+        SupplierProduct.objects.create(
+            main_product=mp,
+            supplier=self.supplier,
+            article='ORDER-SP-1',
+            name='Ordering row',
+            supplier_price=Decimal('100'),
+        )
+        PriceManager.objects.create(
+            name='PM-MARKUP-FIRST',
+            supplier=self.supplier,
+            source='supplier_price',
+            dest='basic_price',
+            markup=Decimal('10'),
+            increase=Decimal('0'),
+        )
+        PriceManager.objects.create(
+            name='PM-FIXED-LAST',
+            supplier=self.supplier,
+            source='fixed_price',
+            dest='basic_price',
+            markup=Decimal('0'),
+            increase=Decimal('0'),
+            fixed_price=Decimal('555'),
+        )
+
+        update_prices()
+        mp.refresh_from_db()
+
+        self.assertEqual(mp.basic_price, Decimal('555'))
+
+    def test_update_prices_applies_fixed_pricetag_after_markup_pricetag(self):
+        mp = MainProduct.objects.create(
+            supplier=self.supplier,
+            article='ORDER-2',
+            name='Ordering by pricetag target',
+        )
+        PriceTag.objects.create(
+            mp=mp,
+            source='basic_price',
+            dest='m_price',
+            markup=Decimal('20'),
+            increase=Decimal('5'),
+            p_manager=None,
+        )
+        PriceTag.objects.create(
+            mp=mp,
+            source='fixed_price',
+            dest='m_price',
+            markup=Decimal('0'),
+            increase=Decimal('0'),
+            fixed_price=Decimal('777'),
+            p_manager=None,
+        )
+        mp.basic_price = Decimal('100')
+        mp.save(update_fields=['basic_price'])
+
+        update_prices()
+        mp.refresh_from_db()
+
+        self.assertEqual(mp.m_price, Decimal('777'))

--- a/price_manager/product_price_manager/views.py
+++ b/price_manager/product_price_manager/views.py
@@ -46,14 +46,6 @@ import pandas as pd
 import re
 import math
 
-
-def extract_selected_discount_ids(form):
-  values = form['discounts'].value() or []
-  if not isinstance(values, (list, tuple)):
-    values = [values]
-  return [str(value) for value in values if value not in (None, '')]
-
-
 class PriceManagerList(SingleTableView):
   '''Отображение наценок << /supplier/pricemanagers/<int:pk> >>'''
   model = PriceManager
@@ -174,7 +166,7 @@ class PriceManagerUpdate(SingleTableMixin, UpdateView):
     form = context['form']
     form.initial['price_fixed'] = self.instance.source=='fixed_price'
     form.fields['discounts'].queryset = self.instance.supplier.discounts.all()
-    context['selected_discount_ids'] = extract_selected_discount_ids(form)
+    context['selected_discount_ids'] = form['discounts'].value() or []
     return context
   def form_valid(self, form):
     cd = form.cleaned_data

--- a/price_manager/product_price_manager/views.py
+++ b/price_manager/product_price_manager/views.py
@@ -100,6 +100,13 @@ class PriceManagerCreate(CreateView):
       generated_name = f'{base_name} ({suffix})'
       suffix += 1
     return generated_name
+  @staticmethod
+  def _extract_selected_discount_ids(form):
+    values = form['discounts'].value() or []
+    if not isinstance(values, (list, tuple)):
+      values = [values]
+    return [str(value) for value in values if value not in (None, '')]
+
   def get_context_data(self, **kwargs) -> dict[str, Any]:
     context = super().get_context_data(**kwargs)
     supplier = Supplier.objects.get(pk=self.kwargs.get('pk'))
@@ -107,10 +114,7 @@ class PriceManagerCreate(CreateView):
     context['supplier'] = supplier
     form.fields['discounts'].queryset = supplier.discounts.all()
     form.fields['categories'].queryset = Category.objects.filter(pk__in=MainProduct.objects.select_related('supplierproducts', 'category').filter(supplierproducts__in=supplier.supplierproducts.all()).values('category'))
-    if form.is_bound:
-      context['selected_discount_ids'] = form.data.getlist(form.add_prefix('discounts'))
-    else:
-      context['selected_discount_ids'] = []
+    context['selected_discount_ids'] = self._extract_selected_discount_ids(form)
     return context
   def form_invalid(self, form):
     messages.error(self.request, 'Ошибка')
@@ -139,14 +143,8 @@ class PriceManagerCreate(CreateView):
       instance.source = 'fixed_price'
     instance.name = self._build_generated_name(supplier, cd)
     instance.save()
-    for discount in instance.discounts.filter(~Q(pk__in=cd['discounts'])):
-      instance.discounts.remove(discount)
-    for discount in cd['discounts']:
-      instance.discounts.add(discount)
-    for category in instance.categories.filter(~Q(pk__in=cd['categories'])):
-      instance.categories.remove(category)
-    for category in cd['categories']:
-      instance.categories.add(category)
+    instance.discounts.set(cd['discounts'])
+    instance.categories.set(cd['categories'])
     messages.success(self.request, 'Менеджер добавлен')
     return HttpResponseClientRefresh()
   
@@ -175,10 +173,7 @@ class PriceManagerUpdate(SingleTableMixin, UpdateView):
     form = context['form']
     form.initial['price_fixed'] = self.instance.source=='fixed_price'
     form.fields['discounts'].queryset = self.instance.supplier.discounts.all()
-    if form.is_bound:
-      context['selected_discount_ids'] = form.data.getlist(form.add_prefix('discounts'))
-    else:
-      context['selected_discount_ids'] = [str(pk) for pk in self.instance.discounts.values_list('pk', flat=True)]
+    context['selected_discount_ids'] = self._extract_selected_discount_ids(form)
     return context
   def form_valid(self, form):
     cd = form.cleaned_data
@@ -200,14 +195,8 @@ class PriceManagerUpdate(SingleTableMixin, UpdateView):
     if cd['price_fixed']:
       instance.source = 'fixed_price'
     instance.save()
-    for discount in instance.discounts.filter(~Q(pk__in=cd['discounts'])):
-      instance.discounts.remove(discount)
-    for discount in cd['discounts']:
-      instance.discounts.add(discount)
-    for category in instance.categories.filter(~Q(pk__in=cd['categories'])):
-      instance.categories.remove(category)
-    for category in cd['categories']:
-      instance.categories.add(category)
+    instance.discounts.set(cd['discounts'])
+    instance.categories.set(cd['categories'])
     messages.success(self.request, 'Обновления менеджера сохранены')
     return HttpResponseClientRefresh()
   

--- a/price_manager/product_price_manager/views.py
+++ b/price_manager/product_price_manager/views.py
@@ -103,9 +103,14 @@ class PriceManagerCreate(CreateView):
   def get_context_data(self, **kwargs) -> dict[str, Any]:
     context = super().get_context_data(**kwargs)
     supplier = Supplier.objects.get(pk=self.kwargs.get('pk'))
+    form = context['form']
     context['supplier'] = supplier
-    context['form'].fields['discounts'].queryset = supplier.discounts
-    context['form'].fields['categories'].queryset = Category.objects.filter(pk__in=MainProduct.objects.select_related('supplierproducts', 'category').filter(supplierproducts__in=supplier.supplierproducts.all()).values('category'))
+    form.fields['discounts'].queryset = supplier.discounts.all()
+    form.fields['categories'].queryset = Category.objects.filter(pk__in=MainProduct.objects.select_related('supplierproducts', 'category').filter(supplierproducts__in=supplier.supplierproducts.all()).values('category'))
+    if form.is_bound:
+      context['selected_discount_ids'] = form.data.getlist(form.add_prefix('discounts'))
+    else:
+      context['selected_discount_ids'] = []
     return context
   def form_invalid(self, form):
     messages.error(self.request, 'Ошибка')
@@ -167,8 +172,13 @@ class PriceManagerUpdate(SingleTableMixin, UpdateView):
     return super().post(request, *args, **kwargs)
   def get_context_data(self, **kwargs) -> dict[str, Any]:
     context = super().get_context_data(**kwargs)
-    context['form'].initial['price_fixed'] = self.instance.source=='fixed_price'
-    context['form'].fields['discounts'].queryset = self.instance.supplier.discounts
+    form = context['form']
+    form.initial['price_fixed'] = self.instance.source=='fixed_price'
+    form.fields['discounts'].queryset = self.instance.supplier.discounts.all()
+    if form.is_bound:
+      context['selected_discount_ids'] = form.data.getlist(form.add_prefix('discounts'))
+    else:
+      context['selected_discount_ids'] = [str(pk) for pk in self.instance.discounts.values_list('pk', flat=True)]
     return context
   def form_valid(self, form):
     cd = form.cleaned_data

--- a/price_manager/product_price_manager/views.py
+++ b/price_manager/product_price_manager/views.py
@@ -46,6 +46,14 @@ import pandas as pd
 import re
 import math
 
+
+def extract_selected_discount_ids(form):
+  values = form['discounts'].value() or []
+  if not isinstance(values, (list, tuple)):
+    values = [values]
+  return [str(value) for value in values if value not in (None, '')]
+
+
 class PriceManagerList(SingleTableView):
   '''Отображение наценок << /supplier/pricemanagers/<int:pk> >>'''
   model = PriceManager
@@ -100,13 +108,6 @@ class PriceManagerCreate(CreateView):
       generated_name = f'{base_name} ({suffix})'
       suffix += 1
     return generated_name
-  @staticmethod
-  def _extract_selected_discount_ids(form):
-    values = form['discounts'].value() or []
-    if not isinstance(values, (list, tuple)):
-      values = [values]
-    return [str(value) for value in values if value not in (None, '')]
-
   def get_context_data(self, **kwargs) -> dict[str, Any]:
     context = super().get_context_data(**kwargs)
     supplier = Supplier.objects.get(pk=self.kwargs.get('pk'))
@@ -114,7 +115,7 @@ class PriceManagerCreate(CreateView):
     context['supplier'] = supplier
     form.fields['discounts'].queryset = supplier.discounts.all()
     form.fields['categories'].queryset = Category.objects.filter(pk__in=MainProduct.objects.select_related('supplierproducts', 'category').filter(supplierproducts__in=supplier.supplierproducts.all()).values('category'))
-    context['selected_discount_ids'] = self._extract_selected_discount_ids(form)
+    context['selected_discount_ids'] = extract_selected_discount_ids(form)
     return context
   def form_invalid(self, form):
     messages.error(self.request, 'Ошибка')
@@ -173,7 +174,7 @@ class PriceManagerUpdate(SingleTableMixin, UpdateView):
     form = context['form']
     form.initial['price_fixed'] = self.instance.source=='fixed_price'
     form.fields['discounts'].queryset = self.instance.supplier.discounts.all()
-    context['selected_discount_ids'] = self._extract_selected_discount_ids(form)
+    context['selected_discount_ids'] = extract_selected_discount_ids(form)
     return context
   def form_valid(self, form):
     cd = form.cleaned_data


### PR DESCRIPTION
### Motivation
- Fixed product prices were being ignored in the bulk update flow because `fixed_price` rules were not applied in `update_prices()` order.
- The expected pipeline is to apply supplier/main-product markups first and then override with fixed product prices where configured.

### Description
- Added a pass over `PriceManager` rows with `source='fixed_price'` in `update_prices()` after the `SP_PRICES` and `MP_PRICES` passes by calling `pm.apply()` for those managers.
- Added processing of standalone `PriceTag` entries with `source='fixed_price'` at the end of the pricetag bulk-update sequence and bulk-updated resulting `MainProduct` instances.
- Imported `update_prices` into the tests module and added `UpdatePricesOrderingTests` containing two regression tests that validate manager-level and pricetag-level ordering behavior.

### Testing
- Added unit tests in `price_manager/product_price_manager/tests.py` (`UpdatePricesOrderingTests.test_update_prices_applies_fixed_after_supplier_markup` and `test_update_prices_applies_fixed_pricetag_after_markup_pricetag`).
- Attempted to run the affected tests with `python manage.py test ...`, but execution failed due to missing test environment dependency (`ModuleNotFoundError: No module named 'django'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea45c81050832d847f8812eba04b19)