### PR TITLE
Add tabbed SelectFile modal with existing-file picker and unified response

### DIFF
--- a/price_manager/dataframe/templates/dataframe/partials/file_select_modal.html
+++ b/price_manager/dataframe/templates/dataframe/partials/file_select_modal.html
@@ -1,6 +1,52 @@
-<form method="post" action="{% url 'dataframe:filesselect' %}" enctype="multipart/form-data">
-  {% csrf_token %}
-  {{ form.file.label_tag }}
-  {{ form.file }}
-  <button type="submit">Добавить</button>
-</form>
+<ul class="nav nav-tabs" id="selectFileTabs" role="tablist">
+  <li class="nav-item" role="presentation">
+    <button class="nav-link active" id="new-file-tab" data-bs-toggle="tab" data-bs-target="#new-file-pane" type="button" role="tab" aria-controls="new-file-pane" aria-selected="true">Загрузить новый файл</button>
+  </li>
+  <li class="nav-item" role="presentation">
+    <button class="nav-link" id="existing-file-tab" data-bs-toggle="tab" data-bs-target="#existing-file-pane" type="button" role="tab" aria-controls="existing-file-pane" aria-selected="false">Выбрать существующий файл</button>
+  </li>
+</ul>
+
+<div class="tab-content pt-3" id="selectFileTabsContent">
+  <div class="tab-pane fade show active" id="new-file-pane" role="tabpanel" aria-labelledby="new-file-tab">
+    <form method="post" action="{% url 'dataframe:filesselect' %}" enctype="multipart/form-data">
+      {% csrf_token %}
+      {{ form.file.label_tag }}
+      {{ form.file }}
+      <button type="submit" class="btn btn-primary mt-2">Добавить</button>
+    </form>
+  </div>
+
+  <div class="tab-pane fade" id="existing-file-pane" role="tabpanel" aria-labelledby="existing-file-tab">
+    {% if files %}
+      <ul class="list-group">
+        {% for item in files %}
+          <li class="list-group-item d-flex justify-content-between align-items-center">
+            <span>{{ item.file.name }}</span>
+            <form method="post" action="{% url 'dataframe:filesselect' %}">
+              {% csrf_token %}
+              <input type="hidden" name="existing_file_pk" value="{{ item.pk }}">
+              <button type="submit" class="btn btn-outline-primary btn-sm">Выбрать</button>
+            </form>
+          </li>
+        {% endfor %}
+      </ul>
+
+      {% if page_obj.has_other_pages %}
+        <nav class="mt-3" aria-label="Pagination for existing files">
+          <ul class="pagination pagination-sm mb-0">
+            {% if page_obj.has_previous %}
+              <li class="page-item"><a class="page-link" href="?page={{ page_obj.previous_page_number }}">Назад</a></li>
+            {% endif %}
+            <li class="page-item disabled"><span class="page-link">{{ page_obj.number }}/{{ page_obj.paginator.num_pages }}</span></li>
+            {% if page_obj.has_next %}
+              <li class="page-item"><a class="page-link" href="?page={{ page_obj.next_page_number }}">Вперёд</a></li>
+            {% endif %}
+          </ul>
+        </nav>
+      {% endif %}
+    {% else %}
+      <p class="text-muted mb-0">Существующие файлы не найдены.</p>
+    {% endif %}
+  </div>
+</div>

--- a/price_manager/dataframe/views/fileupload.py
+++ b/price_manager/dataframe/views/fileupload.py
@@ -1,21 +1,47 @@
 from django.http import JsonResponse
+from django.core.paginator import Paginator
 from django.shortcuts import render
 from django.views import View
 
-from forms import FileForm
+from ..forms import FileForm
+from ..models import FileModel
 
 
 class SelectFile(View):
     template_name = "dataframe/partials/file_select_modal.html"
+    per_page = 10
+
+    @staticmethod
+    def _success_response(file_obj):
+        return JsonResponse({"pk": file_obj.pk})
 
     def get(self, request, *args, **kwargs):
         form = FileForm()
-        return render(request, self.template_name, {"form": form})
+        files_queryset = FileModel.objects.order_by("-id")
+        paginator = Paginator(files_queryset, self.per_page)
+        page_obj = paginator.get_page(request.GET.get("page"))
+        context = {
+            "form": form,
+            "page_obj": page_obj,
+            "files": page_obj.object_list,
+        }
+        return render(request, self.template_name, context)
 
     def post(self, request, *args, **kwargs):
+        existing_file_pk = request.POST.get("existing_file_pk")
+        if existing_file_pk:
+            try:
+                file_obj = FileModel.objects.get(pk=existing_file_pk)
+            except (ValueError, TypeError):
+                return JsonResponse({"errors": {"existing_file_pk": ["Некорректный идентификатор файла."]}}, status=400)
+            except FileModel.DoesNotExist:
+                return JsonResponse({"errors": {"existing_file_pk": ["Файл не найден."]}}, status=404)
+
+            return self._success_response(file_obj)
+
         form = FileForm(request.POST, request.FILES)
         if form.is_valid():
             file_obj = form.save()
-            return JsonResponse({"pk": file_obj.pk})
+            return self._success_response(file_obj)
 
         return JsonResponse({"errors": form.errors}, status=400)


### PR DESCRIPTION
### Motivation
- Сделать в модальном окне `SelectFile` удобный UI с двумя сценариями: загрузка нового файла и выбор уже загруженного.
- Передавать список существующих файлов в `GET` для показа последних записей и поддержать навигацию по ним.
- Унифицировать контракт ответа для фронта и добавить простую валидацию выбора существующего файла с корректными HTTP-кодами.

### Description
- Обновлён шаблон `dataframe/partials/file_select_modal.html`: добавлены Bootstrap tabs «Загрузить новый файл» и «Выбрать существующий файл», список существующих файлов с кнопкой `Выбрать` и простая пагинация.
- Обновлён view `SelectFile` (`price_manager/dataframe/views/fileupload.py`): `get` теперь формирует `files`, `page_obj` (используется `Paginator`) и передаёт их в контекст шаблона.
- В `post` добавлена поддержка `existing_file_pk` — при наличии этого поля выполняется поиск `FileModel` и возвращается унифицированный JSON-ответ `{"pk": <pk>}`; добавлена валидация с ответами `400` для некорректного идентификатора и `404` если файл не найден.
- Мелкие правки импорта (`..forms`, `..models`), введено поле `per_page` и вспомогательный метод `_success_response` для единообразного ответа.

### Testing
- Запущена компиляция модуля: `python -m compileall price_manager/dataframe/views/fileupload.py`, проверка прошла успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5c3f9d384832da76683f508420568)