### PR TITLE
Fix dataframe URL namespace typo

### DIFF
--- a/price_manager/price_manager/urls.py
+++ b/price_manager/price_manager/urls.py
@@ -72,7 +72,7 @@ urlpatterns = [
     path('shopping-tabs/select/<int:product_id>/', views.ShoppingTabSelectionView.as_view(), name='shopping-tab-select'),
     path('shopping-tabs/<int:tab_pk>/add/<int:product_id>/', views.ShoppingTabAddProductView.as_view(), name='shopping-tab-add-product'),
 
-    path('dataframe/', include('dataframe.urls', namespace='dtaframe')),
+    path('dataframe/', include('dataframe.urls', namespace='dataframe')),
     path('product/', include('product.urls', namespace='product')),
 
     path('blog/', include('blogapp.urls')),


### PR DESCRIPTION
### Motivation
- Ensure the included URL namespace for the `dataframe` app matches template `{% url %}` and `reverse()` usage to avoid broken URL lookups.

### Description
- Change `namespace='dtaframe'` to `namespace='dataframe'` in `price_manager/price_manager/urls.py` so the include reads `path('dataframe/', include('dataframe.urls', namespace='dataframe'))`.

### Testing
- Ran `rg -n "dtaframe|['\"]dataframe:[^'\"]+|reverse\([^)]*dataframe" /workspace/price_manager/price_manager` to confirm no remaining `dtaframe` occurrences and that templates use the `dataframe:` namespace, and verified the file diff with `git diff` before committing; the checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5dbf99c3c832db806a83de498dfda)