### PR TITLE
feat(frontend): update FeedMapping form for text-matching config

### DIFF
--- a/frontend/src/features/supplier/__tests__/SupplierDetailPage.test.tsx
+++ b/frontend/src/features/supplier/__tests__/SupplierDetailPage.test.tsx
@@ -15,9 +15,10 @@ const MAPPING = {
   dataframe: 3,
   dataframe_detail: { id: 3, name: 'Пайп' },
   supplier_sku_column: 'sku',
-  identity_columns: [],
+  name_column: 'name',
   variable_columns: [],
   auto_match_threshold: 0.9,
+  low_match_threshold: 0.5,
 };
 const FEED = {
   id: 10,

--- a/frontend/src/features/supplier/__tests__/SupplierFeedPage.test.tsx
+++ b/frontend/src/features/supplier/__tests__/SupplierFeedPage.test.tsx
@@ -15,9 +15,10 @@ const MAPPING = {
   dataframe: 3,
   dataframe_detail: { id: 3, name: 'Пайп' },
   supplier_sku_column: 'sku',
-  identity_columns: [],
+  name_column: 'name',
   variable_columns: [],
   auto_match_threshold: 0.9,
+  low_match_threshold: 0.5,
 };
 
 function makeFeed(overrides = {}) {

--- a/frontend/src/features/supplier/pages/FeedMappingCreatePage.tsx
+++ b/frontend/src/features/supplier/pages/FeedMappingCreatePage.tsx
@@ -45,9 +45,10 @@ export function FeedMappingCreatePage() {
   // Step 1: mapping fields
   const [name, setName] = useState('');
   const [skuColumn, setSkuColumn] = useState('');
-  const [identityColumns, setIdentityColumns] = useState<string[]>([]);
+  const [nameColumn, setNameColumn] = useState('');
   const [variableColumns, setVariableColumns] = useState<string[]>([]);
   const [threshold, setThreshold] = useState<number>(0.92);
+  const [lowMatchThreshold, setLowMatchThreshold] = useState<number>(0.5);
 
   const pipelinesQuery = useQuery({
     queryKey: dataframeKeys.pipelines(),
@@ -90,9 +91,10 @@ export function FeedMappingCreatePage() {
         name: name.trim(),
         dataframe: selectedPipelineId!,
         supplier_sku_column: skuColumn.trim(),
-        identity_columns: identityColumns,
+        name_column: nameColumn.trim(),
         variable_columns: variableColumns,
         auto_match_threshold: threshold,
+        low_match_threshold: lowMatchThreshold,
       }),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: supplierKeys.mappings(supplierId) });
@@ -110,8 +112,9 @@ export function FeedMappingCreatePage() {
 
   const canSubmit =
     name.trim().length > 0 &&
+    selectedPipelineId !== null &&
     skuColumn.trim().length > 0 &&
-    identityColumns.length > 0;
+    nameColumn.trim().length > 0;
 
   return (
     <Stack>
@@ -195,13 +198,14 @@ export function FeedMappingCreatePage() {
               required
             />
 
-            <TagsInput
-              label="Identity-колонки"
-              description="Колонки, однозначно идентифицирующие позицию (напр. sku, name)"
-              placeholder="Добавьте колонку"
+            <Autocomplete
+              label="Колонка с названием товара"
+              description="Имя колонки в выводе пайплайна"
+              placeholder="name"
               data={availableColumns}
-              value={identityColumns}
-              onChange={setIdentityColumns}
+              value={nameColumn}
+              onChange={setNameColumn}
+              required
             />
 
             <TagsInput
@@ -220,6 +224,17 @@ export function FeedMappingCreatePage() {
               onChange={(v) => setThreshold(Number(v))}
               min={0}
               max={1}
+              step={0.01}
+              decimalScale={2}
+            />
+
+            <NumberInput
+              label="Нижний порог совпадения"
+              description="От 0 до 1. Позиции ниже порога игнорируются"
+              value={lowMatchThreshold}
+              onChange={(v) => { if (typeof v === 'number') setLowMatchThreshold(v); }}
+              min={0.1}
+              max={0.99}
               step={0.01}
               decimalScale={2}
             />

--- a/frontend/src/features/supplier/pages/FeedMappingEditPage.tsx
+++ b/frontend/src/features/supplier/pages/FeedMappingEditPage.tsx
@@ -39,9 +39,10 @@ export function FeedMappingEditPage() {
   const [pipelineId, setPipelineId] = useState<number | null>(null);
   const [pipelineName, setPipelineName] = useState('');
   const [skuColumn, setSkuColumn] = useState('');
-  const [identityColumns, setIdentityColumns] = useState<string[]>([]);
+  const [nameColumn, setNameColumn] = useState('');
   const [variableColumns, setVariableColumns] = useState<string[]>([]);
   const [threshold, setThreshold] = useState<number>(0.92);
+  const [lowMatchThreshold, setLowMatchThreshold] = useState<number>(0.5);
   const [availableColumns, setAvailableColumns] = useState<string[]>([]);
 
   // Pipeline picker modal + new pipeline drawer
@@ -67,9 +68,10 @@ export function FeedMappingEditPage() {
       setPipelineId(m.dataframe);
       setPipelineName(m.dataframe_detail.name);
       setSkuColumn(m.supplier_sku_column);
-      setIdentityColumns(m.identity_columns);
+      setNameColumn(m.name_column);
       setVariableColumns(m.variable_columns);
       setThreshold(m.auto_match_threshold);
+      setLowMatchThreshold(m.low_match_threshold);
     }
   }, [mappingQuery.data]);
 
@@ -80,9 +82,10 @@ export function FeedMappingEditPage() {
         name: name.trim(),
         dataframe: pipelineId!,
         supplier_sku_column: skuColumn.trim(),
-        identity_columns: identityColumns,
+        name_column: nameColumn.trim(),
         variable_columns: variableColumns,
         auto_match_threshold: threshold,
+        low_match_threshold: lowMatchThreshold,
       }),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: supplierKeys.mappings(supplierId) });
@@ -126,7 +129,7 @@ export function FeedMappingEditPage() {
     name.trim().length > 0 &&
     pipelineId !== null &&
     skuColumn.trim().length > 0 &&
-    identityColumns.length > 0;
+    nameColumn.trim().length > 0;
 
   if (mappingQuery.isLoading) return <Loader />;
 
@@ -182,13 +185,14 @@ export function FeedMappingEditPage() {
           required
         />
 
-        <TagsInput
-          label="Identity-колонки"
-          description="Колонки, однозначно идентифицирующие позицию (напр. sku, name)"
-          placeholder="Добавьте колонку"
+        <Autocomplete
+          label="Колонка с названием товара"
+          description="Имя колонки в выводе пайплайна"
+          placeholder="name"
           data={availableColumns}
-          value={identityColumns}
-          onChange={setIdentityColumns}
+          value={nameColumn}
+          onChange={setNameColumn}
+          required
         />
 
         <TagsInput
@@ -207,6 +211,17 @@ export function FeedMappingEditPage() {
           onChange={(v) => setThreshold(Number(v))}
           min={0}
           max={1}
+          step={0.01}
+          decimalScale={2}
+        />
+
+        <NumberInput
+          label="Нижний порог совпадения"
+          description="От 0 до 1. Позиции ниже порога игнорируются"
+          value={lowMatchThreshold}
+          onChange={(v) => { if (typeof v === 'number') setLowMatchThreshold(v); }}
+          min={0.1}
+          max={0.99}
           step={0.01}
           decimalScale={2}
         />

--- a/frontend/src/features/supplier/pages/FeedQueuePage.tsx
+++ b/frontend/src/features/supplier/pages/FeedQueuePage.tsx
@@ -182,7 +182,7 @@ export function FeedQueuePage() {
 
   function openBulkModal() {
     setBulkResult(null);
-    setBulkNameColumn(mappingQuery.data?.product_name_column ?? null);
+    setBulkNameColumn(mappingQuery.data?.name_column ?? null);
     setBulkModalOpen(true);
   }
 
@@ -203,10 +203,9 @@ export function FeedQueuePage() {
 
   const mapping = mappingQuery.data;
   const columnOptions = mapping
-    ? [...mapping.identity_columns, ...mapping.variable_columns].map((c) => ({
-        value: c,
-        label: c,
-      }))
+    ? [mapping.name_column, ...mapping.variable_columns]
+        .filter((v, i, arr) => v && arr.indexOf(v) === i)
+        .map((c) => ({ value: c, label: c }))
     : [];
 
   return (
@@ -221,7 +220,7 @@ export function FeedQueuePage() {
         <Button
           variant="light"
           onClick={openBulkModal}
-          disabled={entries.length === 0 || mappingQuery.isLoading}
+          disabled={entries.length === 0 || mappingQuery.isLoading || mappingQuery.isError}
         >
           Создать всё оставшееся
         </Button>

--- a/frontend/src/features/supplier/types.ts
+++ b/frontend/src/features/supplier/types.ts
@@ -14,10 +14,10 @@ export interface FeedMapping {
   dataframe: number;
   dataframe_detail: { id: number; name: string };
   supplier_sku_column: string;
-  identity_columns: string[];
+  name_column: string;
   variable_columns: string[];
   auto_match_threshold: number;
-  product_name_column: string | null;
+  low_match_threshold: number;
   product_sku_column: string | null;
 }
 
@@ -26,9 +26,10 @@ export interface FeedMappingWritePayload {
   name: string;
   dataframe: number;
   supplier_sku_column: string;
-  identity_columns: string[];
+  name_column: string;
   variable_columns: string[];
   auto_match_threshold: number;
+  low_match_threshold: number;
 }
 
 export type SupplierFeedStatus = 'draft' | 'processing' | 'matched' | 'partial' | 'done' | 'error';


### PR DESCRIPTION
## Summary

- Removes `identity_columns` field from `FeedMapping` types and all forms
- Renames `product_name_column` → `name_column` (now required) in `types.ts`, `FeedMappingCreatePage`, `FeedMappingEditPage`, and `FeedQueuePage`
- Adds `low_match_threshold` `NumberInput` (default 0.5, range 0.1–0.99) to the create/edit forms
- `FeedQueuePage`: pre-fills bulk-create name column from `mapping.name_column`, removes `identity_columns` from column options list
- Updates test fixtures in `SupplierFeedPage.test.tsx` and `SupplierDetailPage.test.tsx` to match new `FeedMapping` shape

Frontend changes to match the FeedMapping backend model update. All 19 supplier feature tests pass; build and TypeScript checks are clean.

## Test plan

- [x] `pnpm build` — no TypeScript errors
- [x] `pnpm vitest run src/features/supplier` — all 19 supplier tests pass
- [ ] Manual: create a FeedMapping and verify `name_column` is required, `low_match_threshold` accepts values 0.1–0.99
- [ ] Manual: open FeedQueuePage bulk-create modal and verify column options use `name_column` (not `identity_columns`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)