### PR TITLE
Add SelectFile modal and reusable `{% fileupload %}` tag

### DIFF
--- a/price_manager/core/templates/core/partials/fileupload_tag.html
+++ b/price_manager/core/templates/core/partials/fileupload_tag.html
@@ -1,0 +1,16 @@
+<div id="file-upload-field-wrapper"
+     hx-trigger="file:selected from:body"
+     hx-get="{% url 'fileupload-field' %}"
+     hx-vals='js:{pk: event.detail.pk, name: "{{ name }}"}'
+     hx-swap="outerHTML">
+  <button type="button"
+          class="btn btn-success"
+          data-bs-toggle="modal"
+          data-bs-target="#modal-container"
+          hx-get="{% url 'select-file' %}"
+          hx-target="#modal-container .modal-content"
+          hx-swap="innerHTML"
+          hx-on::after-request="if(event.detail.successful){ document.body.dispatchEvent(new CustomEvent('file:selected',{detail:{pk: event.detail.xhr.responseText}})); }">
+    Загрузить файл
+  </button>
+</div>

--- a/price_manager/core/templatetags/special_tags.py
+++ b/price_manager/core/templatetags/special_tags.py
@@ -3,6 +3,11 @@ from product_price_manager.models import PRICE_TYPES
 
 register = template.Library()
 
+
+@register.inclusion_tag('core/partials/fileupload_tag.html')
+def fileupload(name='file_pk'):
+  return {'name': name}
+
 @register.filter
 def get_item(dictionary, key):
   return dictionary.get(key, "")

--- a/price_manager/file_manager/templates/file_manager/fileupload_hidden_field.html
+++ b/price_manager/file_manager/templates/file_manager/fileupload_hidden_field.html
@@ -1,0 +1,4 @@
+<div id="file-upload-field-wrapper">
+  <input type="hidden" name="{{ name }}" value="{{ pk }}">
+  <span class="text-success">Файл выбран (ID: {{ pk }})</span>
+</div>

--- a/price_manager/file_manager/templates/file_manager/select_file_modal.html
+++ b/price_manager/file_manager/templates/file_manager/select_file_modal.html
@@ -1,0 +1,46 @@
+<div class="modal-header">
+  <h5 class="modal-title">Выбор файла</h5>
+  <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+</div>
+<div class="modal-body">
+  <ul class="nav nav-tabs mb-3" id="fileTabs" role="tablist">
+    <li class="nav-item" role="presentation">
+      <button class="nav-link active" id="upload-tab" data-bs-toggle="tab" data-bs-target="#upload-pane" type="button" role="tab">Загрузить</button>
+    </li>
+    <li class="nav-item" role="presentation">
+      <button class="nav-link" id="select-tab" data-bs-toggle="tab" data-bs-target="#select-pane" type="button" role="tab">Выбрать загруженный</button>
+    </li>
+  </ul>
+
+  <div class="tab-content">
+    <div class="tab-pane fade show active" id="upload-pane" role="tabpanel" aria-labelledby="upload-tab">
+      <form method="post" enctype="multipart/form-data"
+            hx-post="{% url 'select-file' %}"
+            hx-target="#file-upload-field-wrapper"
+            hx-swap="outerHTML"
+            hx-on::after-request="if(event.detail.successful){ bootstrap.Modal.getInstance(document.getElementById('modal-container'))?.hide(); }">
+        {% csrf_token %}
+        {{ form.as_p }}
+        <button type="submit" class="btn btn-primary">Добавить</button>
+      </form>
+    </div>
+
+    <div class="tab-pane fade" id="select-pane" role="tabpanel" aria-labelledby="select-tab">
+      <form method="post"
+            hx-post="{% url 'select-file' %}"
+            hx-target="#file-upload-field-wrapper"
+            hx-swap="outerHTML"
+            hx-on::after-request="if(event.detail.successful){ bootstrap.Modal.getInstance(document.getElementById('modal-container'))?.hide(); }">
+        {% csrf_token %}
+        <label class="form-label" for="selected_file_pk">Файл</label>
+        <select class="form-select mb-3" id="selected_file_pk" name="selected_file_pk" required>
+          <option value="" selected disabled>Выберите файл</option>
+          {% for file in files %}
+            <option value="{{ file.pk }}">#{{ file.pk }} — {{ file.file.name }}</option>
+          {% endfor %}
+        </select>
+        <button type="submit" class="btn btn-primary">Добавить</button>
+      </form>
+    </div>
+  </div>
+</div>

