### PR TITLE
Fix file selector tag behavior in modal flow

### DIFF
--- a/price_manager/dataframe/templates/dataframe/partials/file_select_modal.html
+++ b/price_manager/dataframe/templates/dataframe/partials/file_select_modal.html
@@ -17,6 +17,7 @@
       hx-on::after-request="window.handleSelectFileAfterRequest && window.handleSelectFileAfterRequest(event)"
     >
       {% csrf_token %}
+      <input type="hidden" name="field_name" value="{{ field_name|default:'file_pk' }}">
       {{ form.file.label_tag }}
       {{ form.file }}
       <button type="submit" class="btn btn-primary mt-2">Добавить</button>
@@ -35,6 +36,7 @@
               hx-swap="innerHTML"
             >
               {% csrf_token %}
+              <input type="hidden" name="field_name" value="{{ field_name|default:'file_pk' }}">
               <input type="hidden" name="existing_file_pk" value="{{ item.pk }}">
               <button type="submit" class="btn btn-outline-primary btn-sm">Выбрать</button>
             </form>
@@ -46,11 +48,11 @@
         <nav class="mt-3" aria-label="Pagination for existing files">
           <ul class="pagination pagination-sm mb-0">
             {% if page_obj.has_previous %}
-              <li class="page-item"><a class="page-link" href="?page={{ page_obj.previous_page_number }}" hx-get="?page={{ page_obj.previous_page_number }}" hx-target="#SelectFile .modal-body" hx-swap="innerHTML">Назад</a></li>
+              <li class="page-item"><a class="page-link" href="?page={{ page_obj.previous_page_number }}&field_name={{ field_name|default:'file_pk' }}" hx-get="?page={{ page_obj.previous_page_number }}&field_name={{ field_name|default:'file_pk' }}" hx-target="#SelectFile .modal-body" hx-swap="innerHTML">Назад</a></li>
             {% endif %}
             <li class="page-item disabled"><span class="page-link">{{ page_obj.number }}/{{ page_obj.paginator.num_pages }}</span></li>
             {% if page_obj.has_next %}
-              <li class="page-item"><a class="page-link" href="?page={{ page_obj.next_page_number }}" hx-get="?page={{ page_obj.next_page_number }}" hx-target="#SelectFile .modal-body" hx-swap="innerHTML">Вперёд</a></li>
+              <li class="page-item"><a class="page-link" href="?page={{ page_obj.next_page_number }}&field_name={{ field_name|default:'file_pk' }}" hx-get="?page={{ page_obj.next_page_number }}&field_name={{ field_name|default:'file_pk' }}" hx-target="#SelectFile .modal-body" hx-swap="innerHTML">Вперёд</a></li>
             {% endif %}
           </ul>
         </nav>

--- a/price_manager/dataframe/templates/dataframe/tags/fileupload.html
+++ b/price_manager/dataframe/templates/dataframe/tags/fileupload.html
@@ -36,7 +36,8 @@
     }
 
     const ensureSelectedFileUi = () => {
-      const container = document.getElementById('fileupload-hidden-file_pk');
+      const activeFieldName = window.__activeFileuploadComponent?.dataset?.fieldName || 'file_pk';
+      const container = document.getElementById(`fileupload-hidden-${activeFieldName}`);
       if (!container) {
         return null;
       }
@@ -148,7 +149,8 @@
     });
 
     const bootstrapInitialState = async () => {
-      const hiddenInput = document.querySelector('.fileupload-hidden-input-container input[name]');
+      const fieldName = window.__activeFileuploadComponent?.dataset?.fieldName || 'file_pk';
+      const hiddenInput = document.querySelector(`#fileupload-hidden-${fieldName} input[name]`);
       if (!hiddenInput || !hiddenInput.value) {
         return;
       }
@@ -167,6 +169,11 @@
       component.classList.add('fileupload-active');
       window.__activeFileuploadComponent = component;
     });
+
+    const defaultComponent = document.querySelector('.fileupload-component');
+    if (defaultComponent) {
+      window.__activeFileuploadComponent = defaultComponent;
+    }
 
     bootstrapInitialState();
   })();

--- a/price_manager/dataframe/views/fileupload.py
+++ b/price_manager/dataframe/views/fileupload.py
@@ -24,7 +24,7 @@ class SelectFile(View):
         return JsonResponse({"pk": file_obj.pk})
 
 
-    def _build_modal_context(self, form, page):
+    def _build_modal_context(self, form, page, field_name="file_pk"):
         try:
             files_queryset = FileModel.objects.order_by("-id")
             paginator = Paginator(files_queryset, self.per_page)
@@ -34,11 +34,12 @@ class SelectFile(View):
             page_obj = Paginator([], self.per_page).get_page(1)
             files = page_obj.object_list
 
-        return {"form": form, "page_obj": page_obj, "files": files}
+        return {"form": form, "page_obj": page_obj, "files": files, "field_name": field_name}
 
     def get(self, request, *args, **kwargs):
         form = FileForm()
-        context = self._build_modal_context(form=form, page=request.GET.get("page"))
+        field_name = request.GET.get("field_name") or "file_pk"
+        context = self._build_modal_context(form=form, page=request.GET.get("page"), field_name=field_name)
         return render(request, self.template_name, context)
 
     def post(self, request, *args, **kwargs):
@@ -64,7 +65,8 @@ class SelectFile(View):
             return self._success_response(request, file_obj)
 
         if request.headers.get("HX-Request") == "true":
-            context = self._build_modal_context(form=form, page=request.GET.get("page"))
+            field_name = request.POST.get("field_name") or request.GET.get("field_name") or "file_pk"
+            context = self._build_modal_context(form=form, page=request.GET.get("page"), field_name=field_name)
             return render(request, self.template_name, context, status=400)
 
         return JsonResponse({"errors": form.errors}, status=400)


### PR DESCRIPTION
### Motivation
- The file-upload component used a hardcoded field name (`file_pk`) which broke behavior when multiple file inputs exist on a page and when the modal navigates between pages. 
- The modal needed to preserve which field invoked it so OOB updates replace the correct trigger/input after selection.

### Description
- Updated the fileupload JS to resolve the selected-file container by the active component's `data-field-name` and initialize `window.__activeFileuploadComponent` from the first component to support initial state. 
- Added a hidden `field_name` input to both upload and existing-file forms and appended `field_name` to pagination links in the modal to preserve the invoking field across navigation. 
- Propagated `field_name` through the `SelectFile` view by adding a `field_name` parameter to `_build_modal_context`, reading it from GET/POST, and returning it in HTMX error responses so the modal renders consistently for any target field. 

### Testing
- Ran `python -m py_compile price_manager/dataframe/views/fileupload.py` which succeeded. 
- Attempted `cd price_manager && python manage.py test dataframe.tests` which could not run in this environment because Django is not installed (`ModuleNotFoundError: No module named 'django'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f655bdb810832d8a31fedf99813011)