### PR TITLE
Add SelectFile modal workflow and `{% fileupload %}` tag

### DIFF
--- a/price_manager/core/templates/file_manager/select_file_modal.html
+++ b/price_manager/core/templates/file_manager/select_file_modal.html
@@ -1,0 +1,36 @@
+<div class="modal-header">
+  <h5 class="modal-title">Выбор файла</h5>
+  <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+</div>
+<div class="modal-body">
+  <ul class="nav nav-tabs mb-3" role="tablist">
+    <li class="nav-item" role="presentation">
+      <button class="nav-link active" data-bs-toggle="tab" data-bs-target="#upload-file-tab" type="button" role="tab">Загрузить</button>
+    </li>
+    <li class="nav-item" role="presentation">
+      <button class="nav-link" data-bs-toggle="tab" data-bs-target="#existing-file-tab" type="button" role="tab">Выбрать загруженный</button>
+    </li>
+  </ul>
+
+  <div class="tab-content">
+    <div class="tab-pane fade show active" id="upload-file-tab" role="tabpanel">
+      <form method="post" enctype="multipart/form-data" hx-post="{% url 'select-file' %}" hx-target="this" hx-swap="none"
+            onhtmx:afterRequest="window.handleFileSelected(event)">
+        {% csrf_token %}
+        <input type="hidden" name="action" value="upload">
+        {{ upload_form.as_p }}
+        <button type="submit" class="btn btn-primary">Добавить</button>
+      </form>
+    </div>
+
+    <div class="tab-pane fade" id="existing-file-tab" role="tabpanel">
+      <form method="post" hx-post="{% url 'select-file' %}" hx-target="this" hx-swap="none"
+            onhtmx:afterRequest="window.handleFileSelected(event)">
+        {% csrf_token %}
+        <input type="hidden" name="action" value="select">
+        {{ existing_form.as_p }}
+        <button type="submit" class="btn btn-primary">Выбрать</button>
+      </form>
+    </div>
+  </div>
+</div>

--- a/price_manager/core/templatetags/special_tags.py
+++ b/price_manager/core/templatetags/special_tags.py
@@ -58,3 +58,44 @@ def values_list(queryset, value):
 @register.filter
 def intersection(a,b):
   return not set(a).intersection(set(b)) == set()
+from django.utils.safestring import mark_safe
+from django.urls import reverse
+
+@register.simple_tag
+def fileupload(input_name='file_id', button_text='Загрузить файл'):
+  modal_id = f'file-upload-modal-{input_name}'.replace('[', '-').replace(']', '-')
+  trigger_id = f'file-upload-trigger-{input_name}'.replace('[', '-').replace(']', '-')
+  hidden_id = f'file-upload-hidden-{input_name}'.replace('[', '-').replace(']', '-')
+  html = f"""
+<button type=\"button\" id=\"{trigger_id}\" class=\"btn btn-outline-primary\"
+        data-bs-toggle=\"modal\" data-bs-target=\"#{modal_id}\"
+        hx-get=\"{reverse('select-file')}\"
+        hx-target=\"#{modal_id} .modal-content\" hx-swap=\"innerHTML\">{button_text}</button>
+
+<input type=\"hidden\" id=\"{hidden_id}\" name=\"{input_name}\" value=\"\" />
+
+<div id=\"{modal_id}\" class=\"modal fade\" tabindex=\"-1\" aria-hidden=\"true\">
+  <div class=\"modal-dialog modal-lg\">
+    <div class=\"modal-content\"></div>
+  </div>
+</div>
+
+<script>
+window.handleFileSelected = function(event) {{
+  const xhr = event.detail.xhr;
+  if (!xhr || xhr.status < 200 || xhr.status >= 300) return;
+  const filePk = (xhr.responseText || '').trim();
+  if (!filePk) return;
+  const hiddenInput = document.getElementById('{hidden_id}');
+  const triggerButton = document.getElementById('{trigger_id}');
+  if (hiddenInput) hiddenInput.value = filePk;
+  if (triggerButton) triggerButton.remove();
+  const modalEl = document.getElementById('{modal_id}');
+  if (modalEl && window.bootstrap) {{
+    const modalInstance = bootstrap.Modal.getInstance(modalEl);
+    if (modalInstance) modalInstance.hide();
+  }}
+}};
+</script>
+"""
+  return mark_safe(html)

