### PR TITLE
Integrate htmx into file selection modal and refactor fileupload component

### DIFF
--- a/price_manager/core/templates/base.html
+++ b/price_manager/core/templates/base.html
@@ -58,6 +58,9 @@
     {% block script %}{% endblock %}
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <script src={% static "js/htmx.min.js"%}></script>
+    <script>
+      htmx.config.implicitInheritance = true;
+    </script>
     <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"
     integrity="sha384-geWF76RCwLtnZ8qwWowPQNguL3RmwHVBC9FhGdlKrxdiJJigb/j/68SIy3Te4Bkz"

--- a/price_manager/dataframe/templates/dataframe/partials/file_select_modal.html
+++ b/price_manager/dataframe/templates/dataframe/partials/file_select_modal.html
@@ -9,7 +9,11 @@
 
 <div class="tab-content pt-3" id="selectFileTabsContent">
   <div class="tab-pane fade show active" id="new-file-pane" role="tabpanel" aria-labelledby="new-file-tab">
-    <form method="post" action="{% url 'dataframe:filesselect' %}" enctype="multipart/form-data">
+    <form method="post" action="{% url 'dataframe:filesselect' %}" enctype="multipart/form-data"
+      hx-post="{% url 'dataframe:filesselect' %}"
+      hx-target="#SelectFile .modal-body"
+      hx-swap="innerHTML"
+    >
       {% csrf_token %}
       {{ form.file.label_tag }}
       {{ form.file }}
@@ -23,7 +27,11 @@
         {% for item in files %}
           <li class="list-group-item d-flex justify-content-between align-items-center">
             <span>{{ item.file.name }}</span>
-            <form method="post" action="{% url 'dataframe:filesselect' %}">
+            <form method="post" action="{% url 'dataframe:filesselect' %}"
+              hx-post="{% url 'dataframe:filesselect' %}"
+              hx-target="#SelectFile .modal-body"
+              hx-swap="innerHTML"
+            >
               {% csrf_token %}
               <input type="hidden" name="existing_file_pk" value="{{ item.pk }}">
               <button type="submit" class="btn btn-outline-primary btn-sm">Выбрать</button>
@@ -36,11 +44,11 @@
         <nav class="mt-3" aria-label="Pagination for existing files">
           <ul class="pagination pagination-sm mb-0">
             {% if page_obj.has_previous %}
-              <li class="page-item"><a class="page-link" href="?page={{ page_obj.previous_page_number }}">Назад</a></li>
+              <li class="page-item"><a class="page-link" href="?page={{ page_obj.previous_page_number }}" hx-get="?page={{ page_obj.previous_page_number }}" hx-target="#SelectFile .modal-body" hx-swap="innerHTML">Назад</a></li>
             {% endif %}
             <li class="page-item disabled"><span class="page-link">{{ page_obj.number }}/{{ page_obj.paginator.num_pages }}</span></li>
             {% if page_obj.has_next %}
-              <li class="page-item"><a class="page-link" href="?page={{ page_obj.next_page_number }}">Вперёд</a></li>
+              <li class="page-item"><a class="page-link" href="?page={{ page_obj.next_page_number }}" hx-get="?page={{ page_obj.next_page_number }}" hx-target="#SelectFile .modal-body" hx-swap="innerHTML">Вперёд</a></li>
             {% endif %}
           </ul>
         </nav>

--- a/price_manager/dataframe/templates/dataframe/partials/file_select_success.html
+++ b/price_manager/dataframe/templates/dataframe/partials/file_select_success.html
@@ -1,0 +1,19 @@
+<div id="fileupload-trigger-{{ field_name }}" class="fileupload-trigger d-none" hx-swap-oob="outerHTML">
+  <button
+    type="button"
+    class="btn btn-outline-primary"
+    data-bs-toggle="modal"
+    data-bs-target="#SelectFile"
+    hx-get="{% url 'dataframe:filesselect' %}"
+    hx-target="#SelectFile .modal-body"
+    hx-swap="innerHTML"
+  >
+    Загрузить файл
+  </button>
+</div>
+
+<div id="fileupload-hidden-{{ field_name }}" class="fileupload-hidden-input-container" hx-swap-oob="outerHTML">
+  <input type="hidden" name="{{ field_name }}" value="{{ pk }}">
+</div>
+
+<div class="d-none" data-selected-pk="{{ pk }}"></div>

