### PR TITLE
feat(supplier_feed): add FeedColumnMapping REST API (nested under /mappings/<pk>/column-mappings/)

### DIFF
--- a/API_MAP.md
+++ b/API_MAP.md
@@ -1112,40 +1112,42 @@ Deletes a supplier link permanently.
 
 ### Column Mappings
 
-`FeedColumnMapping` records declare the **role** and optional **price type** for each variable column in a `FeedMapping`. This replaces the plain `variable_columns` JSONField with a proper relational model.
+`FeedColumnMapping` records declare the **role** and optional **price type** for each variable column in a `FeedMapping`. Endpoints are nested under the parent mapping — `mapping_pk` is the `FeedMapping` PK.
 
-#### `GET /api/supplier-feed/column-mappings/`
+#### `GET /api/supplier-feed/mappings/<mapping_pk>/column-mappings/`
 
-Lists all column mappings. Supports `?feed_mapping=<id>` filter.
+Lists all column mappings for a given `FeedMapping`.
 
-**Response fields:** `id`, `feed_mapping` (PK), `column_name`, `role` (`price`|`stock`|`other`), `price_type` (PK or `null`).
+**Response fields:** `id`, `feed_mapping` (PK, read-only), `column_name`, `role` (`price`|`stock`|`other`), `price_type` (PK or `null`).
 
-#### `POST /api/supplier-feed/column-mappings/`
+**Response `404`:** Parent `FeedMapping` not found.
 
-Creates a column mapping.
+#### `POST /api/supplier-feed/mappings/<mapping_pk>/column-mappings/`
+
+Creates a column mapping under the given `FeedMapping`. `feed_mapping` is set automatically from the URL — do not include it in the request body.
 
 ```json
 {
-  "feed_mapping": 1,
   "column_name": "price",
   "role": "price",
   "price_type": 2
 }
 ```
 
-**Validation:** `price_type` is required when `role == "price"`.
+**Validation:** `price_type` is required when `role == "price"` (enforced by DB `CheckConstraint`).
 
-**Response `400`:** `price_type` missing for role `price`, or duplicate `(feed_mapping, column_name)`.
+**Response `400`:** `price_type` missing for role `price`, or duplicate `(feed_mapping, column_name)`.  
+**Response `404`:** Parent `FeedMapping` not found.
 
-#### `GET /api/supplier-feed/column-mappings/<id>/`
+#### `GET /api/supplier-feed/mappings/<mapping_pk>/column-mappings/<id>/`
 
 Retrieves a single column mapping.
 
-#### `PUT/PATCH /api/supplier-feed/column-mappings/<id>/`
+#### `PATCH /api/supplier-feed/mappings/<mapping_pk>/column-mappings/<id>/`
 
-Updates a column mapping.
+Partially updates a column mapping.
 
-#### `DELETE /api/supplier-feed/column-mappings/<id>/`
+#### `DELETE /api/supplier-feed/mappings/<mapping_pk>/column-mappings/<id>/`
 
 Deletes a column mapping.
 

