### PR TITLE
Add HTMX dataframe table preview endpoint and UI wiring

### DIFF
--- a/price_manager/dataframe/templates/dataframe/create.html
+++ b/price_manager/dataframe/templates/dataframe/create.html
@@ -15,6 +15,7 @@
     {% fileupload field_name='file_pk' button_text='Загрузить файл' %}
     <button type="submit" value="add">Сохранить</button>
   </form>
+  <div id="dataframe-table" class="mt-3"></div>
 </div>
 
 <div class="modal fade" id="SelectFile" tabindex="-1" aria-hidden="true">
@@ -28,4 +29,31 @@
     </div>
   </div>
 </div>
+
+<script>
+  (function() {
+    const bindDataframePreview = () => {
+      const tableContainer = document.getElementById('dataframe-table');
+      const fileField = document.querySelector('[name="file_pk"]');
+      const sheetField = document.querySelector('[name="sheet_name"]');
+      const indexField = document.querySelector('[name="index_row"]');
+      if (!tableContainer || !fileField || !sheetField || !indexField) {
+        return;
+      }
+
+      const url = "{% url 'dataframe:table' %}";
+      [fileField, sheetField, indexField].forEach((field) => {
+        field.setAttribute('hx-get', url);
+        field.setAttribute('hx-target', '#dataframe-table');
+        field.setAttribute('hx-include', '[name="file_pk"], [name="sheet_name"], [name="index_row"]');
+      });
+      fileField.setAttribute('hx-trigger', 'change');
+      sheetField.setAttribute('hx-trigger', 'change, keyup delay:300ms');
+      indexField.setAttribute('hx-trigger', 'change');
+    };
+
+    bindDataframePreview();
+    document.body.addEventListener('htmx:afterSwap', bindDataframePreview);
+  })();
+</script>
 {% endblock %}

--- a/price_manager/dataframe/templates/dataframe/partials/table.html
+++ b/price_manager/dataframe/templates/dataframe/partials/table.html
@@ -1,0 +1,26 @@
+{% if error %}
+  <div class="alert alert-warning" role="alert">{{ error }}</div>
+{% elif columns and rows %}
+  <div class="table-responsive">
+    <table class="table table-sm table-striped">
+      <thead>
+        <tr>
+          {% for column in columns %}
+            <th>{{ column }}</th>
+          {% endfor %}
+        </tr>
+      </thead>
+      <tbody>
+        {% for row in rows %}
+          <tr>
+            {% for cell in row %}
+              <td>{{ cell }}</td>
+            {% endfor %}
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+{% else %}
+  <div class="alert alert-info" role="alert">Нет данных для отображения.</div>
+{% endif %}

--- a/price_manager/dataframe/templates/dataframe/tags/fileupload.html
+++ b/price_manager/dataframe/templates/dataframe/tags/fileupload.html
@@ -104,6 +104,12 @@
 
       try {
         await loadFileMetadata(selectedPk);
+        if (window.htmx) {
+          const fileField = document.querySelector('[name="file_pk"]');
+          if (fileField) {
+            window.htmx.trigger(fileField, 'change');
+          }
+        }
       } catch (error) {
         showMetadataWarning('Не удалось загрузить метаданные файла. Можно сохранить форму вручную.');
       }

--- a/price_manager/dataframe/templates/dataframe/update.html
+++ b/price_manager/dataframe/templates/dataframe/update.html
@@ -15,6 +15,7 @@
     {% fileupload field_name='file_pk' button_text='Загрузить файл' initial_pk=initial_pk %}
     <button type="submit" value="add">Сохранить</button>
   </form>
+  <div id="dataframe-table" class="mt-3"></div>
 </div>
 
 <div class="modal fade" id="SelectFile" tabindex="-1" aria-hidden="true">
@@ -28,4 +29,31 @@
     </div>
   </div>
 </div>
+
+<script>
+  (function() {
+    const bindDataframePreview = () => {
+      const tableContainer = document.getElementById('dataframe-table');
+      const fileField = document.querySelector('[name="file_pk"]');
+      const sheetField = document.querySelector('[name="sheet_name"]');
+      const indexField = document.querySelector('[name="index_row"]');
+      if (!tableContainer || !fileField || !sheetField || !indexField) {
+        return;
+      }
+
+      const url = "{% url 'dataframe:table' %}";
+      [fileField, sheetField, indexField].forEach((field) => {
+        field.setAttribute('hx-get', url);
+        field.setAttribute('hx-target', '#dataframe-table');
+        field.setAttribute('hx-include', '[name="file_pk"], [name="sheet_name"], [name="index_row"]');
+      });
+      fileField.setAttribute('hx-trigger', 'change');
+      sheetField.setAttribute('hx-trigger', 'change, keyup delay:300ms');
+      indexField.setAttribute('hx-trigger', 'change');
+    };
+
+    bindDataframePreview();
+    document.body.addEventListener('htmx:afterSwap', bindDataframePreview);
+  })();
+</script>
 {% endblock %}

--- a/price_manager/dataframe/urls.py
+++ b/price_manager/dataframe/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from .views import SelectFile, DataframeCreateView, DataframeUpdateView, FileMetaView
+from .views import SelectFile, DataframeCreateView, DataframeUpdateView, FileMetaView, DataframeTableView
 
 app_name = 'dataframe'
 
@@ -9,4 +9,5 @@ urlpatterns = [
     path('<int:pk>/update/', DataframeUpdateView.as_view(), name='update'),
     path('files/select/', SelectFile.as_view(), name='filesselect'),
     path('files/<int:pk>/meta/', FileMetaView.as_view(), name='filesmeta'),
+    path('table/', DataframeTableView.as_view(), name='table'),
 ]

