### PR TITLE
Dataframe form: HTMX POST + dynamic sheet/column choices from uploaded file

### DIFF
--- a/price_manager/dataframe/forms.py
+++ b/price_manager/dataframe/forms.py
@@ -3,8 +3,10 @@ from crispy_forms.layout import Field, Layout, Submit, HTML
 from django import forms
 from django_jsonform.forms.fields import JSONFormField
 from django.urls import reverse
+import pandas as pd
+from urllib.parse import urlparse
 
-from .models import Dataframe
+from .models import Dataframe, FileModel
 
 
 class Form(forms.ModelForm):
@@ -20,13 +22,13 @@ class Form(forms.ModelForm):
     
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self._hydrate_dynamic_schemas()
         self.helper = FormHelper(self)
-        
+
         self.helper.attrs = {
-            'hx-get':reverse('dataframe:create'),
-            'hx-swap':'innerHTML',
-            'hx-trigger':'input changed delay:2s, change delay:2s, submit',
-            'hx-push-url':'true'
+            "hx-post": reverse("dataframe:create") if not self.instance.pk else reverse("dataframe:update", kwargs={"slug": self.instance.slug}),
+            "hx-trigger": "change delay:300ms, submit",
+            "hx-push-url": "false",
         }
         self.helper.layout = Layout(
             Field('name'),
@@ -34,3 +36,52 @@ class Form(forms.ModelForm):
             Field('cols'),
             Submit(name='save', value="Сохранить")
         )
+
+    def _hydrate_dynamic_schemas(self):
+        file_obj = None
+        conf = self.initial.get("conf") or getattr(self.instance, "conf", None) or {}
+        source = conf.get("source", {}) if isinstance(conf, dict) else {}
+        file_url = source.get("file")
+        if source.get("type") == "file" and file_url:
+            parsed = urlparse(file_url)
+            source_path = parsed.path if parsed.scheme else file_url
+            file_obj = FileModel.objects.filter(file=source_path.lstrip("/")).first()
+
+        if not file_obj:
+            return
+
+        sheets = self._get_sheet_names(file_obj.file.path)
+        columns = self._get_columns(file_obj.file.path, sheets[0] if sheets else None)
+
+        conf_schema = Dataframe.CONF_SCHEMA.copy()
+        one_of = conf_schema.get("properties", {}).get("source", {}).get("oneOf", [])
+        if one_of:
+            file_source_schema = one_of[0]
+            file_source_schema["properties"]["sheet"]["choices"] = sheets
+        self.fields["conf"].schema = conf_schema
+
+        col_schema = Dataframe.COL_SCHEMA.copy()
+        col_schema["keys"]["column"]["choices"] = columns
+        cols_schema = Dataframe.COLS_SCHEMA.copy()
+        cols_schema["items"] = col_schema
+        self.fields["cols"].schema = cols_schema
+
+    @staticmethod
+    def _get_sheet_names(file_path):
+        if file_path.endswith(".csv"):
+            return ["Sheet1"]
+        try:
+            return pd.ExcelFile(file_path, engine="calamine").sheet_names
+        except Exception:
+            return []
+
+    @staticmethod
+    def _get_columns(file_path, sheet_name=None):
+        try:
+            if file_path.endswith(".csv"):
+                df = pd.read_csv(file_path, dtype=str)
+            else:
+                df = pd.read_excel(file_path, engine="calamine", dtype=str, sheet_name=sheet_name or 0)
+            return [str(col) for col in df.columns]
+        except Exception:
+            return []


### PR DESCRIPTION
### Motivation
- Allow the Dataframe creation/update form to submit asynchronously via HTMX POST so the form can be saved immediately after a file is selected and the user can be redirected to the Update page.
- Populate JSON schema choices (sheet names and column names) based on the file the user uploaded so downstream configuration fields are prefilled and constrained.

### Description
- Changed the crispy form helper attrs to use HTMX `hx-post` and a change/submit trigger so form interactions post to the create/update endpoints instead of using `hx-get`.
- Added `_hydrate_dynamic_schemas` to `dataframe/forms.py` to detect a file referenced in `conf.source.file`, resolve the `FileModel` and inject sheet `choices` into `conf` schema and column `choices` into `cols` schema.
- Implemented `_get_sheet_names` and `_get_columns` helpers that read Excel (via `pandas` + `calamine` engine) and CSV with safe fallbacks returning empty lists on error.
- Imported `pandas`, `urlparse`, and `FileModel` and used `urlparse` to map `conf` file URL to the stored `FileModel` path.

### Testing
- Compiled the modified file with `python -m compileall price_manager/dataframe/forms.py` which completed successfully.
- No additional automated unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f377f2a2e4832d95c77f913db8f208)