--- a/price_manager/supplier_feed/api/serializers.py
+++ b/price_manager/supplier_feed/api/serializers.py
@@ -1,6 +1,7 @@
 from rest_framework import serializers
 
 from supplier_feed.models import (
+    FeedColumnMapping,
     FeedMapping,
     SupplierFeed,
     SupplierFeedEntry,
@@ -127,3 +128,46 @@ class SupplierFeedDetailSerializer(SupplierFeedSerializer):
 
     def get_skipped(self, obj) -> int:
         return obj.entries.filter(skipped=True).count()
+
+
+# ── FeedColumnMapping serializer ──────────────────────────────────────────────
+
+class FeedColumnMappingSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = FeedColumnMapping
+        fields = ['id', 'feed_mapping', 'column_name', 'role', 'price_type']
+        read_only_fields = ['feed_mapping']
+
+    def validate(self, data):
+        # On creation the instance is None; on update we fall back to the
+        # stored value for any field omitted from a partial PATCH.
+        instance = self.instance
+        role = data.get('role', getattr(instance, 'role', None))
+        price_type = data.get('price_type', getattr(instance, 'price_type', None))
+        if role == FeedColumnMapping.ROLE_PRICE and price_type is None:
+            raise serializers.ValidationError(
+                {'price_type': 'Тип цены обязателен при роли "price".'}
+            )
+        return data
+
+    def validate_column_name(self, value):
+        # Guard against duplicate (feed_mapping, column_name) within this mapping.
+        # feed_mapping_id is injected via perform_create / already on instance.
+        request = self.context.get('request')
+        view = self.context.get('view')
+        if view is None:
+            return value
+        mapping_pk = view.kwargs.get('mapping_pk')
+        if mapping_pk is None:
+            return value
+        qs = FeedColumnMapping.objects.filter(
+            feed_mapping_id=mapping_pk,
+            column_name=value,
+        )
+        if self.instance is not None:
+            qs = qs.exclude(pk=self.instance.pk)
+        if qs.exists():
+            raise serializers.ValidationError(
+                'Колонка с таким именем уже добавлена для этой конфигурации выгрузки.'
+            )
+        return value

--- a/price_manager/supplier_feed/api/urls.py
+++ b/price_manager/supplier_feed/api/urls.py
@@ -2,6 +2,7 @@ from django.urls import include, path
 from rest_framework.routers import DefaultRouter
 
 from .views import (
+    FeedColumnMappingViewSet,
     FeedMappingViewSet,
     SupplierFeedViewSet,
     SupplierLinkViewSet,
@@ -16,4 +17,14 @@ router.register(r'links', SupplierLinkViewSet, basename='supplierlink')
 
 urlpatterns = [
     path('', include(router.urls)),
+    path(
+        'mappings/<int:mapping_pk>/column-mappings/',
+        FeedColumnMappingViewSet.as_view({'get': 'list', 'post': 'create'}),
+        name='column-mapping-list',
+    ),
+    path(
+        'mappings/<int:mapping_pk>/column-mappings/<int:pk>/',
+        FeedColumnMappingViewSet.as_view({'get': 'retrieve', 'patch': 'partial_update', 'delete': 'destroy'}),
+        name='column-mapping-detail',
+    ),
 ]

--- a/price_manager/supplier_feed/api/views.py
+++ b/price_manager/supplier_feed/api/views.py
@@ -1,4 +1,5 @@
 from django.db import models, transaction
+from django.shortcuts import get_object_or_404
 from rest_framework import mixins, status, viewsets
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.decorators import action
@@ -7,6 +8,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
 from supplier_feed.models import (
+    FeedColumnMapping,
     FeedMapping,
     SupplierFeed,
     SupplierFeedEntry,
@@ -18,6 +20,7 @@ from supplier_feed.models import (
 from supplier_feed.tasks import run_feed_matching_task
 from dataframe import sessions as session_store
 from .serializers import (
+    FeedColumnMappingSerializer,
     FeedMappingSerializer,
     SupplierFeedSerializer,
     SupplierFeedDetailSerializer,
@@ -479,3 +482,22 @@ class SupplierLinkViewSet(
         # Refresh to pick up the new product FK before serialising
         instance.refresh_from_db(fields=['product_id'])
         return Response(SupplierLinkSerializer(instance).data, status=status.HTTP_200_OK)
+
+
+class FeedColumnMappingViewSet(viewsets.ModelViewSet):
+    """CRUD for FeedColumnMapping records nested under a FeedMapping."""
+
+    serializer_class = FeedColumnMappingSerializer
+    authentication_classes = [SessionAuthentication]
+    permission_classes = [IsAuthenticated]
+    http_method_names = ['get', 'post', 'patch', 'delete', 'head', 'options']
+
+    def get_queryset(self):
+        mapping_pk = self.kwargs['mapping_pk']
+        # Raise 404 if parent mapping does not exist
+        get_object_or_404(FeedMapping, pk=mapping_pk)
+        return FeedColumnMapping.objects.filter(feed_mapping_id=mapping_pk)
+
+    def perform_create(self, serializer):
+        mapping_pk = self.kwargs['mapping_pk']
+        serializer.save(feed_mapping_id=mapping_pk)

--- a/price_manager/supplier_feed/migrations/0011_merge_0009_feedcolumnmapping_0009_remove_feedmarkupset.py
+++ b/price_manager/supplier_feed/migrations/0011_merge_0009_feedcolumnmapping_0009_remove_feedmarkupset.py
@@ -1,0 +1,13 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    """Merge the two conflicting 0009 leaf migrations."""
+
+    dependencies = [
+        ('supplier_feed', '0009_feedcolumnmapping'),
+        ('supplier_feed', '0009_remove_feedmarkupset_feed_mapping_feedcolumnmapping_and_more'),
+        ('supplier_feed', '0010_feedcolumnmapping_supplier_feed_column_mapping_price_requires_type'),
+    ]
+
+    operations = []


### PR DESCRIPTION
## Summary

- Adds `FeedColumnMappingViewSet` (full CRUD) scoped to a parent `FeedMapping` via nested URL: `GET/POST /api/supplier-feed/mappings/<mapping_pk>/column-mappings/` and `GET/PATCH/DELETE .../column-mappings/<pk>/`
- Adds `FeedColumnMappingSerializer` with two serializer-level validators that prevent raw DB `IntegrityError` 500 responses:
  - `validate()` — enforces `price_type` required when `role == 'price'` (mirrors the model's `CheckConstraint`)
  - `validate_column_name()` — enforces uniqueness of `(feed_mapping, column_name)` within the parent mapping scope (mirrors the model's `UniqueConstraint`)
- Updates `API_MAP.md` to document the nested route structure (replaces the placeholder flat-endpoint docs)
- Adds merge migration `0011` to resolve pre-existing conflicting `0009` leaf migrations in `supplier_feed`

## Test plan

- [ ] `python manage.py check` passes (only pre-existing namespace warnings)
- [ ] `POST /api/supplier-feed/mappings/<pk>/column-mappings/` with `role=price` and no `price_type` → 400 with `{price_type: [...]}`
- [ ] `POST` duplicate `column_name` for same mapping → 400
- [ ] `GET /api/supplier-feed/mappings/<nonexistent_pk>/column-mappings/` → 404
- [ ] `PATCH /api/supplier-feed/mappings/<pk>/column-mappings/<id>/` cross-mapping access → 404
- [ ] Run full test suite via Docker: `docker compose up --build` then `python manage.py test supplier_feed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)