### PR TITLE
Support HTMX JSON responses in file select modal and update fileupload JS

### DIFF
--- a/price_manager/dataframe/templates/dataframe/partials/file_select_modal.html
+++ b/price_manager/dataframe/templates/dataframe/partials/file_select_modal.html
@@ -23,7 +23,13 @@
         {% for item in files %}
           <li class="list-group-item d-flex justify-content-between align-items-center">
             <span>{{ item.file.name }}</span>
-            <form method="post" action="{% url 'dataframe:filesselect' %}">
+            <form method="post" action="{% url 'dataframe:filesselect' %}"
+              hx-post="{% url 'dataframe:filesselect' %}"
+              hx-target="#SelectFile .modal-body"
+              hx-swap="innerHTML"
+              hx-on::before-swap="window.handleSelectFileBeforeSwap && window.handleSelectFileBeforeSwap(event)"
+              hx-on::after-request="window.handleSelectFileAfterRequest && window.handleSelectFileAfterRequest(event)"
+            >
               {% csrf_token %}
               <input type="hidden" name="existing_file_pk" value="{{ item.pk }}">
               <button type="submit" class="btn btn-outline-primary btn-sm">Выбрать</button>
@@ -36,11 +42,11 @@
         <nav class="mt-3" aria-label="Pagination for existing files">
           <ul class="pagination pagination-sm mb-0">
             {% if page_obj.has_previous %}
-              <li class="page-item"><a class="page-link" href="?page={{ page_obj.previous_page_number }}">Назад</a></li>
+              <li class="page-item"><a class="page-link" href="?page={{ page_obj.previous_page_number }}" hx-get="?page={{ page_obj.previous_page_number }}" hx-target="#SelectFile .modal-body" hx-swap="innerHTML">Назад</a></li>
             {% endif %}
             <li class="page-item disabled"><span class="page-link">{{ page_obj.number }}/{{ page_obj.paginator.num_pages }}</span></li>
             {% if page_obj.has_next %}
-              <li class="page-item"><a class="page-link" href="?page={{ page_obj.next_page_number }}">Вперёд</a></li>
+              <li class="page-item"><a class="page-link" href="?page={{ page_obj.next_page_number }}" hx-get="?page={{ page_obj.next_page_number }}" hx-target="#SelectFile .modal-body" hx-swap="innerHTML">Вперёд</a></li>
             {% endif %}
           </ul>
         </nav>

--- a/price_manager/dataframe/templates/dataframe/tags/fileupload.html
+++ b/price_manager/dataframe/templates/dataframe/tags/fileupload.html
@@ -88,7 +88,8 @@
         return;
       }
 
-      const activeComponent = document.querySelector('.fileupload-component.fileupload-active')
+      const activeComponent = window.__activeFileuploadComponent
+        || document.querySelector('.fileupload-component.fileupload-active')
         || document.querySelector('.fileupload-component');
 
       if (!activeComponent) {
@@ -102,10 +103,8 @@
       hiddenContainer.innerHTML = `<input type="hidden" name="${fieldName}" value="${payload.pk}">`;
       trigger.classList.add('d-none');
 
-      const modalInstance = bootstrap.Modal.getInstance(modalEl);
-      if (modalInstance) {
-        modalInstance.hide();
-      }
+      const modalInstance = bootstrap.Modal.getOrCreateInstance(modalEl);
+      modalInstance.hide();
 
       try {
         await loadFileMetadata(payload.pk);
@@ -114,6 +113,48 @@
       }
 
       activeComponent.classList.remove('fileupload-active');
+      window.__activeFileuploadComponent = null;
+    };
+
+
+
+
+
+    window.handleSelectFileBeforeSwap = (event) => {
+      const xhr = event?.detail?.xhr;
+      if (!xhr) {
+        return;
+      }
+
+      const contentType = xhr.getResponseHeader('Content-Type') || '';
+      if (!contentType.includes('application/json')) {
+        return;
+      }
+
+      event.detail.shouldSwap = false;
+    };
+
+    window.handleSelectFileAfterRequest = async (event) => {
+      const xhr = event?.detail?.xhr;
+      if (!xhr) {
+        return;
+      }
+
+      const contentType = xhr.getResponseHeader('Content-Type') || '';
+      if (!contentType.includes('application/json')) {
+        return;
+      }
+
+      let payload = null;
+      try {
+        payload = JSON.parse(xhr.responseText || '{}');
+      } catch (error) {
+        return;
+      }
+
+      if (xhr.status >= 200 && xhr.status < 300) {
+        await handleResult(payload);
+      }
     };
 
     const bootstrapInitialState = async () => {
@@ -139,38 +180,7 @@
         .querySelectorAll('.fileupload-component.fileupload-active')
         .forEach((item) => item.classList.remove('fileupload-active'));
       component.classList.add('fileupload-active');
-    });
-
-    modalEl.addEventListener('submit', async (event) => {
-      const form = event.target;
-      if (!(form instanceof HTMLFormElement)) {
-        return;
-      }
-
-      event.preventDefault();
-
-      const response = await fetch(form.action, {
-        method: form.method || 'POST',
-        headers: {
-          'X-Requested-With': 'XMLHttpRequest',
-        },
-        body: new FormData(form),
-      });
-
-      const contentType = response.headers.get('content-type') || '';
-      if (contentType.includes('application/json')) {
-        const payload = await response.json();
-        if (response.ok) {
-          await handleResult(payload);
-        }
-        return;
-      }
-
-      const html = await response.text();
-      const modalBody = modalEl.querySelector('.modal-body');
-      if (modalBody) {
-        modalBody.innerHTML = html;
-      }
+      window.__activeFileuploadComponent = component;
     });
 
     bootstrapInitialState();


### PR DESCRIPTION
### Motivation

- Enable dynamic in-modal file selection and pagination via HTMX while preserving existing JSON-based responses for file selection actions.
- Ensure the file upload widget correctly processes server-returned JSON (selected file metadata) without replacing the modal body HTML.

### Description

- Added HTMX attributes (`hx-post`, `hx-get`, `hx-target`, `hx-swap`) to the existing-file selection form and pagination links to load content into `#SelectFile .modal-body` via HTMX. 
- Implemented `window.handleSelectFileBeforeSwap` to detect JSON responses and cancel HTMX swaps for those responses. 
- Implemented `window.handleSelectFileAfterRequest` to parse JSON responses and route them to the existing `handleResult` flow to set the hidden file input, hide the modal, and load file metadata. 
- Reworked the fileupload script to track the active component via `window.__activeFileuploadComponent`, use `bootstrap.Modal.getOrCreateInstance` to reliably close the modal, and clear the global active component after handling a selection. 

### Testing

- Ran the backend test suite with `pytest` and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f632da2d0c832da584457c168a8487)