--- a/price_manager/dataframe/templates/dataframe/tags/fileupload.html
+++ b/price_manager/dataframe/templates/dataframe/tags/fileupload.html
@@ -1,6 +1,6 @@
 {% load static %}
 <div class="fileupload-component" data-field-name="{{ field_name }}">
-  <div class="fileupload-trigger {% if initial_pk %}d-none{% endif %}">
+  <div id="fileupload-trigger-{{ field_name }}" class="fileupload-trigger {% if initial_pk %}d-none{% endif %}">
     <button
       type="button"
       class="btn btn-outline-primary"
@@ -14,7 +14,7 @@
     </button>
   </div>
 
-  <div class="fileupload-hidden-input-container">
+  <div id="fileupload-hidden-{{ field_name }}" class="fileupload-hidden-input-container">
     {% if initial_pk %}
       <input type="hidden" name="{{ field_name }}" value="{{ initial_pk }}">
     {% endif %}
@@ -83,38 +83,31 @@
       updateSheetOptions(metadata.sheets || []);
     };
 
-    const handleResult = async (payload) => {
-      if (!payload || !payload.pk) {
+
+    document.body.addEventListener('htmx:configRequest', (event) => {
+      const target = event.target;
+      if (!target || !target.closest || !target.closest('#SelectFile')) {
         return;
       }
 
-      const activeComponent = document.querySelector('.fileupload-component.fileupload-active')
-        || document.querySelector('.fileupload-component');
+      event.detail.parameters.field_name = window.__activeFileuploadComponent?.dataset?.fieldName || 'file_pk';
+    });
 
-      if (!activeComponent) {
+    document.body.addEventListener('htmx:afterSwap', async (event) => {
+      const selectedPk = event.detail?.target?.querySelector?.('[data-selected-pk]')?.dataset?.selectedPk;
+      if (!selectedPk) {
         return;
       }
 
-      const fieldName = activeComponent.dataset.fieldName || 'file_pk';
-      const hiddenContainer = activeComponent.querySelector('.fileupload-hidden-input-container');
-      const trigger = activeComponent.querySelector('.fileupload-trigger');
-
-      hiddenContainer.innerHTML = `<input type="hidden" name="${fieldName}" value="${payload.pk}">`;
-      trigger.classList.add('d-none');
-
-      const modalInstance = bootstrap.Modal.getInstance(modalEl);
-      if (modalInstance) {
-        modalInstance.hide();
-      }
+      const modalInstance = bootstrap.Modal.getOrCreateInstance(modalEl);
+      modalInstance.hide();
 
       try {
-        await loadFileMetadata(payload.pk);
+        await loadFileMetadata(selectedPk);
       } catch (error) {
         showMetadataWarning('Не удалось загрузить метаданные файла. Можно сохранить форму вручную.');
       }
-
-      activeComponent.classList.remove('fileupload-active');
-    };
+    });
 
     const bootstrapInitialState = async () => {
       const hiddenInput = document.querySelector('.fileupload-hidden-input-container input[name]');
@@ -139,38 +132,7 @@
         .querySelectorAll('.fileupload-component.fileupload-active')
         .forEach((item) => item.classList.remove('fileupload-active'));
       component.classList.add('fileupload-active');
-    });
-
-    modalEl.addEventListener('submit', async (event) => {
-      const form = event.target;
-      if (!(form instanceof HTMLFormElement)) {
-        return;
-      }
-
-      event.preventDefault();
-
-      const response = await fetch(form.action, {
-        method: form.method || 'POST',
-        headers: {
-          'X-Requested-With': 'XMLHttpRequest',
-        },
-        body: new FormData(form),
-      });
-
-      const contentType = response.headers.get('content-type') || '';
-      if (contentType.includes('application/json')) {
-        const payload = await response.json();
-        if (response.ok) {
-          await handleResult(payload);
-        }
-        return;
-      }
-
-      const html = await response.text();
-      const modalBody = modalEl.querySelector('.modal-body');
-      if (modalBody) {
-        modalBody.innerHTML = html;
-      }
+      window.__activeFileuploadComponent = component;
     });
 
     bootstrapInitialState();

--- a/price_manager/dataframe/views/fileupload.py
+++ b/price_manager/dataframe/views/fileupload.py
@@ -16,24 +16,28 @@ class SelectFile(View):
     per_page = 10
 
     @staticmethod
-    def _success_response(file_obj):
+    def _success_response(request, file_obj):
+        if request.headers.get("HX-Request") == "true":
+            field_name = request.POST.get("field_name") or "file_pk"
+            return render(request, "dataframe/partials/file_select_success.html", {"pk": file_obj.pk, "field_name": field_name})
         return JsonResponse({"pk": file_obj.pk})
 
-    def get(self, request, *args, **kwargs):
-        form = FileForm()
+
+    def _build_modal_context(self, form, page):
         try:
             files_queryset = FileModel.objects.order_by("-id")
             paginator = Paginator(files_queryset, self.per_page)
-            page_obj = paginator.get_page(request.GET.get("page"))
+            page_obj = paginator.get_page(page)
             files = page_obj.object_list
         except (ProgrammingError, OperationalError):
             page_obj = Paginator([], self.per_page).get_page(1)
             files = page_obj.object_list
-        context = {
-            "form": form,
-            "page_obj": page_obj,
-            "files": files,
-        }
+
+        return {"form": form, "page_obj": page_obj, "files": files}
+
+    def get(self, request, *args, **kwargs):
+        form = FileForm()
+        context = self._build_modal_context(form=form, page=request.GET.get("page"))
         return render(request, self.template_name, context)
 
     def post(self, request, *args, **kwargs):
@@ -48,7 +52,7 @@ class SelectFile(View):
             except (ProgrammingError, OperationalError):
                 return JsonResponse({"errors": {"database": ["Таблица файлов отсутствует. Выполните миграции."]}}, status=503)
 
-            return self._success_response(file_obj)
+            return self._success_response(request, file_obj)
 
         form = FileForm(request.POST, request.FILES)
         if form.is_valid():
@@ -56,7 +60,11 @@ class SelectFile(View):
                 file_obj = form.save()
             except (ProgrammingError, OperationalError):
                 return JsonResponse({"errors": {"database": ["Таблица файлов отсутствует. Выполните миграции."]}}, status=503)
-            return self._success_response(file_obj)
+            return self._success_response(request, file_obj)
+
+        if request.headers.get("HX-Request") == "true":
+            context = self._build_modal_context(form=form, page=request.GET.get("page"))
+            return render(request, self.template_name, context, status=400)
 
         return JsonResponse({"errors": form.errors}, status=400)
 


### PR DESCRIPTION
### Motivation

- Improve UX of the file-selection modal by using htmx for inline updates and pagination without full-page reloads.
- Centralize server-side modal rendering and success responses to support both JSON and htmx flows.
- Simplify client-side logic by reacting to htmx events instead of manually fetching form submissions.

### Description

- Enabled `htmx.config.implicitInheritance = true` in the base template to support nested htmx interactions.
- Updated `file_select_modal.html` to add `hx-post`, `hx-get`, `hx-target`, and `hx-swap` attributes for form submissions and pagination links so the modal body is updated via htmx.
- Added `file_select_success.html` partial that uses out-of-band swaps (`hx-swap-oob`) to replace the trigger button, inject a hidden input, and mark the selected PK when a file is chosen.
- Modified `fileupload.html` tag to give elements stable IDs and rewrote the client-side script to listen for htmx events (`htmx:configRequest` and `htmx:afterSwap`), set the `field_name` parameter, detect the selected PK from the swapped response, hide the modal, and load metadata via `fetch` for the selected file.
- Refactored `SelectFile` view in `fileupload.py` by adding `_build_modal_context`, changing `_success_response` to render the success partial for htmx requests, and returning the modal HTML with `status=400` when an htmx post returns an invalid form; preserved JSON responses for non-htmx flows.

### Testing

- Ran the Django app test suite for the dataframe area with `./manage.py test price_manager.dataframe` and the tests passed.
- Executed the core Django tests with `./manage.py test price_manager.core` and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f632da2d0c832da584457c168a8487)