### PR TITLE
Use htmx for file-select modal and add JS handlers to process JSON responses

### DIFF
--- a/price_manager/dataframe/templates/dataframe/partials/file_select_modal.html
+++ b/price_manager/dataframe/templates/dataframe/partials/file_select_modal.html
@@ -9,7 +9,13 @@
 
 <div class="tab-content pt-3" id="selectFileTabsContent">
   <div class="tab-pane fade show active" id="new-file-pane" role="tabpanel" aria-labelledby="new-file-tab">
-    <form method="post" action="{% url 'dataframe:filesselect' %}" enctype="multipart/form-data">
+    <form method="post" action="{% url 'dataframe:filesselect' %}" enctype="multipart/form-data"
+      hx-post="{% url 'dataframe:filesselect' %}"
+      hx-target="#SelectFile .modal-body"
+      hx-swap="innerHTML"
+      hx-on::before-swap="window.handleSelectFileBeforeSwap && window.handleSelectFileBeforeSwap(event)"
+      hx-on::after-request="window.handleSelectFileAfterRequest && window.handleSelectFileAfterRequest(event)"
+    >
       {% csrf_token %}
       {{ form.file.label_tag }}
       {{ form.file }}
@@ -23,7 +29,13 @@
         {% for item in files %}
           <li class="list-group-item d-flex justify-content-between align-items-center">
             <span>{{ item.file.name }}</span>
-            <form method="post" action="{% url 'dataframe:filesselect' %}">
+            <form method="post" action="{% url 'dataframe:filesselect' %}"
+              hx-post="{% url 'dataframe:filesselect' %}"
+              hx-target="#SelectFile .modal-body"
+              hx-swap="innerHTML"
+              hx-on::before-swap="window.handleSelectFileBeforeSwap && window.handleSelectFileBeforeSwap(event)"
+              hx-on::after-request="window.handleSelectFileAfterRequest && window.handleSelectFileAfterRequest(event)"
+            >
               {% csrf_token %}
               <input type="hidden" name="existing_file_pk" value="{{ item.pk }}">
               <button type="submit" class="btn btn-outline-primary btn-sm">Выбрать</button>
@@ -36,11 +48,11 @@
         <nav class="mt-3" aria-label="Pagination for existing files">
           <ul class="pagination pagination-sm mb-0">
             {% if page_obj.has_previous %}
-              <li class="page-item"><a class="page-link" href="?page={{ page_obj.previous_page_number }}">Назад</a></li>
+              <li class="page-item"><a class="page-link" href="?page={{ page_obj.previous_page_number }}" hx-get="?page={{ page_obj.previous_page_number }}" hx-target="#SelectFile .modal-body" hx-swap="innerHTML">Назад</a></li>
             {% endif %}
             <li class="page-item disabled"><span class="page-link">{{ page_obj.number }}/{{ page_obj.paginator.num_pages }}</span></li>
             {% if page_obj.has_next %}
-              <li class="page-item"><a class="page-link" href="?page={{ page_obj.next_page_number }}">Вперёд</a></li>
+              <li class="page-item"><a class="page-link" href="?page={{ page_obj.next_page_number }}" hx-get="?page={{ page_obj.next_page_number }}" hx-target="#SelectFile .modal-body" hx-swap="innerHTML">Вперёд</a></li>
             {% endif %}
           </ul>
         </nav>

--- a/price_manager/dataframe/templates/dataframe/tags/fileupload.html
+++ b/price_manager/dataframe/templates/dataframe/tags/fileupload.html
@@ -88,7 +88,8 @@
         return;
       }
 
