### PR TITLE
Add Dataframe create/update forms with file upload binding

### DIFF
--- a/price_manager/dataframe/forms.py
+++ b/price_manager/dataframe/forms.py
@@ -2,10 +2,36 @@ from django import forms
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Layout, Div, Field, HTML
 
-from .models import FileModel
+from .models import FileModel, Dataframe
 
 
 class FileForm(forms.ModelForm):
     class Meta:
         model = FileModel
         fields = ("file",)
+
+
+class DataframeForm(forms.ModelForm):
+    file_pk = forms.IntegerField(required=True, widget=forms.HiddenInput)
+
+    class Meta:
+        model = Dataframe
+        fields = ("name", "sheet_name", "index_row")
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.instance and self.instance.pk and self.instance.file_id:
+            self.fields["file_pk"].initial = self.instance.file_id
+
+    def clean_file_pk(self):
+        file_pk = self.cleaned_data["file_pk"]
+        if not FileModel.objects.filter(pk=file_pk).exists():
+            raise forms.ValidationError("Выбранный файл не найден.")
+        return file_pk
+
+    def save(self, commit=True):
+        instance = super().save(commit=False)
+        instance.file_id = self.cleaned_data["file_pk"]
+        if commit:
+            instance.save()
+        return instance

--- a/price_manager/dataframe/migrations/0004_dataframe_file.py
+++ b/price_manager/dataframe/migrations/0004_dataframe_file.py
@@ -1,0 +1,24 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('dataframe', '0003_remove_dataframe_cols_remove_dataframe_conf_and_more'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='dataframe',
+            name='file',
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name='dataframes',
+                to='dataframe.filemodel',
+                verbose_name='Файл',
+                default=1,
+            ),
+            preserve_default=False,
+        ),
+    ]

--- a/price_manager/dataframe/models.py
+++ b/price_manager/dataframe/models.py
@@ -24,6 +24,12 @@ def document_pre_delete(sender, instance, **kwargs):
     instance.file.delete(save=False)
 
 class Dataframe(TimeStampedModel, SlugModel):
+  file = models.ForeignKey(
+    FileModel,
+    on_delete=models.PROTECT,
+    related_name='dataframes',
+    verbose_name='Файл'
+  )
   sheet_name = models.CharField(verbose_name='Название листа')
   create_new = models.BooleanField(verbose_name='Создавать если нет',
                                    default=False)

--- a/price_manager/dataframe/templates/dataframe/update.html
+++ b/price_manager/dataframe/templates/dataframe/update.html
@@ -11,7 +11,7 @@
   <form method="post">
     {% csrf_token %}
     {{ form.as_p }}
-    {% fileupload field_name='file_pk' button_text='Загрузить файл' %}
+    {% fileupload field_name='file_pk' button_text='Загрузить файл' initial_pk=initial_pk %}
     <button type="submit" value="add">Сохранить</button>
   </form>
 </div>

--- a/price_manager/dataframe/urls.py
+++ b/price_manager/dataframe/urls.py
@@ -1,9 +1,11 @@
 from django.urls import path
 
-from .views import SelectFile
+from .views import SelectFile, DataframeCreateView, DataframeUpdateView
 
 app_name = 'dataframe'
 
 urlpatterns = [
+    path('create/', DataframeCreateView.as_view(), name='create'),
+    path('<int:pk>/update/', DataframeUpdateView.as_view(), name='update'),
     path('files/select/', SelectFile.as_view(), name='filesselect'),
 ]

--- a/price_manager/dataframe/views/__init__.py
+++ b/price_manager/dataframe/views/__init__.py
@@ -1,1 +1,25 @@
+from django.urls import reverse_lazy
+from django.views.generic import CreateView, UpdateView
+
+from ..forms import DataframeForm
+from ..models import Dataframe
 from .fileupload import SelectFile
+
+
+class DataframeCreateView(CreateView):
+    model = Dataframe
+    form_class = DataframeForm
+    template_name = 'dataframe/create.html'
+    success_url = reverse_lazy('dataframe:create')
+
+
+class DataframeUpdateView(UpdateView):
+    model = Dataframe
+    form_class = DataframeForm
+    template_name = 'dataframe/update.html'
+    success_url = reverse_lazy('dataframe:create')
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['initial_pk'] = self.object.file_id
+        return context


### PR DESCRIPTION
### Motivation
- Provide a create/update UI for `Dataframe` that binds a selected `FileModel` (chosen via existing fileupload widget) to the `Dataframe` record so users can attach uploaded files when creating or editing dataframes.
- Ensure the edit form pre-fills the currently attached file in the fileupload widget and persist the file association on save.

### Description
- Added `DataframeForm` (`ModelForm` for `dataframe.models.Dataframe`) with fields `name`, `sheet_name`, and `index_row`, plus a hidden required `file_pk` field, validation (`clean_file_pk`) and `save()` logic to persist the selected file id (`price_manager/dataframe/forms.py`).
- Added `file` relation to `Dataframe` as a `ForeignKey` to `FileModel` with `on_delete=PROTECT` and `related_name='dataframes'` and updated `models.py` accordingly (`price_manager/dataframe/models.py`).
- Created migration `0004_dataframe_file.py` to add the `file` field to `Dataframe` (`price_manager/dataframe/migrations/0004_dataframe_file.py`).
- Implemented `DataframeCreateView` and `DataframeUpdateView` using `CreateView`/`UpdateView` and wired them to use `DataframeForm`, with `UpdateView` providing `initial_pk` in context (`price_manager/dataframe/views/__init__.py`).
- Updated the update template to pass `initial_pk` to the `{% fileupload %}` tag so the existing file is prefilled, and added `create`/`update` routes to `dataframe/urls.py` (`price_manager/dataframe/templates/dataframe/update.html`, `price_manager/dataframe/urls.py`).

### Testing
- Attempted to run `python price_manager/manage.py makemigrations dataframe`, but the command failed due to missing Django in this environment (`ModuleNotFoundError: No module named 'django'`).
- Because migrations could not be generated here, the migration file `0004_dataframe_file.py` was created manually and included in the changes; no further automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5dca4f4f8832d81c2c87ed1844f4f)