### PR TITLE
Frontend: Pricing feature — /prices PriceTypes page + PricingRules on supplier

### DIFF
--- a/frontend/FRONTEND_MAP.md
+++ b/frontend/FRONTEND_MAP.md
@@ -407,9 +407,44 @@ No top-level nav entry. All pages reachable contextually (from mapping edit page
 
 ---
 
-## Prices — `/prices`
+## Prices
 
-Placeholder page — not yet implemented.
+### `/prices` — PriceTypesPage
+File: `src/features/pricing/pages/PriceTypesPage.tsx`
+
+| Action | Endpoint |
+|--------|----------|
+| List price types | `GET /pricing/price-types/` |
+| Create price type | `POST /pricing/price-types/` |
+| Update label | `PATCH /pricing/price-types/{id}/` |
+| Delete price type | `DELETE /pricing/price-types/{id}/` |
+
+Query keys: `pricingKeys.priceTypes()`
+
+- Table with Ключ (slug, read-only) and Название (label) columns.
+- Create modal warns that the key cannot be changed after creation.
+- Edit modal allows updating only the label.
+- Delete shows a confirmation dialog.
+
+### PricingRulesSection (embedded in `/suppliers/:id`)
+File: `src/features/pricing/components/PricingRulesSection.tsx`
+
+| Action | Endpoint |
+|--------|----------|
+| List rules for supplier | `GET /pricing/rules/?supplier={id}` |
+| Create rule | `POST /pricing/rules/` |
+| Update rule | `PATCH /pricing/rules/{id}/` |
+| Delete rule | `DELETE /pricing/rules/{id}/` |
+| List price types (for labels) | `GET /pricing/price-types/` |
+
+Query keys: `pricingKeys.rules(supplierId)`, `pricingKeys.priceTypes()`
+
+- Rule cards show: `source_price_type label → dest_price_type label`, mode badge, priority.
+- Modal fields: source/dest price type Selects, mode SegmentedControl (formula/fixed).
+- Formula mode: markup % + increase NumberInputs.
+- Fixed mode: value NumberInput.
+- Optional conditions (Collapse): price_from, price_to, date_from, date_to.
+- Invalidates `pricingKeys.rules(supplierId)` on create/update/delete.
 
 ---
 
@@ -533,6 +568,19 @@ PATCH  /supplier-feed/markup-rules/{id}/
 DELETE /supplier-feed/markup-rules/{id}/
 ```
 
+### Pricing
+```
+GET    /pricing/price-types/
+POST   /pricing/price-types/
+PATCH  /pricing/price-types/{id}/
+DELETE /pricing/price-types/{id}/
+
+GET    /pricing/rules/              # ?supplier={id}
+POST   /pricing/rules/
+PATCH  /pricing/rules/{id}/
+DELETE /pricing/rules/{id}/
+```
+
 ---
 
 ## Polling Summary
@@ -573,3 +621,5 @@ DELETE /supplier-feed/markup-rules/{id}/
 | `transformKeys.snapshotField(id)` | field update |
 | `transformKeys.rules(mappingId)` | rule create/update/delete |
 | `transformKeys.snapshots(productId)` | read-only (transform task writes via backend) |
+| `pricingKeys.priceTypes()` | price type create/update/delete |
+| `pricingKeys.rules(supplierId)` | pricing rule create/update/delete |

--- a/frontend/src/features/pricing/api.ts
+++ b/frontend/src/features/pricing/api.ts
@@ -1,0 +1,44 @@
+import { api } from '@/api/client';
+import type { PriceType, PriceTypeWritePayload, PricingRule, PricingRuleWritePayload } from './types';
+
+const BASE = '/pricing';
+
+export async function listPriceTypes(): Promise<PriceType[]> {
+  const { data } = await api.get<PriceType[]>(`${BASE}/price-types/`);
+  return data;
+}
+
+export async function createPriceType(payload: PriceTypeWritePayload): Promise<PriceType> {
+  const { data } = await api.post<PriceType>(`${BASE}/price-types/`, payload);
+  return data;
+}
+
+export async function updatePriceType(id: number, payload: Partial<PriceTypeWritePayload>): Promise<PriceType> {
+  const { data } = await api.patch<PriceType>(`${BASE}/price-types/${id}/`, payload);
+  return data;
+}
+
+export async function deletePriceType(id: number): Promise<void> {
+  await api.delete(`${BASE}/price-types/${id}/`);
+}
+
+export async function listPricingRules(supplierId: number): Promise<PricingRule[]> {
+  const { data } = await api.get<PricingRule[]>(`${BASE}/rules/`, {
+    params: { supplier: supplierId },
+  });
+  return data;
+}
+
+export async function createPricingRule(payload: PricingRuleWritePayload): Promise<PricingRule> {
+  const { data } = await api.post<PricingRule>(`${BASE}/rules/`, payload);
+  return data;
+}
+
+export async function updatePricingRule(id: number, payload: Partial<PricingRuleWritePayload>): Promise<PricingRule> {
+  const { data } = await api.patch<PricingRule>(`${BASE}/rules/${id}/`, payload);
+  return data;
+}
+
+export async function deletePricingRule(id: number): Promise<void> {
+  await api.delete(`${BASE}/rules/${id}/`);
+}

--- a/frontend/src/features/pricing/components/PricingRulesSection.tsx
+++ b/frontend/src/features/pricing/components/PricingRulesSection.tsx
@@ -1,0 +1,419 @@
+import {
+  ActionIcon,
+  Badge,
+  Button,
+  Card,
+  Collapse,
+  Divider,
+  Group,
+  Modal,
+  NumberInput,
+  SegmentedControl,
+  Select,
+  Stack,
+  Text,
+  TextInput,
+} from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
+import { notifications } from '@mantine/notifications';
+import { IconEdit, IconPlus, IconTrash } from '@tabler/icons-react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useEffect, useState } from 'react';
+import {
+  createPricingRule,
+  deletePricingRule,
+  listPriceTypes,
+  listPricingRules,
+  updatePricingRule,
+} from '../api';
+import { pricingKeys } from '../queryKeys';
+import type { PricingRule, PricingRuleMode, PricingRuleWritePayload } from '../types';
+
+interface RuleFormState {
+  source_price_type: string;
+  dest_price_type: string;
+  mode: PricingRuleMode;
+  markup: number | string;
+  increase: number | string;
+  fixed_value: number | string;
+  priority: number | string;
+  price_from: string;
+  price_to: string;
+  date_from: string;
+  date_to: string;
+}
+
+const emptyForm: RuleFormState = {
+  source_price_type: '',
+  dest_price_type: '',
+  mode: 'formula',
+  markup: '',
+  increase: '',
+  fixed_value: '',
+  priority: 0,
+  price_from: '',
+  price_to: '',
+  date_from: '',
+  date_to: '',
+};
+
+function ruleToForm(rule: PricingRule): RuleFormState {
+  const params = rule.params as Record<string, unknown>;
+  return {
+    source_price_type: String(rule.source_price_type),
+    dest_price_type: String(rule.dest_price_type),
+    mode: rule.mode,
+    markup: rule.mode === 'formula' ? (params.markup as number ?? '') : '',
+    increase: rule.mode === 'formula' ? (params.increase as number ?? '') : '',
+    fixed_value: rule.mode === 'fixed' ? (params.value as number ?? '') : '',
+    priority: rule.priority,
+    price_from: rule.price_from ?? '',
+    price_to: rule.price_to ?? '',
+    date_from: rule.date_from ? rule.date_from.slice(0, 10) : '',
+    date_to: rule.date_to ? rule.date_to.slice(0, 10) : '',
+  };
+}
+
+function formToPayload(form: RuleFormState, supplierId: number): PricingRuleWritePayload {
+  const params: Record<string, unknown> =
+    form.mode === 'formula'
+      ? {
+          markup: form.markup === '' ? 0 : Number(form.markup),
+          increase: form.increase === '' ? 0 : Number(form.increase),
+        }
+      : { value: form.fixed_value === '' ? 0 : Number(form.fixed_value) };
+
+  return {
+    supplier: supplierId,
+    source_price_type: Number(form.source_price_type),
+    dest_price_type: Number(form.dest_price_type),
+    mode: form.mode,
+    params,
+    priority: form.priority === '' ? 0 : Number(form.priority),
+    price_from: form.price_from.trim() || null,
+    price_to: form.price_to.trim() || null,
+    date_from: form.date_from.trim() || null,
+    date_to: form.date_to.trim() || null,
+  };
+}
+
+interface PricingRuleModalProps {
+  opened: boolean;
+  onClose: () => void;
+  supplierId: number;
+  editRule?: PricingRule | null;
+}
+
+function PricingRuleModal({ opened, onClose, supplierId, editRule }: PricingRuleModalProps) {
+  const qc = useQueryClient();
+  const [form, setForm] = useState<RuleFormState>(
+    editRule ? ruleToForm(editRule) : emptyForm,
+  );
+  const [conditionsOpen, { toggle: toggleConditions }] = useDisclosure(false);
+
+  // Bug 1 fix: sync form state when modal opens or editRule changes
+  useEffect(() => {
+    if (opened) {
+      setForm(editRule ? ruleToForm(editRule) : emptyForm);
+    }
+  }, [opened, editRule]);
+
+  const { data: priceTypes } = useQuery({
+    queryKey: pricingKeys.priceTypes(),
+    queryFn: listPriceTypes,
+  });
+
+  const priceTypeOptions = (priceTypes ?? []).map((pt) => ({
+    value: String(pt.id),
+    label: pt.label,
+  }));
+
+  const isEdit = editRule != null;
+
+  const createMutation = useMutation({
+    mutationFn: (payload: PricingRuleWritePayload) => createPricingRule(payload),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: pricingKeys.rules(supplierId) });
+      onClose();
+    },
+    onError: () => {
+      notifications.show({ message: 'Не удалось создать правило', color: 'red' });
+    },
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: ({ id, payload }: { id: number; payload: PricingRuleWritePayload }) =>
+      updatePricingRule(id, payload),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: pricingKeys.rules(supplierId) });
+      onClose();
+    },
+    onError: () => {
+      notifications.show({ message: 'Не удалось обновить правило', color: 'red' });
+    },
+  });
+
+  function handleSubmit() {
+    const payload = formToPayload(form, supplierId);
+    if (isEdit) {
+      if (!editRule) return;
+      updateMutation.mutate({ id: editRule.id, payload });
+    } else {
+      createMutation.mutate(payload);
+    }
+  }
+
+  const isPending = createMutation.isPending || updateMutation.isPending;
+  const isValid =
+    form.source_price_type !== '' &&
+    form.dest_price_type !== '' &&
+    (form.mode === 'formula'
+      ? form.markup !== '' || form.increase !== ''
+      : form.fixed_value !== '');
+
+  function handleClose() {
+    onClose();
+  }
+
+  return (
+    <Modal
+      opened={opened}
+      onClose={handleClose}
+      title={isEdit ? 'Редактировать правило' : 'Новое правило ценообразования'}
+      size="md"
+    >
+      <Stack>
+        <Select
+          label="Исходный тип цены"
+          placeholder="Выберите тип"
+          data={priceTypeOptions}
+          value={form.source_price_type || null}
+          onChange={(v) => setForm({ ...form, source_price_type: v ?? '' })}
+          required
+          searchable
+        />
+        <Select
+          label="Целевой тип цены"
+          placeholder="Выберите тип"
+          data={priceTypeOptions}
+          value={form.dest_price_type || null}
+          onChange={(v) => setForm({ ...form, dest_price_type: v ?? '' })}
+          required
+          searchable
+        />
+
+        <Stack gap={4}>
+          <Text size="sm" fw={500}>
+            Режим
+          </Text>
+          <SegmentedControl
+            data={[
+              { value: 'formula', label: 'Формула' },
+              { value: 'fixed', label: 'Фиксированная' },
+            ]}
+            value={form.mode}
+            onChange={(v) => setForm({ ...form, mode: v as PricingRuleMode })}
+          />
+        </Stack>
+
+        {form.mode === 'formula' && (
+          <Group grow>
+            <NumberInput
+              label="Наценка %"
+              placeholder="0"
+              value={form.markup}
+              onChange={(v) => setForm({ ...form, markup: v })}
+            />
+            <NumberInput
+              label="Надбавка"
+              placeholder="0"
+              value={form.increase}
+              onChange={(v) => setForm({ ...form, increase: v })}
+            />
+          </Group>
+        )}
+
+        {form.mode === 'fixed' && (
+          <NumberInput
+            label="Значение"
+            placeholder="0"
+            value={form.fixed_value}
+            onChange={(v) => setForm({ ...form, fixed_value: v })}
+            required
+          />
+        )}
+
+        <NumberInput
+          label="Приоритет"
+          value={form.priority}
+          onChange={(v) => setForm({ ...form, priority: v })}
+        />
+
+        <Button
+          variant="subtle"
+          size="sm"
+          onClick={toggleConditions}
+          styles={{ root: { alignSelf: 'flex-start' } }}
+        >
+          {conditionsOpen ? 'Скрыть условия' : 'Добавить условия'}
+        </Button>
+
+        <Collapse in={conditionsOpen}>
+          <Stack gap="sm">
+            <Group grow>
+              <NumberInput
+                label="Цена от"
+                placeholder="—"
+                value={form.price_from}
+                onChange={(v) => setForm({ ...form, price_from: v === '' ? '' : String(v) })}
+                decimalScale={2}
+              />
+              <NumberInput
+                label="Цена до"
+                placeholder="—"
+                value={form.price_to}
+                onChange={(v) => setForm({ ...form, price_to: v === '' ? '' : String(v) })}
+                decimalScale={2}
+              />
+            </Group>
+            <Group grow>
+              <TextInput
+                type="date"
+                label="Дата начала"
+                value={form.date_from}
+                onChange={(e) => setForm({ ...form, date_from: e.currentTarget.value })}
+              />
+              <TextInput
+                type="date"
+                label="Дата окончания"
+                value={form.date_to}
+                onChange={(e) => setForm({ ...form, date_to: e.currentTarget.value })}
+              />
+            </Group>
+          </Stack>
+        </Collapse>
+
+        <Group justify="flex-end">
+          <Button variant="default" onClick={handleClose}>
+            Отмена
+          </Button>
+          <Button loading={isPending} disabled={!isValid} onClick={handleSubmit}>
+            {isEdit ? 'Сохранить' : 'Создать'}
+          </Button>
+        </Group>
+      </Stack>
+    </Modal>
+  );
+}
+
+interface PricingRulesSectionProps {
+  supplierId: number;
+}
+
+export function PricingRulesSection({ supplierId }: PricingRulesSectionProps) {
+  const qc = useQueryClient();
+
+  const { data: rules } = useQuery({
+    queryKey: pricingKeys.rules(supplierId),
+    queryFn: () => listPricingRules(supplierId),
+  });
+
+  const { data: priceTypes } = useQuery({
+    queryKey: pricingKeys.priceTypes(),
+    queryFn: listPriceTypes,
+  });
+
+  const priceTypeById = Object.fromEntries((priceTypes ?? []).map((pt) => [pt.id, pt]));
+
+  const [addOpened, { open: openAdd, close: closeAdd }] = useDisclosure(false);
+  const [editRule, setEditRule] = useState<PricingRule | null>(null);
+
+  const deleteMutation = useMutation({
+    mutationFn: deletePricingRule,
+    onSuccess: () => qc.invalidateQueries({ queryKey: pricingKeys.rules(supplierId) }),
+    onError: () => {
+      notifications.show({ message: 'Не удалось удалить правило', color: 'red' });
+    },
+  });
+
+  return (
+    <>
+      <Divider label="Правила ценообразования" labelPosition="left" mt="xl" />
+
+      <Stack gap="sm">
+        {(rules ?? []).map((rule) => {
+          const srcLabel = priceTypeById[rule.source_price_type]?.label ?? String(rule.source_price_type);
+          const dstLabel = priceTypeById[rule.dest_price_type]?.label ?? String(rule.dest_price_type);
+
+          return (
+            <Card key={rule.id} withBorder padding="sm">
+              <Group justify="space-between">
+                <Group gap="xs">
+                  <Text size="sm" fw={500}>
+                    {srcLabel} → {dstLabel}
+                  </Text>
+                  <Badge
+                    variant="light"
+                    color={rule.mode === 'formula' ? 'blue' : 'gray'}
+                    size="sm"
+                  >
+                    {rule.mode === 'formula' ? 'Формула' : 'Фиксированная'}
+                  </Badge>
+                  <Text size="xs" c="dimmed">
+                    Приоритет: {rule.priority}
+                  </Text>
+                </Group>
+                <Group gap="xs">
+                  <ActionIcon
+                    variant="subtle"
+                    onClick={() => setEditRule(rule)}
+                    aria-label="Редактировать"
+                  >
+                    <IconEdit size={16} />
+                  </ActionIcon>
+                  <ActionIcon
+                    variant="subtle"
+                    color="red"
+                    loading={
+                      deleteMutation.isPending && deleteMutation.variables === rule.id
+                    }
+                    onClick={() => {
+                      if (confirm('Удалить правило ценообразования?')) {
+                        deleteMutation.mutate(rule.id);
+                      }
+                    }}
+                    aria-label="Удалить"
+                  >
+                    <IconTrash size={16} />
+                  </ActionIcon>
+                </Group>
+              </Group>
+            </Card>
+          );
+        })}
+
+        <Button
+          variant="subtle"
+          leftSection={<IconPlus size={16} />}
+          onClick={openAdd}
+          styles={{ root: { alignSelf: 'flex-start' } }}
+        >
+          Добавить правило
+        </Button>
+      </Stack>
+
+      <PricingRuleModal
+        opened={addOpened}
+        onClose={closeAdd}
+        supplierId={supplierId}
+      />
+
+      <PricingRuleModal
+        opened={editRule != null}
+        onClose={() => setEditRule(null)}
+        supplierId={supplierId}
+        editRule={editRule}
+      />
+    </>
+  );
+}

--- a/frontend/src/features/pricing/pages/PriceTypesPage.tsx
+++ b/frontend/src/features/pricing/pages/PriceTypesPage.tsx
@@ -1,0 +1,244 @@
+import {
+  ActionIcon,
+  Button,
+  Card,
+  Group,
+  Loader,
+  Modal,
+  Stack,
+  Table,
+  Text,
+  TextInput,
+  Title,
+} from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
+import { notifications } from '@mantine/notifications';
+import { IconEdit, IconPlus, IconTrash } from '@tabler/icons-react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
+import { createPriceType, deletePriceType, listPriceTypes, updatePriceType } from '../api';
+import { pricingKeys } from '../queryKeys';
+import type { PriceType } from '../types';
+
+interface CreateForm {
+  name: string;
+  label: string;
+}
+
+const emptyCreateForm: CreateForm = { name: '', label: '' };
+
+export function PriceTypesPage() {
+  const qc = useQueryClient();
+
+  const { data, isLoading } = useQuery({
+    queryKey: pricingKeys.priceTypes(),
+    queryFn: listPriceTypes,
+  });
+
+  // ---- Create modal -------------------------------------------------------
+  const [createOpened, { open: openCreate, close: closeCreate }] = useDisclosure(false);
+  const [createForm, setCreateForm] = useState<CreateForm>(emptyCreateForm);
+
+  // Bug 3 fix: reset form on cancel so stale values don't persist on reopen
+  function handleCloseCreate() {
+    setCreateForm(emptyCreateForm);
+    closeCreate();
+  }
+
+  const createMutation = useMutation({
+    mutationFn: createPriceType,
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: pricingKeys.priceTypes() });
+      handleCloseCreate();
+    },
+    onError: () => {
+      notifications.show({ message: 'Не удалось создать тип цены', color: 'red' });
+    },
+  });
+
+  // ---- Edit modal ---------------------------------------------------------
+  const [editTarget, setEditTarget] = useState<PriceType | null>(null);
+  const [editLabel, setEditLabel] = useState('');
+
+  function openEdit(pt: PriceType) {
+    setEditTarget(pt);
+    setEditLabel(pt.label);
+  }
+
+  function closeEdit() {
+    setEditTarget(null);
+    setEditLabel('');
+  }
+
+  const updateMutation = useMutation({
+    mutationFn: ({ id, label }: { id: number; label: string }) =>
+      updatePriceType(id, { label }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: pricingKeys.priceTypes() });
+      closeEdit();
+    },
+    onError: () => {
+      notifications.show({ message: 'Не удалось обновить тип цены', color: 'red' });
+    },
+  });
+
+  // ---- Delete -------------------------------------------------------------
+  const deleteMutation = useMutation({
+    mutationFn: deletePriceType,
+    onSuccess: () => qc.invalidateQueries({ queryKey: pricingKeys.priceTypes() }),
+    onError: () => {
+      notifications.show({ message: 'Не удалось удалить тип цены', color: 'red' });
+    },
+  });
+
+  return (
+    <Stack>
+      <Group justify="space-between">
+        <Title order={2}>Типы цен</Title>
+        <Button leftSection={<IconPlus size={16} />} onClick={openCreate}>
+          Добавить
+        </Button>
+      </Group>
+
+      {isLoading && <Loader />}
+
+      {!isLoading && (data ?? []).length === 0 && (
+        <Card withBorder padding="lg">
+          <Stack align="center" gap="xs">
+            <Text c="dimmed">Типы цен не добавлены</Text>
+            <Button
+              variant="light"
+              leftSection={<IconPlus size={16} />}
+              onClick={openCreate}
+            >
+              Добавить первый
+            </Button>
+          </Stack>
+        </Card>
+      )}
+
+      {!isLoading && (data ?? []).length > 0 && (
+        <Card withBorder padding={0}>
+          <Table>
+            <Table.Thead>
+              <Table.Tr>
+                <Table.Th>Ключ</Table.Th>
+                <Table.Th>Название</Table.Th>
+                <Table.Th />
+              </Table.Tr>
+            </Table.Thead>
+            <Table.Tbody>
+              {(data ?? []).map((pt) => (
+                <Table.Tr key={pt.id}>
+                  <Table.Td>
+                    <Text size="sm" c="dimmed" ff="monospace">
+                      {pt.name}
+                    </Text>
+                  </Table.Td>
+                  <Table.Td>{pt.label}</Table.Td>
+                  <Table.Td>
+                    <Group justify="flex-end" gap="xs">
+                      <ActionIcon
+                        variant="subtle"
+                        onClick={() => openEdit(pt)}
+                        aria-label="Редактировать"
+                      >
+                        <IconEdit size={16} />
+                      </ActionIcon>
+                      <ActionIcon
+                        variant="subtle"
+                        color="red"
+                        loading={
+                          deleteMutation.isPending && deleteMutation.variables === pt.id
+                        }
+                        onClick={() => {
+                          if (confirm(`Удалить тип цены «${pt.label}»?`)) {
+                            deleteMutation.mutate(pt.id);
+                          }
+                        }}
+                        aria-label="Удалить"
+                      >
+                        <IconTrash size={16} />
+                      </ActionIcon>
+                    </Group>
+                  </Table.Td>
+                </Table.Tr>
+              ))}
+            </Table.Tbody>
+          </Table>
+        </Card>
+      )}
+
+      {/* Create modal */}
+      <Modal opened={createOpened} onClose={handleCloseCreate} title="Новый тип цены">
+        <Stack>
+          <TextInput
+            label="Ключ (slug)"
+            placeholder="retail_price"
+            value={createForm.name}
+            onChange={(e) => setCreateForm({ ...createForm, name: e.currentTarget.value })}
+            required
+            description="Ключ нельзя изменить после создания"
+          />
+          <TextInput
+            label="Название"
+            placeholder="Розничная цена"
+            value={createForm.label}
+            onChange={(e) => setCreateForm({ ...createForm, label: e.currentTarget.value })}
+            required
+          />
+          <Group justify="flex-end">
+            <Button variant="default" onClick={handleCloseCreate}>
+              Отмена
+            </Button>
+            <Button
+              loading={createMutation.isPending}
+              disabled={!createForm.name.trim() || !createForm.label.trim()}
+              onClick={() =>
+                createMutation.mutate({
+                  name: createForm.name.trim(),
+                  label: createForm.label.trim(),
+                })
+              }
+            >
+              Создать
+            </Button>
+          </Group>
+        </Stack>
+      </Modal>
+
+      {/* Edit label modal */}
+      <Modal
+        opened={editTarget != null}
+        onClose={closeEdit}
+        title="Редактировать название"
+        size="sm"
+      >
+        <Stack>
+          <TextInput
+            label="Название"
+            value={editLabel}
+            onChange={(e) => setEditLabel(e.currentTarget.value)}
+            required
+          />
+          <Group justify="flex-end">
+            <Button variant="default" onClick={closeEdit}>
+              Отмена
+            </Button>
+            <Button
+              loading={updateMutation.isPending}
+              disabled={!editLabel.trim()}
+              onClick={() => {
+                if (editTarget) {
+                  updateMutation.mutate({ id: editTarget.id, label: editLabel.trim() });
+                }
+              }}
+            >
+              Сохранить
+            </Button>
+          </Group>
+        </Stack>
+      </Modal>
+    </Stack>
+  );
+}

--- a/frontend/src/features/pricing/queryKeys.ts
+++ b/frontend/src/features/pricing/queryKeys.ts
@@ -1,0 +1,7 @@
+export const pricingKeys = {
+  all: ['pricing'] as const,
+  priceTypes: () => [...pricingKeys.all, 'price-types'] as const,
+  priceType: (id: number) => [...pricingKeys.all, 'price-types', id] as const,
+  rules: (supplierId?: number) => [...pricingKeys.all, 'rules', supplierId] as const,
+  rule: (id: number) => [...pricingKeys.all, 'rules', 'detail', id] as const,
+};

--- a/frontend/src/features/pricing/types.ts
+++ b/frontend/src/features/pricing/types.ts
@@ -1,0 +1,41 @@
+export interface PriceType {
+  id: number;
+  name: string;
+  label: string;
+}
+
+export interface PriceTypeWritePayload {
+  name: string;
+  label: string;
+}
+
+export type PricingRuleMode = 'fixed' | 'formula';
+
+export interface PricingRule {
+  id: number;
+  supplier: number;
+  source_price_type: number;
+  dest_price_type: number;
+  mode: PricingRuleMode;
+  params: Record<string, unknown>;
+  priority: number;
+  category: number | null;
+  price_from: string | null;
+  price_to: string | null;
+  date_from: string | null;
+  date_to: string | null;
+}
+
+export interface PricingRuleWritePayload {
+  supplier: number;
+  source_price_type: number;
+  dest_price_type: number;
+  mode: PricingRuleMode;
+  params: Record<string, unknown>;
+  priority: number;
+  category?: number | null;
+  price_from?: string | null;
+  price_to?: string | null;
+  date_from?: string | null;
+  date_to?: string | null;
+}

--- a/frontend/src/features/supplier/__tests__/SupplierDetailPage.test.tsx
+++ b/frontend/src/features/supplier/__tests__/SupplierDetailPage.test.tsx
@@ -34,6 +34,9 @@ function baseHandlers() {
     http.get('/api/suppliers/1/', () => HttpResponse.json(SUPPLIER)),
     http.get('/api/supplier-feed/mappings/', () => HttpResponse.json([MAPPING])),
     http.get('/api/supplier-feed/feeds/', () => HttpResponse.json([FEED])),
+    // PricingRulesSection handlers
+    http.get('/api/pricing/price-types/', () => HttpResponse.json([])),
+    http.get('/api/pricing/rules/', () => HttpResponse.json([])),
   ];
 }
 

--- a/frontend/src/features/supplier/pages/SupplierDetailPage.tsx
+++ b/frontend/src/features/supplier/pages/SupplierDetailPage.tsx
@@ -23,6 +23,7 @@ import { Link, useNavigate, useParams } from 'react-router-dom';
 import { createFeed, deleteFeedMapping, getSupplier, listFeedMappings, listFeeds } from '../api';
 import { supplierKeys } from '../queryKeys';
 import type { FeedMapping, SupplierFeedStatus } from '../types';
+import { PricingRulesSection } from '@/features/pricing/components/PricingRulesSection';
 
 type MappingSortField = 'name' | 'pipeline' | 'sku_column' | 'threshold';
 type SortDir = 'asc' | 'desc';
@@ -320,6 +321,8 @@ export function SupplierDetailPage() {
           )}
         </Stack>
       )}
+
+      {!isLoading && <PricingRulesSection supplierId={supplierId} />}
 
       <Modal opened={modalOpen} onClose={closeModal} title="Новая выгрузка">
         <Stack>

--- a/frontend/src/routes.tsx
+++ b/frontend/src/routes.tsx
@@ -21,6 +21,7 @@ import { FeedMappingEditPage } from '@/features/supplier/pages/FeedMappingEditPa
 import { SupplierFeedPage } from '@/features/supplier/pages/SupplierFeedPage';
 import { FeedQueuePage } from '@/features/supplier/pages/FeedQueuePage';
 import { SupplierLinksPage } from '@/features/supplier/pages/SupplierLinksPage';
+import { PriceTypesPage } from '@/features/pricing/pages/PriceTypesPage';
 
 export const router = createBrowserRouter([
   { path: '/login', element: <LoginPage /> },
@@ -50,7 +51,7 @@ export const router = createBrowserRouter([
       { path: 'products/characteristics', element: <CharacteristicTypesPage /> },
       { path: 'products/:id', element: <ProductDetailPage /> },
       { path: 'products/:id/edit', element: <ProductEditorPage /> },
-      { path: 'prices', element: <PlaceholderPage title="Цены" /> },
+      { path: 'prices', element: <PriceTypesPage /> },
       { path: 'dataframe', element: <DataframeListPage /> },
       { path: 'dataframe/new', element: <DataframeEditorPage /> },
       { path: 'dataframe/:id', element: <DataframeEditorPage /> },
@@ -58,7 +59,3 @@ export const router = createBrowserRouter([
   },
   { path: '*', element: <Navigate to="/" replace /> },
 ]);
-
-function PlaceholderPage({ title }: { title: string }) {
-  return <h2>{title} — раздел в разработке</h2>;
-}


### PR DESCRIPTION
## Summary

- Implements full pricing SPA feature: `PriceTypesPage` at `/prices` for CRUD on price type objects, and `PricingRulesSection` embedded in `SupplierDetailPage` for per-supplier pricing rule management
- Adds `pricing/api.ts`, `pricing/types.ts`, `pricing/queryKeys.ts` as the data layer
- Wires `/prices` route in `routes.tsx` and adds the pricing rules section to `SupplierDetailPage`

## Bug fixes applied

- **Bug 1**: Edit modal form was always blank on first open — fixed with `useEffect` that syncs form state when `opened` or `editRule` changes
- **Bug 2**: `handleClose` was calling `setForm` (stale state at close time) — removed, the `useEffect` handles reset on open instead
- **Bug 3**: Create modal form in `PriceTypesPage` was not reset on cancel — added `handleCloseCreate()` that resets `createForm` before closing
- **Bug 4**: All mutations lacked `onError` handlers — added Russian-language `notifications.show(...)` for all 6 mutations across both files
- **Bug 5**: `updateMutation` used `editRule!.id` (non-null assertion crash risk) — refactored to pass `{ id, payload }` as mutation argument with explicit null guard at call site

## Test plan

- [ ] `pnpm typecheck` — passes (no errors)
- [ ] `pnpm test` — 1 pre-existing failure in `importPersistence.test.ts` (unrelated to this PR); all other tests pass
- [ ] Manual: navigate to `/prices`, create/edit/delete a price type, confirm form resets on cancel
- [ ] Manual: open supplier detail, add/edit/delete a pricing rule, confirm edit modal shows correct data on reopen, confirm API errors show notifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)