--- a/price_manager/dataframe/views/__init__.py
+++ b/price_manager/dataframe/views/__init__.py
@@ -1,2 +1,2 @@
 from .fileupload import SelectFile, FileMetaView
-from .dataframe import DataframeCreateView, DataframeUpdateView
+from .dataframe import DataframeCreateView, DataframeUpdateView, DataframeTableView

--- a/price_manager/dataframe/views/dataframe.py
+++ b/price_manager/dataframe/views/dataframe.py
@@ -1,8 +1,15 @@
+from pathlib import Path
+
+import pandas as pd
+from django.db import OperationalError, ProgrammingError
+from django.shortcuts import render
 from django.urls import reverse_lazy
-from django.views.generic import CreateView, UpdateView
+from django.views.generic import CreateView, TemplateView, UpdateView
+
+from core.tables import HTMXMixin
 
 from ..forms import DataframeForm
-from ..models import Dataframe
+from ..models import Dataframe, FileModel
 
 
 
@@ -23,3 +30,75 @@ class DataframeUpdateView(UpdateView):
         context = super().get_context_data(**kwargs)
         context['initial_pk'] = self.object.file_id
         return context
+
+
+class DataframeTableView(HTMXMixin, TemplateView):
+    template_name = 'dataframe/partials/table.html'
+
+    def __init__(self, **kwargs):
+        TemplateView.__init__(self, **kwargs)
+
+    @staticmethod
+    def _parse_index_row(index_row_raw):
+        if index_row_raw in (None, ''):
+            return None, None
+        try:
+            index_row = int(index_row_raw)
+        except (TypeError, ValueError):
+            return None, 'Некорректное значение index_row.'
+        if index_row < 0:
+            return None, 'index_row не может быть отрицательным.'
+        return index_row, None
+
+    @staticmethod
+    def _read_dataframe(file_obj, sheet_name):
+        extension = Path(file_obj.file.name).suffix.lower()
+        with file_obj.file.open('rb') as f:
+            if extension == '.csv':
+                return pd.read_csv(f)
+            if extension in {'.xlsx', '.xlsm', '.xls'}:
+                if not sheet_name:
+                    raise ValueError('Для Excel нужно указать sheet_name.')
+                return pd.read_excel(f, sheet_name=sheet_name, engine='openpyxl')
+        raise ValueError('Неподдерживаемый тип файла.')
+
+    def get(self, request, *args, **kwargs):
+        file_pk = request.GET.get('file_pk')
+        sheet_name = request.GET.get('sheet_name', '').strip()
+        index_row_raw = request.GET.get('index_row')
+
+        context = {'columns': [], 'rows': [], 'error': None}
+
+        if not file_pk:
+            context['error'] = 'Файл не выбран.'
+            return render(request, self.template_name, context)
+
+        index_row, index_error = self._parse_index_row(index_row_raw)
+        if index_error:
+            context['error'] = index_error
+            return render(request, self.template_name, context)
+
+        try:
+            file_obj = FileModel.objects.get(pk=file_pk)
+        except (ValueError, TypeError, FileModel.DoesNotExist):
+            context['error'] = 'Выбранный файл не найден.'
+            return render(request, self.template_name, context)
+        except (ProgrammingError, OperationalError):
+            context['error'] = 'Таблица файлов недоступна. Выполните миграции.'
+            return render(request, self.template_name, context)
+
+        try:
+            df = self._read_dataframe(file_obj=file_obj, sheet_name=sheet_name)
+            if index_row is not None:
+                if index_row >= len(df.columns):
+                    raise ValueError('index_row выходит за границы количества столбцов.')
+                df = df.set_index(df.columns[index_row])
+            df = df.fillna('')
+            context['columns'] = [str(col) for col in df.columns]
+            context['rows'] = [[str(value) for value in row] for row in df.head(50).values.tolist()]
+        except ValueError as exc:
+            context['error'] = str(exc)
+        except Exception:
+            context['error'] = 'Ошибка чтения файла.'
+
+        return render(request, self.template_name, context)


### PR DESCRIPTION
### Motivation
- Нужна интерактивная предпросмотрная таблица при выборе/загрузке файла в форме Dataframe для быстрого просмотра содержимого CSV/Excel перед сохранением.

### Description
- Добавлен `DataframeTableView` (`HTMXMixin` + `TemplateView`) в `price_manager/dataframe/views/dataframe.py`, который читает `file_pk`, `sheet_name`, `index_row` из query params, загружает CSV/Excel через `FileModel`/`pandas` и возвращает структуру `columns`/`rows` с обработкой ошибок и ограничением вывода первыми 50 строками.
- Создан partial-шаблон `price_manager/dataframe/templates/dataframe/partials/table.html` для рендеринга HTML-таблицы или сообщений об ошибке/пустых данных.
- Зарегистрирован маршрут `path('table/', DataframeTableView.as_view(), name='table')` в `price_manager/dataframe/urls.py` и экспортирован view в `views/__init__.py`.
- В `create.html` и `update.html` добавлен контейнер `<div id="dataframe-table">` и HTMX-атрибуты/триггеры на полях `file_pk`, `sheet_name`, `index_row` для автоматического запроса `dataframe:table` при изменениях.
- В скрипте file-upload (`price_manager/dataframe/templates/dataframe/tags/fileupload.html`) добавлен вызов `window.htmx.trigger(fileField, 'change')` после успешной загрузки/выбора файла, чтобы принудительно обновлять предпросмотр.

### Testing
- Выполнена компиляция файла `price_manager/dataframe/views/dataframe.py` с помощью `python -m compileall price_manager/dataframe/views/dataframe.py` и проверка прошла успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f640d31d30832d873de61523e53dde)