### PR TITLE
Add ContentType creation endpoint with modal form partial

### DIFF
--- a/price_manager/price_manager/urls.py
+++ b/price_manager/price_manager/urls.py
@@ -10,6 +10,7 @@ from main_product_manager import views as mp_views
 from supplier_manager import views as sm_views
 from product_price_manager import views as ppm_views
 from dataframe import views as df_views
+from product import views as product_views
 
 
 urlpatterns = [
@@ -73,6 +74,7 @@ urlpatterns = [
     path('shopping-tabs/<int:tab_pk>/add/<int:product_id>/', views.ShoppingTabAddProductView.as_view(), name='shopping-tab-add-product'),
 
     path('dataframe/', include('dataframe.urls', namespace='dtaframe')),
+    path('content-type/create/', product_views.CreateContentType.as_view(), name='content-type-create'),
 
     path('blog/', include('blogapp.urls')),
 

--- a/price_manager/price_manager/urls.py
+++ b/price_manager/price_manager/urls.py
@@ -74,7 +74,7 @@ urlpatterns = [
     path('shopping-tabs/<int:tab_pk>/add/<int:product_id>/', views.ShoppingTabAddProductView.as_view(), name='shopping-tab-add-product'),
 
     path('dataframe/', include('dataframe.urls', namespace='dtaframe')),
-    path('content-type/create/', product_views.CreateContentType.as_view(), name='content-type-create'),
+    path('product/', include('product.urls', namespace='product')),
 
     path('blog/', include('blogapp.urls')),
 

--- a/price_manager/product/forms.py
+++ b/price_manager/product/forms.py
@@ -1,0 +1,9 @@
+from django import forms
+
+from .models import ContentType
+
+
+class ContentTypeForm(forms.ModelForm):
+    class Meta:
+        model = ContentType
+        fields = ("name", "measure", "contenttype")

--- a/price_manager/product/templates/product/partials/content_type_create_modal.html
+++ b/price_manager/product/templates/product/partials/content_type_create_modal.html
@@ -1,0 +1,16 @@
+<form method="post">
+  {% csrf_token %}
+  <div>
+    {{ form.name.label_tag }}
+    {{ form.name }}
+  </div>
+  <div>
+    {{ form.measure.label_tag }}
+    {{ form.measure }}
+  </div>
+  <div>
+    {{ form.contenttype.label_tag }}
+    {{ form.contenttype }}
+  </div>
+  <button type="submit">Сохранить</button>
+</form>

--- a/price_manager/product/urls.py
+++ b/price_manager/product/urls.py
@@ -1,0 +1,10 @@
+from django.urls import path
+
+from .views import CreateContentType
+
+app_name = 'product'
+
+urlpatterns = [
+    path('contenttype/create/', CreateContentType.as_view(), name='contenttype-create'),
+
+]

--- a/price_manager/product/views.py
+++ b/price_manager/product/views.py
@@ -1,6 +1,24 @@
+from django.http import JsonResponse
 from django.shortcuts import render
+from django.views import View
 
 from django_filters.views import FilterView
 
+from .forms import ContentTypeForm
 from .models import Product
-# Create your views here.
+
+
+class CreateContentType(View):
+    template_name = "product/partials/content_type_create_modal.html"
+
+    def get(self, request, *args, **kwargs):
+        form = ContentTypeForm()
+        return render(request, self.template_name, {"form": form})
+
+    def post(self, request, *args, **kwargs):
+        form = ContentTypeForm(request.POST)
+        if form.is_valid():
+            obj = form.save()
+            return JsonResponse({"pk": obj.pk})
+
+        return JsonResponse({"errors": form.errors}, status=400)


### PR DESCRIPTION
### Motivation

- Provide a small UI+API flow to create `product.models.ContentType` records via a modal form and return the created object's PK for client-side usage. 

### Description

- Added a `ModelForm` `ContentTypeForm` in `price_manager/product/forms.py` with fields `name`, `measure`, and `contenttype`. 
- Implemented a class-based view `CreateContentType` in `price_manager/product/views.py` that renders the form on `GET` and on valid `POST` saves the model and returns `JsonResponse({"pk": obj.pk})`, otherwise returns `JsonResponse({"errors": form.errors}, status=400)`. 
- Registered the new route `path('content-type/create/', product_views.CreateContentType.as_view(), name='content-type-create')` in `price_manager/price_manager/urls.py`. 
- Added a modal partial template at `price_manager/product/templates/product/partials/content_type_create_modal.html` containing CSRF and the fields `name`, `measure`, `contenttype`. 

### Testing

- Attempted to run `python price_manager/manage.py check`, but it failed because Django is not installed in the current environment (`ModuleNotFoundError: No module named 'django'`).
- No other automated tests were run in this environment due to the missing dependency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5d167ed0c832db287642f3b6c6c57)