--- a/price_manager/file_manager/views.py
+++ b/price_manager/file_manager/views.py
@@ -1,5 +1,7 @@
 
-from django.views.generic import CreateView
+from django.http import HttpResponse
+from django.shortcuts import render
+from django.views.generic import CreateView, TemplateView
 from django.urls import reverse
 
 # Импорты моделей, функций, форм, таблиц
@@ -26,3 +28,34 @@ class FileUpload(CreateView):
       self.success_url = reverse(self.kwargs['name'],
                                 kwargs={'f_id':f_id})
     return super().form_valid(form)
+
+
+class SelectFile(TemplateView):
+  template_name = 'file_manager/select_file_modal.html'
+
+  def get_context_data(self, **kwargs):
+    context = super().get_context_data(**kwargs)
+    context['form'] = FileForm()
+    context['files'] = FileModel.objects.order_by('-pk')
+    return context
+
+  def post(self, request, *args, **kwargs):
+    selected_pk = request.POST.get('selected_file_pk')
+    if selected_pk:
+      return HttpResponse(selected_pk)
+
+    form = FileForm(request.POST, request.FILES)
+    if form.is_valid():
+      instance = form.save()
+      return HttpResponse(str(instance.pk))
+
+    context = self.get_context_data(**kwargs)
+    context['form'] = form
+    return self.render_to_response(context, status=400)
+
+
+def fileupload_field(request):
+  return render(request, 'file_manager/fileupload_hidden_field.html', {
+    'pk': request.GET.get('pk', ''),
+    'name': request.GET.get('name', 'file_pk'),
+  })

--- a/price_manager/price_manager/urls.py
+++ b/price_manager/price_manager/urls.py
@@ -66,6 +66,8 @@ urlpatterns = [
 
 
     path('upload/<str:name>/<int:id>/', fm_views.FileUpload.as_view(), name='upload'),
+    path('files/select/', fm_views.SelectFile.as_view(), name='select-file'),
+    path('files/field/', fm_views.fileupload_field, name='fileupload-field'),
 
     path('shopping-tabs/', views.ShoppingTabListView.as_view(), name='shopping-tab-list'),
     path('shopping-tabs/<int:pk>/', views.ShoppingTabDetailView.as_view(), name='shopping-tab-detail'),


### PR DESCRIPTION
## Summary
Implemented a reusable file selection/upload flow with modal UI and HTMX integration.

### What was added
1. **`SelectFile` modal view** (`file_manager.views.SelectFile`)
   - Opens as a modal and supports two modes:
     - Upload a new `FileModel`
     - Select an existing uploaded file
   - On submit returns plain `HttpResponse` containing the selected/created file `pk`.

2. **Tab support in modal**
   - New template: `file_manager/select_file_modal.html`
   - Includes tabs:
     - `Загрузить`
     - `Выбрать загруженный`

3. **Template tag `{% fileupload %}`**
   - Added as inclusion tag in `core.templatetags.special_tags`
   - Renders a `Загрузить файл` button.
   - Button opens `SelectFile` modal.
   - After file selection/upload, button area is replaced with hidden input containing selected file pk.

4. **Auxiliary endpoint for hidden input rendering**
   - Added `fileupload_field` view and template `fileupload_hidden_field.html`.

5. **URL routes**
   - `files/select/` → `select-file`
   - `files/field/` → `fileupload-field`

## Files touched
- `price_manager/file_manager/views.py`
- `price_manager/price_manager/urls.py`
- `price_manager/core/templatetags/special_tags.py`
- `price_manager/core/templates/core/partials/fileupload_tag.html`
- `price_manager/file_manager/templates/file_manager/select_file_modal.html`
- `price_manager/file_manager/templates/file_manager/fileupload_hidden_field.html`

## Notes
- Designed for existing Bootstrap modal container with id `modal-container` and HTMX usage patterns already present in the project.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5bbed56a4832db3070a86836ab9ad)