### PR TITLE
Добавить HTMX-обработку в модалке выбора файла

### DIFF
--- a/price_manager/dataframe/templates/dataframe/partials/file_select_modal.html
+++ b/price_manager/dataframe/templates/dataframe/partials/file_select_modal.html
@@ -23,7 +23,12 @@
         {% for item in files %}
           <li class="list-group-item d-flex justify-content-between align-items-center">
             <span>{{ item.file.name }}</span>
-            <form method="post" action="{% url 'dataframe:filesselect' %}">
+            <form method="post" action="{% url 'dataframe:filesselect' %}"
+              hx-post="{% url 'dataframe:filesselect' %}"
+              hx-target="#SelectFile .modal-body"
+              hx-swap="innerHTML"
+              hx-on::after-request="window.handleSelectFileAfterRequest && window.handleSelectFileAfterRequest(event)"
+            >
               {% csrf_token %}
               <input type="hidden" name="existing_file_pk" value="{{ item.pk }}">
               <button type="submit" class="btn btn-outline-primary btn-sm">Выбрать</button>
@@ -36,11 +41,11 @@
         <nav class="mt-3" aria-label="Pagination for existing files">
           <ul class="pagination pagination-sm mb-0">
             {% if page_obj.has_previous %}
-              <li class="page-item"><a class="page-link" href="?page={{ page_obj.previous_page_number }}">Назад</a></li>
+              <li class="page-item"><a class="page-link" href="?page={{ page_obj.previous_page_number }}" hx-get="?page={{ page_obj.previous_page_number }}" hx-target="#SelectFile .modal-body" hx-swap="innerHTML">Назад</a></li>
             {% endif %}
             <li class="page-item disabled"><span class="page-link">{{ page_obj.number }}/{{ page_obj.paginator.num_pages }}</span></li>
             {% if page_obj.has_next %}
-              <li class="page-item"><a class="page-link" href="?page={{ page_obj.next_page_number }}">Вперёд</a></li>
+              <li class="page-item"><a class="page-link" href="?page={{ page_obj.next_page_number }}" hx-get="?page={{ page_obj.next_page_number }}" hx-target="#SelectFile .modal-body" hx-swap="innerHTML">Вперёд</a></li>
             {% endif %}
           </ul>
         </nav>

--- a/price_manager/dataframe/templates/dataframe/tags/fileupload.html
+++ b/price_manager/dataframe/templates/dataframe/tags/fileupload.html
@@ -116,6 +116,31 @@
       activeComponent.classList.remove('fileupload-active');
     };
 
+
+
+    window.handleSelectFileAfterRequest = async (event) => {
+      const xhr = event?.detail?.xhr;
+      if (!xhr) {
+        return;
+      }
+
+      const contentType = xhr.getResponseHeader('Content-Type') || '';
+      if (!contentType.includes('application/json')) {
+        return;
+      }
+
+      let payload = null;
+      try {
+        payload = JSON.parse(xhr.responseText || '{}');
+      } catch (error) {
+        return;
+      }
+
+      if (xhr.status >= 200 && xhr.status < 300) {
+        await handleResult(payload);
+      }
+    };
+
     const bootstrapInitialState = async () => {
       const hiddenInput = document.querySelector('.fileupload-hidden-input-container input[name]');
       if (!hiddenInput || !hiddenInput.value) {
@@ -139,38 +164,6 @@
         .querySelectorAll('.fileupload-component.fileupload-active')
         .forEach((item) => item.classList.remove('fileupload-active'));
       component.classList.add('fileupload-active');
-    });
-
-    modalEl.addEventListener('submit', async (event) => {
-      const form = event.target;
-      if (!(form instanceof HTMLFormElement)) {
-        return;
-      }
-
-      event.preventDefault();
-
-      const response = await fetch(form.action, {
-        method: form.method || 'POST',
-        headers: {
-          'X-Requested-With': 'XMLHttpRequest',
-        },
-        body: new FormData(form),
-      });
-
-      const contentType = response.headers.get('content-type') || '';
-      if (contentType.includes('application/json')) {
-        const payload = await response.json();
-        if (response.ok) {
-          await handleResult(payload);
-        }
-        return;
-      }
-
-      const html = await response.text();
-      const modalBody = modalEl.querySelector('.modal-body');
-      if (modalBody) {
-        modalBody.innerHTML = html;
-      }
     });
 
     bootstrapInitialState();


### PR DESCRIPTION
### Motivation
- Устранить переходы страницы при выборе существующего файла в модальном окне и при перелистывании страниц списка файлов. 
- Обеспечить корректную обработку JSON-ответов от сервера без конфликтов между ручным `fetch` и HTMX-потоком. 
- Гарантировать, что скрытое поле с `pk` всегда перезаписывается и кнопка загрузки остаётся скрытой после успешного выбора.

### Description
- Добавлены HTMX-атрибуты `hx-post`, `hx-target`, `hx-swap` и `hx-on::after-request` в форму выбора существующего файла в `price_manager/dataframe/templates/dataframe/partials/file_select_modal.html` для отправки выбора внутрь модалки. 
- Пагинационные ссылки в том же partial переведены на HTMX (`hx-get` + `hx-target="#SelectFile .modal-body"`) чтобы навигация по страницам работала без перехода страницы. 
- Удалён ручной перехват `submit` на элементе модалки и добавлен глобальный HTMX-хук `window.handleSelectFileAfterRequest` в `price_manager/dataframe/templates/dataframe/tags/fileupload.html`, который парсит JSON-ответ и вызывает существующую функцию `handleResult(payload)`. 
- `handleResult(payload)` гарантирует перезапись скрытого input с именем поля, скрывает `.fileupload-trigger`, закрывает модалку и пытается подгрузить метаданные через `loadFileMetadata`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f632da2d0c832da584457c168a8487)