--- a/price_manager/file_manager/views.py
+++ b/price_manager/file_manager/views.py
@@ -1,10 +1,19 @@
 
-from django.views.generic import CreateView
+from django import forms
+from django.http import HttpResponse
+from django.views.generic import CreateView, TemplateView
 from django.urls import reverse
 
 # Импорты моделей, функций, форм, таблиц
 from file_manager.models import FileModel
 from .forms import *
+
+
+class SelectExistingFileForm(forms.Form):
+  file_id = forms.ModelChoiceField(
+      queryset=FileModel.objects.all().order_by('-id'),
+      label='Уже загруженный файл'
+  )
 
 # Обработка файлов
 
@@ -26,3 +35,31 @@ class FileUpload(CreateView):
       self.success_url = reverse(self.kwargs['name'],
                                 kwargs={'f_id':f_id})
     return super().form_valid(form)
+
+
+class SelectFile(TemplateView):
+  template_name = 'file_manager/select_file_modal.html'
+
+  def get_context_data(self, **kwargs):
+    context = super().get_context_data(**kwargs)
+    context['upload_form'] = FileForm()
+    context['existing_form'] = SelectExistingFileForm()
+    return context
+
+  def post(self, request, *args, **kwargs):
+    action = request.POST.get('action')
+    if action == 'upload':
+      form = FileForm(request.POST, request.FILES)
+      if form.is_valid():
+        file_instance = form.save()
+        return HttpResponse(str(file_instance.pk))
+    elif action == 'select':
+      form = SelectExistingFileForm(request.POST)
+      if form.is_valid():
+        file_instance = form.cleaned_data['file_id']
+        return HttpResponse(str(file_instance.pk))
+
+    context = self.get_context_data()
+    context['upload_form'] = form if action == 'upload' else FileForm()
+    context['existing_form'] = form if action == 'select' else SelectExistingFileForm()
+    return self.render_to_response(context, status=400)

--- a/price_manager/price_manager/urls.py
+++ b/price_manager/price_manager/urls.py
@@ -66,6 +66,7 @@ urlpatterns = [
 
 
     path('upload/<str:name>/<int:id>/', fm_views.FileUpload.as_view(), name='upload'),
+    path('select-file/', fm_views.SelectFile.as_view(), name='select-file'),
 
     path('shopping-tabs/', views.ShoppingTabListView.as_view(), name='shopping-tab-list'),
     path('shopping-tabs/<int:pk>/', views.ShoppingTabDetailView.as_view(), name='shopping-tab-detail'),


### PR DESCRIPTION
## Summary
- Added a new `SelectFile` modal view for `FileModel` selection/upload.
- Upload tab creates a new file and returns HTTP response with created file `pk`.
- Added a second tab to choose an already uploaded file and return its `pk`.
- Added `{% fileupload %}` template tag that renders a "Загрузить файл" button, opens `SelectFile`, and on selection sets hidden input with file `pk` and removes the button.
- Registered new route `select-file/`.

## Changed files
- `price_manager/file_manager/views.py`
- `price_manager/price_manager/urls.py`
- `price_manager/core/templatetags/special_tags.py`
- `price_manager/core/templates/file_manager/select_file_modal.html`

## Notes
- Implemented with HTMX + Bootstrap modal flow consistent with existing templates.
- Added basic compile-time check with `python -m py_compile` for touched python files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5bbed56a4832db3070a86836ab9ad)