### PR TITLE
Add create_content_type inclusion tag with Bootstrap modal and AJAX submit

### DIFF
--- a/price_manager/product/templates/product/tags/create_content_type.html
+++ b/price_manager/product/templates/product/tags/create_content_type.html
@@ -1,0 +1,118 @@
+<div class="content-type-component" data-field-name="{{ field_name }}">
+  <div class="content-type-trigger {% if initial_pk %}d-none{% endif %}">
+    <button
+      type="button"
+      class="btn btn-outline-primary"
+      data-bs-toggle="modal"
+      data-bs-target="#CreateContentTypeModal"
+      hx-get="{% url 'product:contenttype-create' %}"
+      hx-target="#CreateContentTypeModal .modal-body"
+      hx-swap="innerHTML"
+    >
+      {{ button_text }}
+    </button>
+  </div>
+
+  <div class="content-type-hidden-input-container">
+    {% if initial_pk %}
+      <input type="hidden" name="{{ field_name }}" value="{{ initial_pk }}">
+    {% endif %}
+  </div>
+</div>
+
+<div class="modal fade" id="CreateContentTypeModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Создать новый</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body"></div>
+    </div>
+  </div>
+</div>
+
+<script>
+  (function() {
+    if (window.__contentTypeCreateBound) {
+      return;
+    }
+    window.__contentTypeCreateBound = true;
+
+    const modalEl = document.getElementById('CreateContentTypeModal');
+    if (!modalEl) {
+      return;
+    }
+
+    const handleResult = (payload) => {
+      if (!payload || !payload.pk) {
+        return;
+      }
+
+      const activeComponent = document.querySelector('.content-type-component.content-type-active')
+        || document.querySelector('.content-type-component');
+
+      if (!activeComponent) {
+        return;
+      }
+
+      const fieldName = activeComponent.dataset.fieldName || 'content_type_pk';
+      const hiddenContainer = activeComponent.querySelector('.content-type-hidden-input-container');
+      const trigger = activeComponent.querySelector('.content-type-trigger');
+
+      hiddenContainer.innerHTML = `<input type="hidden" name="${fieldName}" value="${payload.pk}">`;
+      trigger.classList.add('d-none');
+
+      const modalInstance = bootstrap.Modal.getInstance(modalEl);
+      if (modalInstance) {
+        modalInstance.hide();
+      }
+
+      activeComponent.classList.remove('content-type-active');
+    };
+
+    document.addEventListener('click', (event) => {
+      const component = event.target.closest('.content-type-component');
+      if (!component) {
+        return;
+      }
+
+      document
+        .querySelectorAll('.content-type-component.content-type-active')
+        .forEach((item) => item.classList.remove('content-type-active'));
+      component.classList.add('content-type-active');
+    });
+
+    modalEl.addEventListener('submit', async (event) => {
+      const form = event.target;
+      if (!(form instanceof HTMLFormElement)) {
+        return;
+      }
+
+      event.preventDefault();
+
+      const response = await fetch(form.action || '{% url "product:contenttype-create" %}', {
+        method: form.method || 'POST',
+        headers: {
+          'X-Requested-With': 'XMLHttpRequest',
+        },
+        body: new FormData(form),
+      });
+
+      const contentType = response.headers.get('content-type') || '';
+      if (contentType.includes('application/json')) {
+        const payload = await response.json();
+        if (response.ok && payload.pk) {
+          handleResult(payload);
+        }
+        return;
+      }
+
+      const html = await response.text();
+      const modalBody = modalEl.querySelector('.modal-body');
+      if (modalBody) {
+        modalBody.innerHTML = html;
+      }
+    });
+  })();
+</script>

--- a/price_manager/product/templatetags/content_type_tags.py
+++ b/price_manager/product/templatetags/content_type_tags.py
@@ -1,0 +1,12 @@
+from django import template
+
+register = template.Library()
+
+
+@register.inclusion_tag("product/tags/create_content_type.html")
+def create_content_type(field_name="content_type_pk", button_text="Создать новый", initial_pk=None):
+    return {
+        "field_name": field_name,
+        "button_text": button_text,
+        "initial_pk": initial_pk,
+    }


### PR DESCRIPTION
### Motivation
- Provide a reusable UI component to create a new content type inline and inject its PK into a form field without a full-page reload. 
- Mirror existing `fileupload` behavior by supporting configurable target field name and optional initial value. 

### Description
- Added a new inclusion tag `create_content_type` in `product/templatetags/content_type_tags.py` that accepts `field_name`, `button_text`, and `initial_pk` and renders `product/tags/create_content_type.html`. 
- Implemented `create_content_type.html` which renders a “Создать новый” button, a Bootstrap modal, and uses `hx-get` to load `product:contenttype-create` into the modal body. 
- Embedded JS that safely initializes once (using `window.__contentTypeCreateBound`), marks the active component on click, intercepts modal form `submit`, posts the form via `fetch` with `FormData`, and on `response.ok` with `payload.pk` hides the trigger and inserts a hidden `<input name="{{ field_name }}" value="pk">`. 
- Preserves `initial_pk` by rendering an initial hidden input and hides the trigger when an initial PK is present. 

### Testing
- Compiled the templatetag module with `python -m compileall price_manager/product/templatetags/content_type_tags.py` and it succeeded. 
- No automated unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5d540bb74832d8ce226cf841a36bb)