### PR TITLE
Add reusable `choose_content_type` inclusion tag with unified modal result handling

### DIFF
--- a/price_manager/product/templates/product/partials/content_type_select_modal.html
+++ b/price_manager/product/templates/product/partials/content_type_select_modal.html
@@ -86,6 +86,11 @@
       }
 
       const payload = await response.json();
+      if (window.handleContentTypeResult) {
+        window.handleContentTypeResult(payload);
+        return;
+      }
+
       document.dispatchEvent(new CustomEvent('content-type-selected', { detail: payload }));
     });
   })();

--- a/price_manager/product/templates/product/tags/choose_content_type.html
+++ b/price_manager/product/templates/product/tags/choose_content_type.html
@@ -1,0 +1,34 @@
+<div class="content-type-component" data-field-name="{{ field_name }}">
+  <div class="content-type-trigger {% if initial_pk %}d-none{% endif %}">
+    <button
+      type="button"
+      class="btn btn-outline-primary"
+      data-bs-toggle="modal"
+      data-bs-target="#SelectContentTypeModal"
+      hx-get="{% url 'product:content-type-select' %}"
+      hx-target="#SelectContentTypeModal .modal-body"
+      hx-swap="innerHTML"
+    >
+      {{ button_text }}
+    </button>
+  </div>
+
+  <div class="content-type-hidden-input-container">
+    {% if initial_pk %}
+      <input type="hidden" name="{{ field_name }}" value="{{ initial_pk }}">
+    {% endif %}
+  </div>
+</div>
+
+<script>
+  (function() {
+    const component = document.currentScript && document.currentScript.previousElementSibling;
+    if (!component || !component.classList.contains('content-type-component')) {
+      return;
+    }
+
+    if (window.bindContentTypeComponent) {
+      window.bindContentTypeComponent(component);
+    }
+  })();
+</script>

