### PR TITLE
feat: replace embedding matcher with pg_trgm + rapidfuzz

### DIFF
--- a/API_MAP.md
+++ b/API_MAP.md
@@ -763,15 +763,15 @@ draft → (upload files) → process → processing → matched / partial → (r
 
 ### Feed Mappings
 
-Configuration templates that describe how to parse a supplier's file format. Each mapping references a **Dataframe pipeline** (`dataframe` FK) which is applied to every uploaded file before matching — raw files are never read directly. Column names (`supplier_sku_column`, `identity_columns`, `variable_columns`) refer to the **output** of the pipeline, not the raw file.
+Configuration templates that describe how to parse a supplier's file format. Each mapping references a **Dataframe pipeline** (`dataframe` FK) which is applied to every uploaded file before matching — raw files are never read directly. Column names (`supplier_sku_column`, `name_column`, `variable_columns`) refer to the **output** of the pipeline, not the raw file.
 
 #### `GET /api/supplier-feed/mappings/`
 
 Lists all feed mapping configurations, ordered by supplier + name. Supports `?supplier=<id>` filter.
 
-**Response fields:** `id`, `supplier`, `name`, `dataframe` (PK), `dataframe_detail` `{id, name}`, `supplier_sku_column`, `identity_columns`, `variable_columns`, `auto_match_threshold`, `product_name_column`, `product_sku_column`.
+**Response fields:** `id`, `supplier`, `name`, `dataframe` (PK), `dataframe_detail` `{id, name}`, `supplier_sku_column`, `name_column` (required), `variable_columns`, `auto_match_threshold`, `low_match_threshold`, `product_sku_column`.
 
-`product_name_column` and `product_sku_column` are optional column hints used by the `create-product` UI: they tell the SPA which pipeline-output column to pre-fill the new-product name / SKU fields from.
+`name_column` is the pipeline-output column used as the product name for text matching and for the `create-product` UI. `product_sku_column` is an optional column hint for pre-filling the SKU field.
 
 #### `POST /api/supplier-feed/mappings/`
 
@@ -783,10 +783,10 @@ Creates a feed mapping. `dataframe` is required — create a pipeline first via 
   "name": "Прайс-лист основной",
   "dataframe": 3,
   "supplier_sku_column": "sku",
-  "identity_columns": ["sku", "name"],
+  "name_column": "name",
   "variable_columns": ["price", "stock"],
   "auto_match_threshold": 0.92,
-  "product_name_column": "name",
+  "low_match_threshold": 0.5,
   "product_sku_column": "sku"
 }
 ```

--- a/price_manager/requirements.txt
+++ b/price_manager/requirements.txt
@@ -77,6 +77,7 @@ python-dateutil==2.9.0.post0
 python-dotenv==1.2.1
 pytz==2025.2
 pyxlsb==1.0.10
+rapidfuzz>=3.0
 regex==2026.2.28
 requests==2.32.5
 selenium==4.40.0

--- a/price_manager/supplier_feed/api/serializers.py
+++ b/price_manager/supplier_feed/api/serializers.py
@@ -80,10 +80,10 @@ class FeedMappingSerializer(serializers.ModelSerializer):
             'dataframe',
             'dataframe_detail',
             'supplier_sku_column',
-            'identity_columns',
+            'name_column',
             'variable_columns',
             'auto_match_threshold',
-            'product_name_column',
+            'low_match_threshold',
             'product_sku_column',
         ]
 

--- a/price_manager/supplier_feed/matcher.py
+++ b/price_manager/supplier_feed/matcher.py
@@ -1,53 +1,43 @@
 """Supplier feed matching module.
 
-Deep module with a single public function:
-    run_matching(feed, rows) -> {'matched': int, 'queued': int}
-
 Algorithm:
-  1. Load all SupplierLink records for the supplier into a dict (one DB query).
-  2. For rows with a cached link → create SupplierFeedEntry immediately.
-  3. For the rest → call embed_query() per row (asymmetric query mode).
-  4. For each embedding, find the nearest Product via CosineDistance HNSW index.
-     - score >= threshold  → auto-match: create SupplierFeedEntry + SupplierLink.
-     - score <  threshold  → queue:      create SupplierFeedEntry with
-                                          product=None and top-N candidates.
-  5. Bulk-write all entries; bulk-create new links with update_conflicts.
+  1. Load all SupplierLink records for the supplier (one DB query).
+  2. Rows with a cached link → create SupplierFeedEntry immediately.
+  3. Rows without a link → text matching against Product.name:
+     a. pg_trgm pre-filter (GIN index) returns top-10 candidates.
+     b. rapidfuzz.token_sort_ratio re-ranks them (word-order-insensitive).
+     c. best_score >= auto_match_threshold → auto-match + SupplierLink.
+     d. low_match_threshold <= best_score < auto_match_threshold → MatchQueue with candidates.
+     e. best_score < low_match_threshold (or no candidates) → MatchQueue without candidates.
+  4. Bulk-write all entries; bulk-create new links.
 
-Mocking point for tests:  patch 'supplier_feed.matcher.embed_query'.
+Mocking point for tests: patch 'supplier_feed.matcher._find_candidates'.
 """
 from __future__ import annotations
 
 import logging
 from typing import Any
 
-from pgvector.django import CosineDistance
+from django.contrib.postgres.search import TrigramSimilarity
+from rapidfuzz import fuzz
 
 from product.models import Product
-from product.services.embeddings import embed_query
 from .models import SupplierFeedEntry, SupplierLink
 
 logger = logging.getLogger(__name__)
 
 TOP_N_CANDIDATES = 5
+TRGM_PREFILTER_MULTIPLIER = 0.7  # looser than low_thresh to allow re-rank headroom
 
 
 def run_matching(feed, rows: list[dict[str, Any]]) -> dict[str, int]:
-    """Match feed rows against the Product catalogue.
-
-    Creates ``SupplierFeedEntry`` records for every row and ``SupplierLink``
-    records for every automatic match (either via cached link or high-score
-    vector similarity).
-
-    Returns ``{'matched': int, 'queued': int, 'skipped': int}``.
-    """
     mapping = feed.feed_mapping
     sku_col: str = mapping.supplier_sku_column
-    id_cols: list[str] = list(mapping.identity_columns or [])
+    name_col: str = mapping.name_column
     var_cols: list[str] = list(mapping.variable_columns or [])
-    threshold: float = float(mapping.auto_match_threshold)
+    high_thresh: float = float(mapping.auto_match_threshold)
+    low_thresh: float = float(mapping.low_match_threshold)
 
-    # ── Step 1: load all SupplierLink records for this supplier (one query) ──
-    # product_id=None means ignore-link (permanent skip marker).
     cached_links: dict[str, int | None] = {
         sl.supplier_sku: sl.product_id
         for sl in SupplierLink.objects.filter(supplier=feed.supplier)
@@ -55,107 +45,59 @@ def run_matching(feed, rows: list[dict[str, Any]]) -> dict[str, int]:
 
     entries_to_create: list[SupplierFeedEntry] = []
     links_to_create: list[SupplierLink] = []
-    need_embed: list[tuple[dict, str, dict]] = []
+    need_text: list[tuple[str, str, dict]] = []  # (supplier_sku, entry_name, data)
 
-    matched = 0
-    queued = 0
-    skipped = 0
+    matched = queued = skipped = 0
 
-    # ── Step 2: partition rows into linked / ignore-linked / unlinked ─────────
     for row in rows:
         supplier_sku = str(row.get(sku_col) or '').strip()
         if not supplier_sku:
             continue
         data = {
-            **{col: row.get(col) for col in id_cols if col in row},
-            **{col: row.get(col) for col in var_cols if col in row},
+            col: row.get(col)
+            for col in ([name_col] + var_cols)
+            if col in row
         }
 
         if supplier_sku in cached_links:
             product_id = cached_links[supplier_sku]
             if product_id is None:
                 entries_to_create.append(SupplierFeedEntry(
-                    feed=feed,
-                    supplier_sku=supplier_sku,
-                    data=data,
-                    skipped=True,
+                    feed=feed, supplier_sku=supplier_sku, data=data, skipped=True,
                 ))
                 skipped += 1
             else:
                 entries_to_create.append(SupplierFeedEntry(
-                    feed=feed,
-                    supplier_sku=supplier_sku,
-                    product_id=product_id,
-                    data=data,
+                    feed=feed, supplier_sku=supplier_sku, product_id=product_id, data=data,
                 ))
                 matched += 1
         else:
-            need_embed.append((row, supplier_sku, data))
+            entry_name = str(row.get(name_col) or supplier_sku).strip()
+            need_text.append((supplier_sku, entry_name, data))
 
-    # ── Steps 3–4: embed unlinked rows and find nearest product ───────────────
-    for row, supplier_sku, data in need_embed:
-        identity_text = ' '.join(
-            str(row.get(col, '')) for col in id_cols if col in row
-        ).strip() or supplier_sku
+    for supplier_sku, entry_name, data in need_text:
+        candidates = _find_candidates(entry_name, low_thresh)
 
-        vec = embed_query(identity_text)
-
-        candidates = list(
-            Product.objects
-            .filter(embedding__isnull=False)
-            .select_related('category', 'brand')
-            .annotate(distance=CosineDistance('embedding', vec))
-            .order_by('distance')[:TOP_N_CANDIDATES]
-        )
-
-        if candidates:
+        if candidates and candidates[0]['score'] >= high_thresh:
             best = candidates[0]
-            best_dist = float(best.distance) if best.distance is not None else 2.0
-            similarity = 1.0 - best_dist
-        else:
-            best = None
-            similarity = -1.0
-
-        if best is not None and similarity >= threshold:
-            # Auto-match
             entries_to_create.append(SupplierFeedEntry(
-                feed=feed,
-                supplier_sku=supplier_sku,
-                product_id=best.pk,
-                data=data,
-                best_score=round(similarity, 4),
+                feed=feed, supplier_sku=supplier_sku, product_id=best['product_id'],
+                data=data, best_score=best['score'],
             ))
             links_to_create.append(SupplierLink(
-                supplier=feed.supplier,
-                supplier_sku=supplier_sku,
-                product_id=best.pk,
+                supplier=feed.supplier, supplier_sku=supplier_sku,
+                product_id=best['product_id'],
             ))
             matched += 1
         else:
-            # Queue with top-N candidates for manual review
-            candidate_list = [
-                {
-                    'product_id': p.pk,
-                    'score': round(1.0 - float(p.distance), 4),
-                    'name': p.name,
-                    'sku': p.sku,
-                    'category': p.category.name if p.category_id else None,
-                    'brand': p.brand.name if p.brand_id else None,
-                }
-                for p in candidates
-            ]
-            queued_score = round(similarity, 4) if best is not None else None
             entries_to_create.append(SupplierFeedEntry(
-                feed=feed,
-                supplier_sku=supplier_sku,
-                product_id=None,
+                feed=feed, supplier_sku=supplier_sku, product_id=None,
                 data=data,
-                match_candidates=candidate_list,
-                best_score=queued_score,
+                match_candidates=candidates,
+                best_score=candidates[0]['score'] if candidates else None,
             ))
             queued += 1
 
-    # ── Step 5: bulk-write entries and new links ───────────────────────────────
     if entries_to_create:
         SupplierFeedEntry.objects.bulk_create(entries_to_create, batch_size=500)
 
@@ -168,6 +110,37 @@ def run_matching(feed, rows: list[dict[str, Any]]) -> dict[str, int]:
         )
 
     logger.info(
-        'run_matching feed=%s matched=%d queued=%d skipped=%d', feed.pk, matched, queued, skipped
+        'run_matching feed=%s matched=%d queued=%d skipped=%d',
+        feed.pk, matched, queued, skipped,
     )
     return {'matched': matched, 'queued': queued, 'skipped': skipped}
+
+
+def _find_candidates(name: str, low_thresh: float) -> list[dict]:
+    if not name:
+        return []
+
+    trgm_min = low_thresh * TRGM_PREFILTER_MULTIPLIER
+    qs = (
+        Product.objects
+        .annotate(trgm=TrigramSimilarity('name', name))
+        .filter(trgm__gt=trgm_min)
+        .select_related('category', 'brand')
+        .order_by('-trgm')[:10]
+    )
+
+    results = []
+    for p in qs:
+        score = fuzz.token_sort_ratio(name.lower(), p.name.lower()) / 100.0
+        if score >= low_thresh:
+            results.append({
+                'product_id': p.pk,
+                'score': round(score, 4),
+                'name': p.name,
+                'sku': p.sku,
+                'category': p.category.name if p.category_id else None,
+                'brand': p.brand.name if p.brand_id else None,
+            })
+
+    results.sort(key=lambda x: x['score'], reverse=True)
+    return results[:TOP_N_CANDIDATES]

--- a/price_manager/supplier_feed/migrations/0011_feedmapping_text_matching.py
+++ b/price_manager/supplier_feed/migrations/0011_feedmapping_text_matching.py
@@ -1,0 +1,41 @@
+from django.db import migrations, models
+
+
+def backfill_name_column(apps, schema_editor):
+    FeedMapping = apps.get_model('supplier_feed', 'FeedMapping')
+    to_update = []
+    for fm in FeedMapping.objects.filter(name_column=''):
+        fm.name_column = fm.supplier_sku_column
+        to_update.append(fm)
+    if to_update:
+        FeedMapping.objects.bulk_update(to_update, ['name_column'])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('supplier_feed', '0010_feedcolumnmapping_supplier_feed_column_mapping_price_requires_type'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='feedmapping',
+            name='identity_columns',
+        ),
+        migrations.RenameField(
+            model_name='feedmapping',
+            old_name='product_name_column',
+            new_name='name_column',
+        ),
+        migrations.RunPython(backfill_name_column, migrations.RunPython.noop),
+        migrations.AlterField(
+            model_name='feedmapping',
+            name='name_column',
+            field=models.CharField(max_length=128, verbose_name='Колонка названия товара'),
+        ),
+        migrations.AddField(
+            model_name='feedmapping',
+            name='low_match_threshold',
+            field=models.FloatField(default=0.5, verbose_name='Нижний порог совпадения'),
+        ),
+    ]

--- a/price_manager/supplier_feed/migrations/0012_product_trgm_index.py
+++ b/price_manager/supplier_feed/migrations/0012_product_trgm_index.py
@@ -1,0 +1,19 @@
+from django.contrib.postgres.operations import CreateExtension
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    atomic = False
+
+    dependencies = [
+        ('supplier_feed', '0011_feedmapping_text_matching'),
+    ]
+
+    operations = [
+        CreateExtension('pg_trgm'),
+        migrations.RunSQL(
+            sql="CREATE INDEX CONCURRENTLY IF NOT EXISTS product_name_trgm_idx ON product_product USING GIN(name gin_trgm_ops);",
+            reverse_sql="DROP INDEX IF EXISTS product_name_trgm_idx;",
+        ),
+    ]

--- a/price_manager/supplier_feed/models.py
+++ b/price_manager/supplier_feed/models.py
@@ -35,10 +35,10 @@ class FeedMapping(models.Model):
     )
     name = models.CharField('Название', max_length=255)
     supplier_sku_column = models.CharField('Колонка артикула поставщика', max_length=128)
-    identity_columns = models.JSONField('Identity-колонки', default=list, blank=True)
+    name_column = models.CharField('Колонка названия товара', max_length=128)
     variable_columns = models.JSONField('Переменные колонки', default=list, blank=True)
     auto_match_threshold = models.FloatField('Порог авто-матчинга', default=0.92)
-    product_name_column = models.CharField('Колонка названия товара', max_length=128, blank=True)
+    low_match_threshold = models.FloatField('Нижний порог совпадения', default=0.5)
     product_sku_column = models.CharField('Колонка артикула товара', max_length=128, blank=True)
 
     class Meta:

--- a/price_manager/supplier_feed/tests/fixtures.py
+++ b/price_manager/supplier_feed/tests/fixtures.py
@@ -21,7 +21,8 @@ def make_dataframe(name='Test Pipeline'):
     return df
 
 
-def make_feed_mapping(supplier=None, name='Прайс', supplier_sku_column='article', **kwargs):
+def make_feed_mapping(supplier=None, name='Прайс', supplier_sku_column='article',
+                      name_column='name', low_match_threshold=0.5, **kwargs):
     if supplier is None:
         supplier = make_supplier()
     if 'dataframe' not in kwargs:
@@ -30,6 +31,8 @@ def make_feed_mapping(supplier=None, name='Прайс', supplier_sku_column='art
         supplier=supplier,
         name=name,
         supplier_sku_column=supplier_sku_column,
+        name_column=name_column,
+        low_match_threshold=low_match_threshold,
         **kwargs,
     )
 

--- a/price_manager/supplier_feed/tests/test_api_mappings.py
+++ b/price_manager/supplier_feed/tests/test_api_mappings.py
@@ -43,7 +43,7 @@ class CreateFeedMappingTests(FeedMappingApiBase):
                 'name': 'Прайс Рога',
                 'dataframe': self.dataframe.pk,
                 'supplier_sku_column': 'article',
-                'identity_columns': ['article', 'name'],
+                'name_column': 'name',
                 'variable_columns': ['price', 'stock'],
                 'auto_match_threshold': 0.88,
             },
@@ -66,6 +66,7 @@ class CreateFeedMappingTests(FeedMappingApiBase):
                 'name': 'Остатки',
                 'dataframe': self.dataframe.pk,
                 'supplier_sku_column': 'sku',
+                'name_column': 'name',
             },
             content_type='application/json',
         )
@@ -150,10 +151,10 @@ class DeleteProtectionTests(FeedMappingApiBase):
         self.assertTrue(FeedMapping.objects.filter(pk=mapping.pk).exists())
 
 
-# ── Cycle 9: FeedMapping product columns ─────────────────────────────────────
+# ── Cycle 9: FeedMapping matching columns ────────────────────────────────────
 
-class FeedMappingProductColumnsTest(FeedMappingApiBase):
-    def test_create_with_product_columns(self):
+class FeedMappingMatchingColumnsTest(FeedMappingApiBase):
+    def test_create_with_name_and_sku_columns(self):
         resp = self.client.post(
             reverse(MAPPING_LIST_URL),
             {
@@ -161,28 +162,29 @@ class FeedMappingProductColumnsTest(FeedMappingApiBase):
                 'name': 'Прайс с товарами',
                 'dataframe': self.dataframe.pk,
                 'supplier_sku_column': 'article',
-                'product_name_column': 'product_name',
+                'name_column': 'product_name',
                 'product_sku_column': 'product_sku',
             },
             content_type='application/json',
         )
         self.assertEqual(resp.status_code, 201, resp.content[:300])
         data = resp.json()
-        self.assertEqual(data['product_name_column'], 'product_name')
+        self.assertEqual(data['name_column'], 'product_name')
         self.assertEqual(data['product_sku_column'], 'product_sku')
 
-    def test_product_columns_default_to_empty(self):
+    def test_low_match_threshold_default(self):
         resp = self.client.post(
             reverse(MAPPING_LIST_URL),
             {
                 'supplier': self.supplier.pk,
-                'name': 'Прайс без товаров',
+                'name': 'Прайс пороги',
                 'dataframe': self.dataframe.pk,
                 'supplier_sku_column': 'article',
+                'name_column': 'name',
             },
             content_type='application/json',
         )
         self.assertEqual(resp.status_code, 201, resp.content[:300])
         data = resp.json()
-        self.assertEqual(data['product_name_column'], '')
+        self.assertAlmostEqual(data['low_match_threshold'], 0.5)
         self.assertEqual(data['product_sku_column'], '')

--- a/price_manager/supplier_feed/tests/test_matcher.py
+++ b/price_manager/supplier_feed/tests/test_matcher.py
@@ -1,12 +1,11 @@
 """Tests for supplier_feed.matcher.run_matching — behavior via public interface.
 
-Each class covers one algorithmic branch.  The embedder (embed_query) is always
-mocked so no live Ollama instance is required.  pgvector CosineDistance is
-exercised through real Product rows in the test database.
+Each class covers one algorithmic branch. _find_candidates is always mocked so
+no live PostgreSQL pg_trgm extension or rapidfuzz scoring is required.
 """
 from __future__ import annotations
 
-from unittest.mock import patch, call
+from unittest.mock import patch
 
 from django.test import TestCase
 
@@ -19,49 +18,30 @@ from supplier_feed.models import (
 )
 from .fixtures import make_feed_mapping, make_supplier
 
-EMBED_PATH = 'supplier_feed.matcher.embed_query'
-
-DIM = 256  # must match PRODUCT_EMBEDDING_DIM
+FIND_CANDIDATES_PATH = 'supplier_feed.matcher._find_candidates'
 
 
-def _unit_vec(idx: int = 0) -> list[float]:
-    """Unit vector with 1.0 at position `idx`, 0.0 elsewhere."""
-    v = [0.0] * DIM
-    v[idx] = 1.0
-    return v
-
-
-def _make_product(name: str, sku: str, embedding: list[float] | None = None) -> Product:
+def _make_product(name: str, sku: str) -> Product:
     brand, _ = Brand.objects.get_or_create(name='TestBrand', defaults={'slug': 'testbrand'})
     cat, _ = Category.objects.get_or_create(name='TestCat', defaults={'slug': 'testcat'})
-    p = Product.objects.create(name=name, sku=sku, brand=brand, category=cat)
-    if embedding is not None:
-        p.embedding = embedding
-        p.save(update_fields=['embedding'])
-    return p
+    return Product.objects.create(name=name, sku=sku, brand=brand, category=cat)
 
 
-def _make_feed(supplier=None, mapping=None) -> SupplierFeed:
-    if supplier is None:
-        supplier = make_supplier()
-    if mapping is None:
-        mapping = make_feed_mapping(
-            supplier=supplier,
-            supplier_sku_column='article',
-            identity_columns=['name'],
-            variable_columns=['price'],
-        )
-    return SupplierFeed.objects.create(
-        supplier=supplier,
-        feed_mapping=mapping,
-        status='processing',
-    )
+def _candidate(product: Product, score: float) -> dict:
+    return {
+        'product_id': product.pk,
+        'score': score,
+        'name': product.name,
+        'sku': product.sku,
+        'category': 'TestCat',
+        'brand': 'TestBrand',
+    }
 
 
 # ── Cycle 1: SupplierLink lookup ─────────────────────────────────────────────
 
 class SupplierLinkMatchTests(TestCase):
-    """Branch 1: rows already in SupplierLink → instant match, no embedder call."""
+    """Branch 1: rows already in SupplierLink → instant match, no text search."""
 
     def setUp(self):
         self.supplier = make_supplier(name='Supplier A')
@@ -69,7 +49,7 @@ class SupplierLinkMatchTests(TestCase):
         self.mapping = make_feed_mapping(
             supplier=self.supplier,
             supplier_sku_column='article',
-            identity_columns=['name'],
+            name_column='name',
             variable_columns=['price'],
         )
         self.feed = SupplierFeed.objects.create(
@@ -87,11 +67,10 @@ class SupplierLinkMatchTests(TestCase):
         """Known SKU → entry.product set, stats show matched=1, queued=0."""
         rows = [{'article': 'SKU-001', 'name': 'Дрель', 'price': '500'}]
 
-        with patch(EMBED_PATH) as mock_embed:
+        with patch(FIND_CANDIDATES_PATH) as mock_find:
             stats = run_matching(self.feed, rows)
 
-        # embed_query must never be called for already-linked SKUs
-        mock_embed.assert_not_called()
+        mock_find.assert_not_called()
 
         self.assertEqual(stats['matched'], 1)
         self.assertEqual(stats['queued'], 0)
@@ -103,17 +82,17 @@ class SupplierLinkMatchTests(TestCase):
         """Variable columns are saved to entry.data."""
         rows = [{'article': 'SKU-001', 'name': 'Дрель', 'price': '750'}]
 
-        with patch(EMBED_PATH):
+        with patch(FIND_CANDIDATES_PATH):
             run_matching(self.feed, rows)
 
         entry = SupplierFeedEntry.objects.get(feed=self.feed, supplier_sku='SKU-001')
         self.assertEqual(entry.data.get('price'), '750')
 
-    def test_sku_match_stores_identity_data(self):
-        """Identity columns are merged into entry.data alongside variable columns."""
+    def test_sku_match_stores_name_data(self):
+        """name_column value is stored in entry.data."""
         rows = [{'article': 'SKU-001', 'name': 'Дрель', 'price': '750'}]
 
-        with patch(EMBED_PATH):
+        with patch(FIND_CANDIDATES_PATH):
             run_matching(self.feed, rows)
 
         entry = SupplierFeedEntry.objects.get(feed=self.feed, supplier_sku='SKU-001')
@@ -132,30 +111,29 @@ class SupplierLinkMatchTests(TestCase):
             {'article': 'SKU-002', 'name': 'Перфоратор', 'price': '1200'},
         ]
 
-        with patch(EMBED_PATH) as mock_embed:
+        with patch(FIND_CANDIDATES_PATH) as mock_find:
             stats = run_matching(self.feed, rows)
 
-        mock_embed.assert_not_called()
+        mock_find.assert_not_called()
         self.assertEqual(stats['matched'], 2)
         self.assertEqual(stats['queued'], 0)
         self.assertEqual(SupplierFeedEntry.objects.filter(feed=self.feed).count(), 2)
 
 
-# ── Cycle 2: Vector auto-match ────────────────────────────────────────────────
+# ── Cycle 2: Text auto-match ──────────────────────────────────────────────────
 
-class VectorAutoMatchTests(TestCase):
-    """Branch 2: no SupplierLink, embedding score ≥ threshold → auto-match."""
+class TextAutoMatchTests(TestCase):
+    """Branch 2: no SupplierLink, score >= auto_match_threshold → auto-match."""
 
     def setUp(self):
         self.supplier = make_supplier(name='Supplier B')
-        # Product with embedding pointing in direction [1, 0, 0, ...]
-        self.product = _make_product('Шуруповерт', 'P-010', embedding=_unit_vec(0))
+        self.product = _make_product('Шуруповерт', 'P-010')
         self.mapping = make_feed_mapping(
             supplier=self.supplier,
             supplier_sku_column='article',
-            identity_columns=['name'],
-            variable_columns=[],
+            name_column='name',
             auto_match_threshold=0.92,
+            low_match_threshold=0.5,
         )
         self.feed = SupplierFeed.objects.create(
             supplier=self.supplier,
@@ -163,13 +141,13 @@ class VectorAutoMatchTests(TestCase):
             status='processing',
         )
 
-    def test_high_similarity_creates_supplier_link(self):
-        """Score ≥ threshold → entry.product set AND SupplierLink created."""
+    @patch(FIND_CANDIDATES_PATH)
+    def test_high_score_creates_supplier_link(self, mock_find):
+        """Score >= auto_match_threshold → entry.product set AND SupplierLink created."""
+        mock_find.return_value = [_candidate(self.product, 0.95)]
         rows = [{'article': 'NEW-SKU', 'name': 'Шуруповерт'}]
 
-        # Query embedding is identical to product embedding → cosine distance = 0
-        with patch(EMBED_PATH, return_value=_unit_vec(0)):
-            stats = run_matching(self.feed, rows)
+        stats = run_matching(self.feed, rows)
 
         self.assertEqual(stats['matched'], 1)
         self.assertEqual(stats['queued'], 0)
@@ -178,35 +156,34 @@ class VectorAutoMatchTests(TestCase):
         self.assertEqual(entry.product_id, self.product.pk)
         self.assertEqual(entry.match_candidates, [])
 
-        # Permanent link created for future feeds
         link = SupplierLink.objects.get(supplier=self.supplier, supplier_sku='NEW-SKU')
         self.assertEqual(link.product_id, self.product.pk)
 
-    def test_embed_query_called_with_identity_text(self):
-        """Identity columns are joined and passed to embed_query."""
+    @patch(FIND_CANDIDATES_PATH)
+    def test_find_candidates_called_with_entry_name(self, mock_find):
+        """_find_candidates is called with the name column value and low_thresh."""
+        mock_find.return_value = [_candidate(self.product, 0.95)]
         rows = [{'article': 'NEW-SKU', 'name': 'Шуруповерт'}]
 
-        with patch(EMBED_PATH, return_value=_unit_vec(0)) as mock_embed:
-            run_matching(self.feed, rows)
+        run_matching(self.feed, rows)
 
-        mock_embed.assert_called_once_with('Шуруповерт')
+        mock_find.assert_called_once_with('Шуруповерт', 0.5)
 
 
 # ── Cycle 3: Queue path ───────────────────────────────────────────────────────
 
-class VectorQueueTests(TestCase):
-    """Branch 3: no SupplierLink, embedding score < threshold → queued."""
+class TextQueueTests(TestCase):
+    """Branch 3: no SupplierLink, score < auto_match_threshold → queued."""
 
     def setUp(self):
         self.supplier = make_supplier(name='Supplier C')
-        # Product pointing [1, 0, 0, ...]
-        self.product = _make_product('Фен', 'P-020', embedding=_unit_vec(0))
+        self.product = _make_product('Фен', 'P-020')
         self.mapping = make_feed_mapping(
             supplier=self.supplier,
             supplier_sku_column='article',
-            identity_columns=['name'],
-            variable_columns=[],
+            name_column='name',
             auto_match_threshold=0.92,
+            low_match_threshold=0.5,
         )
         self.feed = SupplierFeed.objects.create(
             supplier=self.supplier,
@@ -214,22 +191,20 @@ class VectorQueueTests(TestCase):
             status='processing',
         )
 
-    def test_low_similarity_queues_entry_with_candidates(self):
-        """Score < threshold → entry.product=None, match_candidates populated."""
+    @patch(FIND_CANDIDATES_PATH)
+    def test_low_score_queues_entry_with_candidates(self, mock_find):
+        """Score < auto_match_threshold → entry.product=None, match_candidates populated."""
+        mock_find.return_value = [_candidate(self.product, 0.75)]
         rows = [{'article': 'UNKNOWN-SKU', 'name': 'Утюг'}]
 
-        # Query vector perpendicular to product → cosine distance = 1, similarity = 0
-        with patch(EMBED_PATH, return_value=_unit_vec(1)):
-            stats = run_matching(self.feed, rows)
+        stats = run_matching(self.feed, rows)
 
         self.assertEqual(stats['matched'], 0)
         self.assertEqual(stats['queued'], 1)
 
         entry = SupplierFeedEntry.objects.get(feed=self.feed, supplier_sku='UNKNOWN-SKU')
         self.assertIsNone(entry.product_id)
-
-        # Candidates list contains the product with its score and catalogue fields
-        self.assertGreater(len(entry.match_candidates), 0)
+        self.assertEqual(len(entry.match_candidates), 1)
         first = entry.match_candidates[0]
         self.assertEqual(first['product_id'], self.product.pk)
         self.assertIn('score', first)
@@ -238,12 +213,13 @@ class VectorQueueTests(TestCase):
         self.assertEqual(first['category'], 'TestCat')
         self.assertEqual(first['brand'], 'TestBrand')
 
-    def test_no_supplier_link_created_for_queued_entry(self):
-        """Low-similarity match must NOT create a SupplierLink."""
+    @patch(FIND_CANDIDATES_PATH)
+    def test_no_supplier_link_created_for_queued_entry(self, mock_find):
+        """Low-score match must NOT create a SupplierLink."""
+        mock_find.return_value = [_candidate(self.product, 0.75)]
         rows = [{'article': 'UNKNOWN-SKU', 'name': 'Утюг'}]
 
-        with patch(EMBED_PATH, return_value=_unit_vec(1)):
-            run_matching(self.feed, rows)
+        run_matching(self.feed, rows)
 
         self.assertFalse(
             SupplierLink.objects.filter(
@@ -251,127 +227,43 @@ class VectorQueueTests(TestCase):
             ).exists()
         )
 
-    def test_low_similarity_entry_has_best_score_set(self):
+    @patch(FIND_CANDIDATES_PATH)
+    def test_queued_entry_has_best_score(self, mock_find):
         """Queued entry with candidates must have best_score populated."""
+        mock_find.return_value = [_candidate(self.product, 0.75)]
         rows = [{'article': 'SCORE-SKU', 'name': 'Утюг'}]
 
-        with patch(EMBED_PATH, return_value=_unit_vec(1)):
-            run_matching(self.feed, rows)
+        run_matching(self.feed, rows)
 
         entry = SupplierFeedEntry.objects.get(feed=self.feed, supplier_sku='SCORE-SKU')
-        self.assertIsNotNone(entry.best_score)
-        # Perpendicular vectors → cosine similarity = 0
-        self.assertAlmostEqual(entry.best_score, 0.0, places=3)
+        self.assertAlmostEqual(entry.best_score, 0.75, places=3)
 
-    def test_no_products_with_embeddings_still_queues(self):
-        """When no products have embeddings, entry is queued with empty candidates."""
-        self.product.embedding = None
-        self.product.save(update_fields=['embedding'])
-
+    @patch(FIND_CANDIDATES_PATH)
+    def test_no_candidates_queues_with_null_best_score(self, mock_find):
+        """When _find_candidates returns [], entry is queued with empty candidates and best_score=None."""
+        mock_find.return_value = []
         rows = [{'article': 'GHOST-SKU', 'name': 'Что-то'}]
 
-        with patch(EMBED_PATH, return_value=_unit_vec(0)):
-            stats = run_matching(self.feed, rows)
+        stats = run_matching(self.feed, rows)
 
         self.assertEqual(stats['queued'], 1)
         entry = SupplierFeedEntry.objects.get(feed=self.feed, supplier_sku='GHOST-SKU')
         self.assertIsNone(entry.product_id)
         self.assertEqual(entry.match_candidates, [])
-
-    def test_no_products_with_embeddings_gives_null_best_score(self):
-        """Entry with no candidates must have best_score=None (anomaly marker)."""
-        self.product.embedding = None
-        self.product.save(update_fields=['embedding'])
-
-        rows = [{'article': 'NULL-SCORE-SKU', 'name': 'Что-то'}]
-
-        with patch(EMBED_PATH, return_value=_unit_vec(0)):
-            run_matching(self.feed, rows)
-
-        entry = SupplierFeedEntry.objects.get(feed=self.feed, supplier_sku='NULL-SCORE-SKU')
         self.assertIsNone(entry.best_score)
 
 
-# ── Cycle 4: Mixed batch ──────────────────────────────────────────────────────
-
-class MixedBatchTests(TestCase):
-    """Branch 4: batch with linked + auto-match + queued rows → correct totals."""
-
-    def setUp(self):
-        self.supplier = make_supplier(name='Supplier D')
-        self.mapping = make_feed_mapping(
-            supplier=self.supplier,
-            supplier_sku_column='article',
-            identity_columns=['name'],
-            variable_columns=[],
-            auto_match_threshold=0.92,
-        )
-        self.feed = SupplierFeed.objects.create(
-            supplier=self.supplier,
-            feed_mapping=self.mapping,
-            status='processing',
-        )
-
-        # product_a: will be matched via SupplierLink
-        self.product_a = _make_product('Товар A', 'PA')
-        SupplierLink.objects.create(
-            supplier=self.supplier, supplier_sku='SKU-A', product=self.product_a
-        )
-
-        # product_b: will be auto-matched via embedding (vec index 2)
-        self.product_b = _make_product('Товар B', 'PB', embedding=_unit_vec(2))
-
-        # product_c: exists but only as low-similarity candidate (vec index 3)
-        self.product_c = _make_product('Товар C', 'PC', embedding=_unit_vec(3))
-
-    def test_mixed_batch_returns_correct_stats_includes_skipped_key(self):
-        """run_matching return dict must include 'skipped' key."""
-        rows = []
-        with patch(EMBED_PATH, return_value=_unit_vec(0)):
-            stats = run_matching(self.feed, rows)
-        self.assertIn('skipped', stats)
-
-    def test_mixed_batch_returns_correct_stats(self):
-        """1 linked + 1 auto-match + 1 queued → matched=2, queued=1."""
-        rows = [
-            {'article': 'SKU-A', 'name': 'Товар A'},   # linked
-            {'article': 'SKU-B', 'name': 'Товар B'},   # auto-match (vec[2] ≈ product_b)
-            {'article': 'SKU-C', 'name': 'Товар C'},   # queued   (vec[4] ≠ anything close)
-        ]
-
-        def fake_embed(text):
-            if 'Товар B' in text:
-                return _unit_vec(2)   # identical to product_b → distance 0 → auto-match
-            return _unit_vec(4)       # perpendicular to everything → queued
-
-        with patch(EMBED_PATH, side_effect=fake_embed):
-            stats = run_matching(self.feed, rows)
-
-        self.assertEqual(stats['matched'], 2)
-        self.assertEqual(stats['queued'], 1)
-
-        # Auto-match created a SupplierLink
-        self.assertTrue(
-            SupplierLink.objects.filter(
-                supplier=self.supplier, supplier_sku='SKU-B'
-            ).exists()
-        )
-        # Queued entry has product=None
-        queued_entry = SupplierFeedEntry.objects.get(feed=self.feed, supplier_sku='SKU-C')
-        self.assertIsNone(queued_entry.product_id)
-
-
-# ── Cycle 5: Ignore-link ─────────────────────────────────────────────────────
+# ── Cycle 4: Ignore-link ─────────────────────────────────────────────────────
 
 class IgnoreLinkTests(TestCase):
-    """Branch 5: SupplierLink with product=None (ignore-link) → entry skipped, no embedding."""
+    """Branch 4: SupplierLink with product=None (ignore-link) → entry skipped."""
 
     def setUp(self):
         self.supplier = make_supplier(name='Supplier E')
         self.mapping = make_feed_mapping(
             supplier=self.supplier,
             supplier_sku_column='article',
-            identity_columns=['name'],
+            name_column='name',
             variable_columns=['price'],
         )
         self.feed = SupplierFeed.objects.create(
@@ -389,10 +281,10 @@ class IgnoreLinkTests(TestCase):
         """Row matching an ignore-link → entry.skipped=True, not matched."""
         rows = [{'article': 'IGN-001', 'name': 'Что-то', 'price': '100'}]
 
-        with patch(EMBED_PATH) as mock_embed:
+        with patch(FIND_CANDIDATES_PATH) as mock_find:
             stats = run_matching(self.feed, rows)
 
-        mock_embed.assert_not_called()
+        mock_find.assert_not_called()
         self.assertEqual(stats.get('skipped', 0), 1)
 
         entry = SupplierFeedEntry.objects.get(feed=self.feed, supplier_sku='IGN-001')
@@ -403,7 +295,7 @@ class IgnoreLinkTests(TestCase):
         """Ignored row must NOT increment the matched counter."""
         rows = [{'article': 'IGN-001', 'name': 'Что-то', 'price': '100'}]
 
-        with patch(EMBED_PATH):
+        with patch(FIND_CANDIDATES_PATH):
             stats = run_matching(self.feed, rows)
 
         self.assertEqual(stats['matched'], 0)
@@ -418,10 +310,73 @@ class IgnoreLinkTests(TestCase):
         )
         rows = [{'article': 'REG-001', 'name': 'Дрель', 'price': '500'}]
 
-        with patch(EMBED_PATH) as mock_embed:
+        with patch(FIND_CANDIDATES_PATH) as mock_find:
             stats = run_matching(self.feed, rows)
 
-        mock_embed.assert_not_called()
+        mock_find.assert_not_called()
         self.assertEqual(stats['matched'], 1)
         entry = SupplierFeedEntry.objects.get(feed=self.feed, supplier_sku='REG-001')
         self.assertEqual(entry.product_id, product.pk)
+
+
+# ── Cycle 5: Mixed batch ──────────────────────────────────────────────────────
+
+class MixedBatchTests(TestCase):
+    """Branch 5: batch with linked + auto-match + queued → correct totals."""
+
+    def setUp(self):
+        self.supplier = make_supplier(name='Supplier D')
+        self.mapping = make_feed_mapping(
+            supplier=self.supplier,
+            supplier_sku_column='article',
+            name_column='name',
+            auto_match_threshold=0.92,
+            low_match_threshold=0.5,
+        )
+        self.feed = SupplierFeed.objects.create(
+            supplier=self.supplier,
+            feed_mapping=self.mapping,
+            status='processing',
+        )
+
+        self.product_a = _make_product('Товар A', 'PA')
+        SupplierLink.objects.create(
+            supplier=self.supplier, supplier_sku='SKU-A', product=self.product_a
+        )
+        self.product_b = _make_product('Товар B', 'PB')
+        self.product_c = _make_product('Товар C', 'PC')
+
+    def test_mixed_batch_returns_correct_stats_includes_skipped_key(self):
+        """run_matching return dict must include 'skipped' key."""
+        with patch(FIND_CANDIDATES_PATH, return_value=[]):
+            stats = run_matching(self.feed, [])
+        self.assertIn('skipped', stats)
+
+    @patch(FIND_CANDIDATES_PATH)
+    def test_mixed_batch_returns_correct_stats(self, mock_find):
+        """1 linked + 1 auto-match + 1 queued → matched=2, queued=1."""
+        rows = [
+            {'article': 'SKU-A', 'name': 'Товар A'},
+            {'article': 'SKU-B', 'name': 'Товар B'},
+            {'article': 'SKU-C', 'name': 'Товар C'},
+        ]
+
+        def side_effect(name, low_thresh):
+            if 'Товар B' in name:
+                return [_candidate(self.product_b, 0.95)]
+            return [_candidate(self.product_c, 0.60)]
+
+        mock_find.side_effect = side_effect
+
+        stats = run_matching(self.feed, rows)
+
+        self.assertEqual(stats['matched'], 2)
+        self.assertEqual(stats['queued'], 1)
+
+        self.assertTrue(
+            SupplierLink.objects.filter(
+                supplier=self.supplier, supplier_sku='SKU-B'
+            ).exists()
+        )
+        queued_entry = SupplierFeedEntry.objects.get(feed=self.feed, supplier_sku='SKU-C')
+        self.assertIsNone(queued_entry.product_id)

--- a/price_manager/supplier_feed/tests/test_models.py
+++ b/price_manager/supplier_feed/tests/test_models.py
@@ -14,9 +14,9 @@ class FeedMappingDefaultsTests(TestCase):
         mapping = make_feed_mapping(supplier=self.supplier)
         self.assertAlmostEqual(mapping.auto_match_threshold, 0.92)
 
-    def test_identity_columns_default_empty_list(self):
+    def test_low_match_threshold_default(self):
         mapping = make_feed_mapping(supplier=self.supplier)
-        self.assertEqual(mapping.identity_columns, [])
+        self.assertAlmostEqual(mapping.low_match_threshold, 0.5)
 
     def test_variable_columns_default_empty_list(self):
         mapping = make_feed_mapping(supplier=self.supplier)


### PR DESCRIPTION
## Summary

- Replaces Ollama `embed_query` + HNSW cosine similarity matching with pure in-process text matching
- Uses pg_trgm GIN index on `product_product.name` for fast candidate retrieval (migration 0012)
- Uses `rapidfuzz.token_sort_ratio` for word-order-insensitive re-ranking
- `FeedMapping` gains `low_match_threshold` for a two-tier decision: auto-match / queue-with-candidates / queue-without-candidates
- Removes `identity_columns`; renames `product_name_column` → `name_column` (required field)
- See ADR-0012

## Test plan

- [ ] Run `python manage.py test supplier_feed` — all matcher, model, and API tests pass
- [ ] Run migration on a dev DB: `python manage.py migrate supplier_feed`
- [ ] Verify `pg_trgm` extension is created and `product_name_trgm_idx` GIN index exists
- [ ] Upload a supplier feed and confirm rows are matched/queued correctly
- [ ] Confirm `low_match_threshold` is respected: scores between 0.5 and 0.92 show candidates in MatchQueue

🤖 Generated with [Claude Code](https://claude.com/claude-code)