### PR TITLE
Добавить endpoint метаданных файла и автозаполнение списка листов

### DIFF
--- a/price_manager/dataframe/forms.py
+++ b/price_manager/dataframe/forms.py
@@ -13,6 +13,7 @@ class FileForm(forms.ModelForm):
 
 class DataframeForm(forms.ModelForm):
     file_pk = forms.IntegerField(required=True, widget=forms.HiddenInput)
+    sheet_name = forms.ChoiceField(choices=())
 
     class Meta:
         model = Dataframe
@@ -20,6 +21,11 @@ class DataframeForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
+        self.fields["sheet_name"].choices = [("", "---------")]
+        if self.instance and self.instance.pk and self.instance.sheet_name:
+            self.fields["sheet_name"].choices.append((self.instance.sheet_name, self.instance.sheet_name))
+
         if self.instance and self.instance.pk and self.instance.file_id:
             self.fields["file_pk"].initial = self.instance.file_id
 

--- a/price_manager/dataframe/templates/dataframe/tags/fileupload.html
+++ b/price_manager/dataframe/templates/dataframe/tags/fileupload.html
@@ -29,11 +29,61 @@
     window.__fileuploadSelectFileBound = true;
 
     const modalEl = document.getElementById('SelectFile');
+    const fileMetaUrlTemplate = "{% url 'dataframe:filesmeta' 0 %}";
     if (!modalEl) {
       return;
     }
 
-    const handleResult = (payload) => {
+    const showMetadataWarning = (message) => {
+      if (window.showToast) {
+        window.showToast(message, 'warning');
+        return;
+      }
+      alert(message);
+    };
+
+    const updateSheetOptions = (sheets) => {
+      const sheetField = document.querySelector('[name="sheet_name"]');
+      if (!sheetField || sheetField.tagName !== 'SELECT') {
+        return;
+      }
+
+      sheetField.innerHTML = '';
+      const emptyOption = document.createElement('option');
+      emptyOption.value = '';
+      emptyOption.textContent = '---------';
+      sheetField.appendChild(emptyOption);
+
+      sheets.forEach((sheet) => {
+        const option = document.createElement('option');
+        option.value = sheet;
+        option.textContent = sheet;
+        sheetField.appendChild(option);
+      });
+    };
+
+    const loadFileMetadata = async (filePk) => {
+      const metaUrl = fileMetaUrlTemplate.replace('/0/meta/', `/${filePk}/meta/`);
+      const response = await fetch(metaUrl, {
+        headers: {
+          'X-Requested-With': 'XMLHttpRequest',
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error('meta');
+      }
+
+      const metadata = await response.json();
+      const nameField = document.querySelector('[name="name"]');
+      if (nameField && !nameField.value && metadata.filename) {
+        nameField.value = metadata.filename;
+      }
+
+      updateSheetOptions(metadata.sheets || []);
+    };
+
+    const handleResult = async (payload) => {
       if (!payload || !payload.pk) {
         return;
       }
@@ -57,7 +107,26 @@
         modalInstance.hide();
       }
 
+      try {
+        await loadFileMetadata(payload.pk);
+      } catch (error) {
+        showMetadataWarning('Не удалось загрузить метаданные файла. Можно сохранить форму вручную.');
+      }
+
       activeComponent.classList.remove('fileupload-active');
+    };
+
+    const bootstrapInitialState = async () => {
+      const hiddenInput = document.querySelector('.fileupload-hidden-input-container input[name]');
+      if (!hiddenInput || !hiddenInput.value) {
+        return;
+      }
+
+      try {
+        await loadFileMetadata(hiddenInput.value);
+      } catch (error) {
+        showMetadataWarning('Не удалось подгрузить список листов для выбранного файла.');
+      }
     };
 
     document.addEventListener('click', (event) => {
@@ -92,7 +161,7 @@
       if (contentType.includes('application/json')) {
         const payload = await response.json();
         if (response.ok) {
-          handleResult(payload);
+          await handleResult(payload);
         }
         return;
       }
@@ -103,5 +172,7 @@
         modalBody.innerHTML = html;
       }
     });
+
+    bootstrapInitialState();
   })();
 </script>

