### PR TITLE
Style dataframe form controls and trigger HTMX on initial file load

### DIFF
--- a/price_manager/dataframe/forms.py
+++ b/price_manager/dataframe/forms.py
@@ -31,7 +31,7 @@ class DataframeForm(forms.ModelForm):
                 css_class="mb-3",
             ),
             Div(
-                Field("sheet_name"),
+                Field("sheet_name", css_class="form-select dataframe-sheet-select"),
                 css_class="mb-3",
             ),
             Div(

--- a/price_manager/dataframe/templates/dataframe/create.html
+++ b/price_manager/dataframe/templates/dataframe/create.html
@@ -13,7 +13,7 @@
     {% csrf_token %}
     {% crispy form %}
     {% fileupload field_name='file_pk' button_text='Загрузить файл' %}
-    <button type="submit" value="add">Сохранить</button>
+    <button type="submit" value="add" class="btn btn-primary dataframe-save-btn">Сохранить</button>
   </form>
   <div id="dataframe-table" class="mt-3"></div>
 </div>

--- a/price_manager/dataframe/templates/dataframe/tags/fileupload.html
+++ b/price_manager/dataframe/templates/dataframe/tags/fileupload.html
@@ -123,6 +123,12 @@
 
       try {
         await loadFileMetadata(hiddenInput.value);
+        if (window.htmx) {
+          const fileField = document.querySelector('[name="file_pk"]');
+          if (fileField) {
+            window.htmx.trigger(fileField, 'change');
+          }
+        }
       } catch (error) {
         showMetadataWarning('Не удалось подгрузить список листов для выбранного файла.');
       }

--- a/price_manager/dataframe/templates/dataframe/update.html
+++ b/price_manager/dataframe/templates/dataframe/update.html
@@ -13,7 +13,7 @@
     {% csrf_token %}
     {% crispy form %}
     {% fileupload field_name='file_pk' button_text='Загрузить файл' initial_pk=initial_pk %}
-    <button type="submit" value="add">Сохранить</button>
+    <button type="submit" value="add" class="btn btn-primary dataframe-save-btn">Сохранить</button>
   </form>
   <div id="dataframe-table" class="mt-3"></div>
 </div>


### PR DESCRIPTION
### Motivation
- Ensure the dataframe form UI components are styled consistently with Bootstrap and are addressable by JS, and ensure dependent UI updates occur when a file is already selected on page load.

### Description
- Updated the dataframe sheet selector in `price_manager/dataframe/forms.py` to use `css_class="form-select dataframe-sheet-select"` so it receives Bootstrap select styling and a predictable selector for scripts.
- Added `class="btn btn-primary dataframe-save-btn"` to the submit buttons in `price_manager/dataframe/templates/dataframe/create.html` and `.../update.html` to standardize the save button appearance.
- Modified `price_manager/dataframe/templates/dataframe/tags/fileupload.html` to trigger `window.htmx.trigger(fileField, 'change')` during the bootstrap initial state after `loadFileMetadata` completes so HTMX-driven listeners react when an initial `file_pk` is present.

### Testing
- Ran the Django test suite with `./manage.py test` and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f63243abe4832db4dcfd2c166205a4)