### PR TITLE
Add SelectFile modal upload flow for dataframe files

### DIFF
--- a/price_manager/dataframe/forms.py
+++ b/price_manager/dataframe/forms.py
@@ -2,7 +2,7 @@ from django import forms
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Layout, Div, Field, HTML
 
-from .models import Dataframe, FileModel
+from .models import FileModel
 
 
 class FileForm(forms.ModelForm):

--- a/price_manager/dataframe/forms.py
+++ b/price_manager/dataframe/forms.py
@@ -3,3 +3,9 @@ from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Layout, Div, Field, HTML
 
 from .models import Dataframe, FileModel
+
+
+class FileForm(forms.ModelForm):
+    class Meta:
+        model = FileModel
+        fields = ("file",)

--- a/price_manager/dataframe/templates/dataframe/partials/file_select_modal.html
+++ b/price_manager/dataframe/templates/dataframe/partials/file_select_modal.html
@@ -1,4 +1,4 @@
-<form method="post" action="{% url 'dataframe:fileselect' %}" enctype="multipart/form-data">
+<form method="post" action="{% url 'dataframe:filesselect' %}" enctype="multipart/form-data">
   {% csrf_token %}
   {{ form.file.label_tag }}
   {{ form.file }}

--- a/price_manager/dataframe/templates/dataframe/partials/file_select_modal.html
+++ b/price_manager/dataframe/templates/dataframe/partials/file_select_modal.html
@@ -1,0 +1,6 @@
+<form method="post" action="{% url 'dataframe:fileselect' %}" enctype="multipart/form-data">
+  {% csrf_token %}
+  {{ form.file.label_tag }}
+  {{ form.file }}
+  <button type="submit">Добавить</button>
+</form>

--- a/price_manager/dataframe/urls.py
+++ b/price_manager/dataframe/urls.py
@@ -1,7 +1,9 @@
+from django.urls import path
 
-from django.urls import include, path
+from .views import fileupload as fm_views
 
 app_name = 'dataframe'
 
 urlpatterns = [
+    path('files/select/', fm_views.SelectFile.as_view(), name='fileselect'),
 ]

--- a/price_manager/dataframe/urls.py
+++ b/price_manager/dataframe/urls.py
@@ -1,9 +1,9 @@
 from django.urls import path
 
-from .views import fileupload as fm_views
+from .views import SelectFile
 
 app_name = 'dataframe'
 
 urlpatterns = [
-    path('files/select/', fm_views.SelectFile.as_view(), name='fileselect'),
+    path('files/select/', SelectFile.as_view(), name='filesselect'),
 ]

--- a/price_manager/dataframe/views/__init__.py
+++ b/price_manager/dataframe/views/__init__.py
@@ -1,0 +1,1 @@
+from fileupload import SelectFile

--- a/price_manager/dataframe/views/fileupload.py
+++ b/price_manager/dataframe/views/fileupload.py
@@ -2,7 +2,7 @@ from django.http import JsonResponse
 from django.shortcuts import render
 from django.views import View
 
-from ..forms import FileForm
+from forms import FileForm
 
 
 class SelectFile(View):

--- a/price_manager/dataframe/views/fileupload.py
+++ b/price_manager/dataframe/views/fileupload.py
@@ -1,8 +1,21 @@
-from django.views.generic import CreateView
-from django.shortcuts import redirect
-from django.urls import reverse
+from django.http import JsonResponse
+from django.shortcuts import render
+from django.views import View
 
-from models import FileModel
+from ..forms import FileForm
 
-from forms import FileForm
 
+class SelectFile(View):
+    template_name = "dataframe/partials/file_select_modal.html"
+
+    def get(self, request, *args, **kwargs):
+        form = FileForm()
+        return render(request, self.template_name, {"form": form})
+
+    def post(self, request, *args, **kwargs):
+        form = FileForm(request.POST, request.FILES)
+        if form.is_valid():
+            file_obj = form.save()
+            return JsonResponse({"pk": file_obj.pk})
+
+        return JsonResponse({"errors": form.errors}, status=400)


### PR DESCRIPTION
### Motivation
- Provide a small modal-driven flow to upload dataframe files and return the created file identifier for frontend use.
- Centralize server-side validation and saving of uploaded files using existing `FileModel`.

### Description
- Add a class-based `SelectFile` view in `price_manager/dataframe/views/fileupload.py` that implements `GET` to render a modal template and `POST` to validate `FileForm`, save `FileModel`, and return `{ "pk": ... }` as JSON.
- Add a `FileForm` `ModelForm` for `FileModel` in `price_manager/dataframe/forms.py` with the `file` field.
- Add the template `price_manager/dataframe/templates/dataframe/partials/file_select_modal.html` with a `multipart/form-data` upload form and a submit button labeled “Добавить”.
- Register the endpoint in `price_manager/dataframe/urls.py` as `path('files/select/', fm_views.SelectFile.as_view(), name='fileselect')`.

### Testing
- Ran `python -m compileall price_manager/dataframe` and the files in `price_manager/dataframe` compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5c2587f24832db69ac06c8b86c812)