### PR TITLE
Add crispy forms rendering for Dataframe create/update views

### DIFF
--- a/price_manager/dataframe/forms.py
+++ b/price_manager/dataframe/forms.py
@@ -1,6 +1,6 @@
 from django import forms
 from crispy_forms.helper import FormHelper
-from crispy_forms.layout import Layout, Div, Field, HTML
+from crispy_forms.layout import Layout, Div, Field
 
 from .models import FileModel, Dataframe
 
@@ -21,6 +21,24 @@ class DataframeForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
+        self.helper = FormHelper()
+        self.helper.form_method = "post"
+        self.helper.form_tag = False
+        self.helper.layout = Layout(
+            Div(
+                Field("name"),
+                css_class="mb-3",
+            ),
+            Div(
+                Field("sheet_name"),
+                css_class="mb-3",
+            ),
+            Div(
+                Field("index_row"),
+                css_class="mb-3",
+            ),
+        )
 
         self.fields["sheet_name"].choices = [("", "---------")]
         if self.instance and self.instance.pk and self.instance.sheet_name:

--- a/price_manager/dataframe/templates/dataframe/create.html
+++ b/price_manager/dataframe/templates/dataframe/create.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% load fileupload_tags %}
+{% load crispy_forms_tags %}
 
 {% block title %}
 Новый датафрейм
@@ -10,7 +11,7 @@
   <h2>Создание датафрейма</h2>
   <form method="post">
     {% csrf_token %}
-    {{ form.as_p }}
+    {% crispy form %}
     {% fileupload field_name='file_pk' button_text='Загрузить файл' %}
     <button type="submit" value="add">Сохранить</button>
   </form>

--- a/price_manager/dataframe/templates/dataframe/update.html
+++ b/price_manager/dataframe/templates/dataframe/update.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% load fileupload_tags %}
+{% load crispy_forms_tags %}
 
 {% block title %}
 Редактирование датафрейма
@@ -10,7 +11,7 @@
   <h2>Редактирование датафрейма</h2>
   <form method="post">
     {% csrf_token %}
-    {{ form.as_p }}
+    {% crispy form %}
     {% fileupload field_name='file_pk' button_text='Загрузить файл' initial_pk=initial_pk %}
     <button type="submit" value="add">Сохранить</button>
   </form>


### PR DESCRIPTION
### Motivation
- Сделать рендер формы `DataframeForm` через `django-crispy-forms` для более контролируемой верстки и сохранения текущего UI отступов.
- Избежать дублирования скрытого поля `file_pk` между рендером формы и текущим виджетом загрузки файлов в шаблонах.

### Description
- Добавил `self.helper = FormHelper()` в `DataframeForm.__init__` и настроил `self.helper.form_method = "post"` и `self.helper.form_tag = False` в `price_manager/dataframe/forms.py`.
- Добавил `self.helper.layout` с `Layout`/`Div`/`Field` для полей `name`, `sheet_name` и `index_row` с классом `mb-3` для сохранения отступов.
- Удалил импорт неиспользуемого `HTML` из `crispy_forms.layout`.
- Подключил `{% load crispy_forms_tags %}` и заменил `{{ form.as_p }}` на `{% crispy form %}` в `price_manager/dataframe/templates/dataframe/create.html` и `.../update.html`, при этом `file_pk` оставлен вне crispy-`layout`, чтобы не конфликтовать с существующим `{% fileupload field_name='file_pk' %}` виджетом.

### Testing
- Запуск `python manage.py check` из `/workspace/price_manager` завершился неудачей, так как `manage.py` не найден в этом рабочем каталоге (ошибка пути). (failed)
- Запуск `python manage.py check` из `/workspace/price_manager/price_manager` завершился неудачей из-за отсутствия установленного пакета `django` в окружении (`ModuleNotFoundError: No module named 'django'`). (failed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f63fa765a0832da425879eedddddb8)