-      const activeComponent = document.querySelector('.fileupload-component.fileupload-active')
+      const activeComponent = window.__activeFileuploadComponent
+        || document.querySelector('.fileupload-component.fileupload-active')
         || document.querySelector('.fileupload-component');
 
       if (!activeComponent) {
@@ -102,10 +103,8 @@
       hiddenContainer.innerHTML = `<input type="hidden" name="${fieldName}" value="${payload.pk}">`;
       trigger.classList.add('d-none');
 
-      const modalInstance = bootstrap.Modal.getInstance(modalEl);
-      if (modalInstance) {
-        modalInstance.hide();
-      }
+      const modalInstance = bootstrap.Modal.getOrCreateInstance(modalEl);
+      modalInstance.hide();
 
       try {
         await loadFileMetadata(payload.pk);
@@ -114,6 +113,48 @@
       }
 
       activeComponent.classList.remove('fileupload-active');
+      window.__activeFileuploadComponent = null;
+    };
+
+
+
+
+
+    window.handleSelectFileBeforeSwap = (event) => {
+      const xhr = event?.detail?.xhr;
+      if (!xhr) {
+        return;
+      }
+
+      const contentType = xhr.getResponseHeader('Content-Type') || '';
+      if (!contentType.includes('application/json')) {
+        return;
+      }
+
+      event.detail.shouldSwap = false;
+    };
+
+    window.handleSelectFileAfterRequest = async (event) => {
+      const xhr = event?.detail?.xhr;
+      if (!xhr) {
+        return;
+      }
+
+      const contentType = xhr.getResponseHeader('Content-Type') || '';
+      if (!contentType.includes('application/json')) {
+        return;
+      }
+
+      let payload = null;
+      try {
+        payload = JSON.parse(xhr.responseText || '{}');
+      } catch (error) {
+        return;
+      }
+
+      if (xhr.status >= 200 && xhr.status < 300) {
+        await handleResult(payload);
+      }
     };
 
     const bootstrapInitialState = async () => {
@@ -139,38 +180,7 @@
         .querySelectorAll('.fileupload-component.fileupload-active')
         .forEach((item) => item.classList.remove('fileupload-active'));
       component.classList.add('fileupload-active');
-    });
-
-    modalEl.addEventListener('submit', async (event) => {
-      const form = event.target;
-      if (!(form instanceof HTMLFormElement)) {
-        return;
-      }
-
-      event.preventDefault();
-
-      const response = await fetch(form.action, {
-        method: form.method || 'POST',
-        headers: {
-          'X-Requested-With': 'XMLHttpRequest',
-        },
-        body: new FormData(form),
-      });
-
-      const contentType = response.headers.get('content-type') || '';
-      if (contentType.includes('application/json')) {
-        const payload = await response.json();
-        if (response.ok) {
-          await handleResult(payload);
-        }
-        return;
-      }
-
-      const html = await response.text();
-      const modalBody = modalEl.querySelector('.modal-body');
-      if (modalBody) {
-        modalBody.innerHTML = html;
-      }
+      window.__activeFileuploadComponent = component;
     });
 
     bootstrapInitialState();


### PR DESCRIPTION
### Motivation

- Enable in-modal navigation and form submissions for the file selection UI without full-page swaps by using htmx attributes on forms and pagination links.
- Make the file upload widget consume JSON responses from the modal (so a file can be selected/added and the widget updated without replacing modal markup).

### Description

- Added `hx-post`, `hx-get`, `hx-target`, `hx-swap` and `hx-on` attributes to the file selection forms and pagination links in `file_select_modal.html` to route interactions through htmx targeting `#SelectFile .modal-body`.
- Replaced the old modal submit/fetch flow in the `fileupload` tag script with htmx-aware handlers and JSON processing by adding `window.handleSelectFileBeforeSwap` to prevent HTML swaps for JSON responses and `window.handleSelectFileAfterRequest` to parse JSON results and call the existing `handleResult` flow.
- Introduced `window.__activeFileuploadComponent` to reliably track which fileupload component is active across modal interactions and clear it after selection, and switched to `bootstrap.Modal.getOrCreateInstance(modalEl).hide()` when closing the modal.
- Removed the previous manual `fetch`-based submit handling for the modal and wired selection handling to the new htmx hooks while preserving metadata loading and error reporting logic.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f632da2d0c832da584457c168a8487)