### PR TITLE
Add reusable `{% fileupload %}` template tag for dataframe forms

### DIFF
--- a/price_manager/dataframe/templates/dataframe/create.html
+++ b/price_manager/dataframe/templates/dataframe/create.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% load fileupload_tags %}
 
 {% block title %}
 Новый датафрейм
@@ -10,7 +11,20 @@
   <form method="post">
     {% csrf_token %}
     {{ form.as_p }}
+    {% fileupload field_name='file_pk' button_text='Загрузить файл' %}
     <button type="submit" value="add">Сохранить</button>
   </form>
+</div>
+
+<div class="modal fade" id="SelectFile" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Выбор файла</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body"></div>
+    </div>
+  </div>
 </div>
 {% endblock %}

--- a/price_manager/dataframe/templates/dataframe/tags/fileupload.html
+++ b/price_manager/dataframe/templates/dataframe/tags/fileupload.html
@@ -1,0 +1,107 @@
+{% load static %}
+<div class="fileupload-component" data-field-name="{{ field_name }}">
+  <div class="fileupload-trigger {% if initial_pk %}d-none{% endif %}">
+    <button
+      type="button"
+      class="btn btn-outline-primary"
+      data-bs-toggle="modal"
+      data-bs-target="#SelectFile"
+      hx-get="{% url 'dataframe:filesselect' %}"
+      hx-target="#SelectFile .modal-body"
+      hx-swap="innerHTML"
+    >
+      {{ button_text }}
+    </button>
+  </div>
+
+  <div class="fileupload-hidden-input-container">
+    {% if initial_pk %}
+      <input type="hidden" name="{{ field_name }}" value="{{ initial_pk }}">
+    {% endif %}
+  </div>
+</div>
+
+<script>
+  (function() {
+    if (window.__fileuploadSelectFileBound) {
+      return;
+    }
+    window.__fileuploadSelectFileBound = true;
+
+    const modalEl = document.getElementById('SelectFile');
+    if (!modalEl) {
+      return;
+    }
+
+    const handleResult = (payload) => {
+      if (!payload || !payload.pk) {
+        return;
+      }
+
+      const activeComponent = document.querySelector('.fileupload-component.fileupload-active')
+        || document.querySelector('.fileupload-component');
+
+      if (!activeComponent) {
+        return;
+      }
+
+      const fieldName = activeComponent.dataset.fieldName || 'file_pk';
+      const hiddenContainer = activeComponent.querySelector('.fileupload-hidden-input-container');
+      const trigger = activeComponent.querySelector('.fileupload-trigger');
+
+      hiddenContainer.innerHTML = `<input type="hidden" name="${fieldName}" value="${payload.pk}">`;
+      trigger.classList.add('d-none');
+
+      const modalInstance = bootstrap.Modal.getInstance(modalEl);
+      if (modalInstance) {
+        modalInstance.hide();
+      }
+
+      activeComponent.classList.remove('fileupload-active');
+    };
+
+    document.addEventListener('click', (event) => {
+      const component = event.target.closest('.fileupload-component');
+      if (!component) {
+        return;
+      }
+
+      document
+        .querySelectorAll('.fileupload-component.fileupload-active')
+        .forEach((item) => item.classList.remove('fileupload-active'));
+      component.classList.add('fileupload-active');
+    });
+
+    modalEl.addEventListener('submit', async (event) => {
+      const form = event.target;
+      if (!(form instanceof HTMLFormElement)) {
+        return;
+      }
+
+      event.preventDefault();
+
+      const response = await fetch(form.action, {
+        method: form.method || 'POST',
+        headers: {
+          'X-Requested-With': 'XMLHttpRequest',
+        },
+        body: new FormData(form),
+      });
+
+      const contentType = response.headers.get('content-type') || '';
+      if (contentType.includes('application/json')) {
+        const payload = await response.json();
+        if (response.ok) {
+          handleResult(payload);
+        }
+        return;
+      }
+
+      const html = await response.text();
+      const modalBody = modalEl.querySelector('.modal-body');
+      if (modalBody) {
+        modalBody.innerHTML = html;
+      }
+    });
+  })();
+</script>

--- a/price_manager/dataframe/templates/dataframe/update.html
+++ b/price_manager/dataframe/templates/dataframe/update.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% load fileupload_tags %}
 
 {% block title %}
 Редактирование датафрейма
@@ -10,7 +11,20 @@
   <form method="post">
     {% csrf_token %}
     {{ form.as_p }}
+    {% fileupload field_name='file_pk' button_text='Загрузить файл' %}
     <button type="submit" value="add">Сохранить</button>
   </form>
+</div>
+
+<div class="modal fade" id="SelectFile" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Выбор файла</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body"></div>
+    </div>
+  </div>
 </div>
 {% endblock %}

--- a/price_manager/dataframe/templatetags/fileupload_tags.py
+++ b/price_manager/dataframe/templatetags/fileupload_tags.py
@@ -1,0 +1,12 @@
+from django import template
+
+register = template.Library()
+
+
+@register.inclusion_tag("dataframe/tags/fileupload.html")
+def fileupload(field_name="file_pk", button_text="Загрузить файл", initial_pk=None):
+    return {
+        "field_name": field_name,
+        "button_text": button_text,
+        "initial_pk": initial_pk,
+    }

--- a/price_manager/dataframe/views/__init__.py
+++ b/price_manager/dataframe/views/__init__.py
@@ -1,1 +1,1 @@
-from fileupload import SelectFile
+from .fileupload import SelectFile


### PR DESCRIPTION
### Motivation
- Provide a reusable UI component for selecting/uploading files in dataframe forms and avoid duplicating modal/JS logic across templates.
- Allow templates to render a single `fileupload` snippet that manages opening the `SelectFile` modal and inserting a hidden input with the chosen file `pk`.

### Description
- Added a `templatetags` package and `fileupload_tags.py` with an inclusion tag `fileupload(field_name="file_pk", button_text="Загрузить файл", initial_pk=None)` that renders the component.
- Implemented partial template `dataframe/tags/fileupload.html` which renders the upload/select button (opens `#SelectFile`), a hidden-input container, and client-side JS that handles modal form submission, processes JSON responses `{"pk": ...}`, inserts the hidden input, hides the trigger button, and closes the modal.
- Updated `dataframe` `create.html` and `update.html` to `{% load fileupload_tags %}`, use `{% fileupload %}` and include a `#SelectFile` modal shell for partial injection.
- Fixed view import in `price_manager/dataframe/views/__init__.py` to use a relative import: `from .fileupload import SelectFile`.

### Testing
- Ran `python price_manager/manage.py check` which failed because Django is not installed in the execution environment, so framework-level checks could not be completed (environment error).
- No other automated tests were executed in this environment; template rendering and client-side behavior should be verified in a running Django instance with static files and Bootstrap available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5c52c58ac832d8fb4ffbb68aeec62)