### PR TITLE
Handle missing Dataframe FileModel table in file upload views

### DIFF
--- a/price_manager/dataframe/views/fileupload.py
+++ b/price_manager/dataframe/views/fileupload.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import pandas as pd
 from django.http import JsonResponse
+from django.db import OperationalError, ProgrammingError
 from django.core.paginator import Paginator
 from django.shortcuts import render
 from django.views import View
@@ -20,13 +21,18 @@ class SelectFile(View):
 
     def get(self, request, *args, **kwargs):
         form = FileForm()
-        files_queryset = FileModel.objects.order_by("-id")
-        paginator = Paginator(files_queryset, self.per_page)
-        page_obj = paginator.get_page(request.GET.get("page"))
+        try:
+            files_queryset = FileModel.objects.order_by("-id")
+            paginator = Paginator(files_queryset, self.per_page)
+            page_obj = paginator.get_page(request.GET.get("page"))
+            files = page_obj.object_list
+        except (ProgrammingError, OperationalError):
+            page_obj = Paginator([], self.per_page).get_page(1)
+            files = page_obj.object_list
         context = {
             "form": form,
             "page_obj": page_obj,
-            "files": page_obj.object_list,
+            "files": files,
         }
         return render(request, self.template_name, context)
 
@@ -39,12 +45,17 @@ class SelectFile(View):
                 return JsonResponse({"errors": {"existing_file_pk": ["Некорректный идентификатор файла."]}}, status=400)
             except FileModel.DoesNotExist:
                 return JsonResponse({"errors": {"existing_file_pk": ["Файл не найден."]}}, status=404)
+            except (ProgrammingError, OperationalError):
+                return JsonResponse({"errors": {"database": ["Таблица файлов отсутствует. Выполните миграции."]}}, status=503)
 
             return self._success_response(file_obj)
 
         form = FileForm(request.POST, request.FILES)
         if form.is_valid():
-            file_obj = form.save()
+            try:
+                file_obj = form.save()
+            except (ProgrammingError, OperationalError):
+                return JsonResponse({"errors": {"database": ["Таблица файлов отсутствует. Выполните миграции."]}}, status=503)
             return self._success_response(file_obj)
 
         return JsonResponse({"errors": form.errors}, status=400)
@@ -70,6 +81,8 @@ class FileMetaView(View):
             file_obj = FileModel.objects.get(pk=pk)
         except FileModel.DoesNotExist:
             return JsonResponse({"error": "Файл не найден."}, status=404)
+        except (ProgrammingError, OperationalError):
+            return JsonResponse({"error": "Таблица файлов отсутствует. Выполните миграции."}, status=503)
 
         try:
             sheets = self._build_sheet_names(file_obj)


### PR DESCRIPTION
### Motivation
- Prevent unhandled database errors from crashing file selection and upload endpoints when the `dataframe_filemodel` table is missing (migration/schema mismatch). 
- Avoid runtime 500s caused by queries like `SELECT COUNT(*) FROM "dataframe_filemodel"` bubbling up to request handlers.

### Description
- Import `ProgrammingError` and `OperationalError` from `django.db` and use them to detect missing-table/database schema errors. 
- Wrap `SelectFile.get` database access in a try/except to return an empty paginated result when the file table is absent. 
- Make `SelectFile.post` return a structured `503` JSON error when selecting an existing file or saving a new upload fails due to missing DB table. 
- Make `FileMetaView.get` return a `503` JSON error when the file lookup fails because the underlying table is not present.

### Testing
- Ran `cd /workspace/price_manager && python manage.py check`, which failed because `manage.py` is not at the repo root in this layout. 
- Ran `cd /workspace/price_manager/price_manager && python manage.py check`, which failed because Django is not installed in the container so system checks could not run. 
- No automated tests were successfully executed in this environment due to the missing project/Django dependencies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f618f38040832db6e6c9efdb4786ca)