--- a/price_manager/product/templates/product/tags/create_content_type.html
+++ b/price_manager/product/templates/product/tags/create_content_type.html
@@ -34,57 +34,73 @@
 
 <script>
   (function() {
-    if (window.__contentTypeCreateBound) {
-      return;
-    }
-    window.__contentTypeCreateBound = true;
-
     const modalEl = document.getElementById('SelectContentTypeModal');
     if (!modalEl) {
       return;
     }
 
-    const handleResult = (payload) => {
-      if (!payload || !payload.pk) {
-        return;
-      }
+    if (!window.bindContentTypeComponent) {
+      window.bindContentTypeComponent = (component) => {
+        if (!component || !component.classList.contains('content-type-component')) {
+          return;
+        }
 
-      const activeComponent = document.querySelector('.content-type-component.content-type-active')
-        || document.querySelector('.content-type-component');
+        if (component.dataset.contentTypeBound === '1') {
+          return;
+        }
 
-      if (!activeComponent) {
-        return;
-      }
+        component.dataset.contentTypeBound = '1';
+        component.addEventListener('click', () => {
+          document
+            .querySelectorAll('.content-type-component.content-type-active')
+            .forEach((item) => item.classList.remove('content-type-active'));
+          component.classList.add('content-type-active');
+        });
+      };
+    }
 
-      const fieldName = activeComponent.dataset.fieldName || 'content_type_pk';
-      const hiddenContainer = activeComponent.querySelector('.content-type-hidden-input-container');
-      const trigger = activeComponent.querySelector('.content-type-trigger');
+    if (!window.handleContentTypeResult) {
+      window.handleContentTypeResult = (payload) => {
+        if (!payload || !payload.pk) {
+          return;
+        }
 
-      hiddenContainer.innerHTML = `<input type="hidden" name="${fieldName}" value="${payload.pk}">`;
-      trigger.classList.add('d-none');
+        const activeComponent = document.querySelector('.content-type-component.content-type-active')
+          || document.querySelector('.content-type-component');
 
-      const modalInstance = bootstrap.Modal.getInstance(modalEl);
-      if (modalInstance) {
-        modalInstance.hide();
-      }
+        if (!activeComponent) {
+          return;
+        }
 
-      activeComponent.classList.remove('content-type-active');
-    };
+        const fieldName = activeComponent.dataset.fieldName || 'content_type_pk';
+        const hiddenContainer = activeComponent.querySelector('.content-type-hidden-input-container');
+        const trigger = activeComponent.querySelector('.content-type-trigger');
+
+        hiddenContainer.innerHTML = `<input type="hidden" name="${fieldName}" value="${payload.pk}">`;
+        trigger.classList.add('d-none');
+
+        const modalInstance = bootstrap.Modal.getInstance(modalEl);
+        if (modalInstance) {
+          modalInstance.hide();
+        }
+
+        activeComponent.classList.remove('content-type-active');
+      };
+    }
+
+    const currentComponent = document.currentScript && document.currentScript.previousElementSibling;
+    if (currentComponent && currentComponent.classList.contains('content-type-component')) {
+      window.bindContentTypeComponent(currentComponent);
+    }
+
+    if (window.__contentTypeCreateBound) {
+      return;
+    }
+    window.__contentTypeCreateBound = true;
 
 
     document.addEventListener('content-type-selected', (event) => {
-      handleResult(event.detail || {});
-    });
-    document.addEventListener('click', (event) => {
-      const component = event.target.closest('.content-type-component');
-      if (!component) {
-        return;
-      }
-
-      document
-        .querySelectorAll('.content-type-component.content-type-active')
-        .forEach((item) => item.classList.remove('content-type-active'));
-      component.classList.add('content-type-active');
+      window.handleContentTypeResult(event.detail || {});
     });
 
     modalEl.addEventListener('submit', async (event) => {
@@ -107,7 +123,7 @@
       if (contentType.includes('application/json')) {
         const payload = await response.json();
         if (response.ok && payload.pk) {
-          handleResult(payload);
+          window.handleContentTypeResult(payload);
         }
         return;
       }

--- a/price_manager/product/templatetags/content_type_tags.py
+++ b/price_manager/product/templatetags/content_type_tags.py
@@ -10,3 +10,12 @@ def create_content_type(field_name="content_type_pk", button_text="Создат�
         "button_text": button_text,
         "initial_pk": initial_pk,
     }
+
+
+@register.inclusion_tag("product/tags/choose_content_type.html")
+def choose_content_type(field_name="content_type_pk", button_text="Выбрать", initial_pk=None):
+    return {
+        "field_name": field_name,
+        "button_text": button_text,
+        "initial_pk": initial_pk,
+    }


### PR DESCRIPTION
### Motivation
- Добавить отдельный inclusion tag для выбора существующего типа контента и поддержать передачу `initial_pk` для предварительного заполнения.
- Убрать дублирование сложной логики обработки результата модалки, вынеся единый протокол/хелперы для использования и в создании, и в выборе контента.

### Description
- Добавлен inclusion tag `choose_content_type` в `price_manager/product/templatetags/content_type_tags.py` с параметрами `field_name`, `button_text` и `initial_pk` (файл: `content_type_tags.py`).
- Добавлен шаблон `price_manager/product/templates/product/tags/choose_content_type.html`, который рендерит кнопку «Выбрать», открывает модалку `SelectContentType` через `hx-get` и вставляет `hidden` input при наличии `initial_pk`.
- Рефактор JS в `price_manager/product/templates/product/tags/create_content_type.html`, добавлены глобальные хелперы `window.bindContentTypeComponent(component)` и `window.handleContentTypeResult(payload)` для унифицированного связывания компонента и обработки JSON-ответа `{"pk": ...}`.
- Обновлён `price_manager/product/templates/product/partials/content_type_select_modal.html` чтобы при выборе существующего типа вызывать `window.handleContentTypeResult(payload)` когда он доступен, с откатом на старый `content-type-selected` CustomEvent для совместимости.

### Testing
- Запущена проверка сборки Python: `python -m compileall -q price_manager/product`, проверка прошла успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5da1a2180832dba90e3956fa15b15)