--- a/price_manager/dataframe/urls.py
+++ b/price_manager/dataframe/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from .views import SelectFile, DataframeCreateView, DataframeUpdateView
+from .views import SelectFile, DataframeCreateView, DataframeUpdateView, FileMetaView
 
 app_name = 'dataframe'
 
@@ -8,4 +8,5 @@ urlpatterns = [
     path('create/', DataframeCreateView.as_view(), name='create'),
     path('<int:pk>/update/', DataframeUpdateView.as_view(), name='update'),
     path('files/select/', SelectFile.as_view(), name='filesselect'),
+    path('files/<int:pk>/meta/', FileMetaView.as_view(), name='filesmeta'),
 ]

--- a/price_manager/dataframe/views/__init__.py
+++ b/price_manager/dataframe/views/__init__.py
@@ -3,7 +3,7 @@ from django.views.generic import CreateView, UpdateView
 
 from ..forms import DataframeForm
 from ..models import Dataframe
-from .fileupload import SelectFile
+from .fileupload import SelectFile, FileMetaView
 
 
 class DataframeCreateView(CreateView):

--- a/price_manager/dataframe/views/fileupload.py
+++ b/price_manager/dataframe/views/fileupload.py
@@ -1,3 +1,6 @@
+from pathlib import Path
+
+import pandas as pd
 from django.http import JsonResponse
 from django.core.paginator import Paginator
 from django.shortcuts import render
@@ -45,3 +48,33 @@ class SelectFile(View):
             return self._success_response(file_obj)
 
         return JsonResponse({"errors": form.errors}, status=400)
+
+
+class FileMetaView(View):
+    @staticmethod
+    def _build_sheet_names(file_obj):
+        extension = Path(file_obj.file.name).suffix.lower()
+
+        if extension == ".csv":
+            return ["CSV"]
+
+        if extension in {".xlsx", ".xlsm", ".xls"}:
+            with file_obj.file.open("rb") as f:
+                excel_file = pd.ExcelFile(f, engine="openpyxl")
+                return excel_file.sheet_names
+
+        return []
+
+    def get(self, request, pk, *args, **kwargs):
+        try:
+            file_obj = FileModel.objects.get(pk=pk)
+        except FileModel.DoesNotExist:
+            return JsonResponse({"error": "Файл не найден."}, status=404)
+
+        try:
+            sheets = self._build_sheet_names(file_obj)
+        except Exception:
+            return JsonResponse({"error": "Не удалось получить метаданные файла."}, status=400)
+
+        filename = Path(file_obj.file.name).stem
+        return JsonResponse({"filename": filename, "sheets": sheets})


### PR DESCRIPTION
### Motivation
- Нужно отдавать метаданные загруженного файла (имя без расширения и список листов) чтобы клиент мог автоматически подставлять `name` и дать пользователю выбор листа.  
- На странице редактирования требуется подгружать список листов для уже выбранного файла при открытии формы.  

### Description
- Добавлен `FileMetaView` в `dataframe/views/fileupload.py`, который возвращает JSON с `filename` (без расширения) и `sheets`; для Excel-файлов используется `pandas.ExcelFile(..., engine="openpyxl").sheet_names`, для `*.csv` возвращается псевдолист `["CSV"]`, ошибки возвращают `404`/`400`.  
- Прописан маршрут `GET /dataframe/files/<pk>/meta/` в `price_manager/dataframe/urls.py` и экспортирован `FileMetaView` из `views/__init__.py`.  
- В `DataframeForm` поле `sheet_name` переведено в `ChoiceField` и инициализируется с пустым вариантом и текущим значением при редактировании, чтобы форма корректно рендерилась до загрузки метаданных.  
- Обновлён JS в `fileupload.html`: после выбора/загрузки файла делается `fetch` к новому endpoint, если `name` пустой — подставляется `filename`, пересоздаются `<option>` для `select[name="sheet_name"]`, добавлена обработка ошибок (через `window.showToast` или `alert`) без блокировки сохранения, и реализована начальная подгрузка листов при открытии формы (update).  

### Testing
- Выполнена компиляция модулей для папки с приложением командой `python -m compileall price_manager/dataframe`, которая прошла успешно.  
- Запуск `python manage.py check` не был выполнен в среде CI локально из-за отсутствия установленного `django` в текущем окружении.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5dd718138832d8c7bd371d81f2ceb)