### PR TITLE
feat(product): column picker, price filter, and dynamic price columns

### DIFF
--- a/frontend/src/features/pricing/api.ts
+++ b/frontend/src/features/pricing/api.ts
@@ -1,0 +1,18 @@
+import { api } from '@/api/client';
+import type { PriceType } from './types';
+
+const BASE = '/pricing';
+
+export async function listPriceTypes(): Promise<PriceType[]> {
+  const { data } = await api.get<{ results: PriceType[]; count: number }>(
+    `${BASE}/price-types/`,
+    { params: { page_size: 1000 } },
+  );
+  if (data.count > data.results.length) {
+    console.warn(
+      `listPriceTypes: received ${data.results.length} of ${data.count} price types. ` +
+        'Some types are not shown. Increase page_size or implement pagination.',
+    );
+  }
+  return data.results;
+}

--- a/frontend/src/features/pricing/queryKeys.ts
+++ b/frontend/src/features/pricing/queryKeys.ts
@@ -1,0 +1,4 @@
+export const pricingKeys = {
+  all: ['pricing'] as const,
+  priceTypes: () => [...pricingKeys.all, 'price-types'] as const,
+};

--- a/frontend/src/features/pricing/types.ts
+++ b/frontend/src/features/pricing/types.ts
@@ -1,0 +1,5 @@
+export interface PriceType {
+  id: number;
+  name: string;
+  label: string;
+}

--- a/frontend/src/features/product/__tests__/ImportPage.test.tsx
+++ b/frontend/src/features/product/__tests__/ImportPage.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import { http, HttpResponse } from 'msw';
 import { Route, Routes } from 'react-router-dom';
 import { screen, waitFor } from '@testing-library/react';
@@ -47,6 +47,10 @@ function renderImport() {
 }
 
 describe('ImportPage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
   it('defaults to saved mode and shows pipeline select', async () => {
     commonHandlers();
     renderImport();

--- a/frontend/src/features/product/__tests__/ProductFiltersSidebar.test.tsx
+++ b/frontend/src/features/product/__tests__/ProductFiltersSidebar.test.tsx
@@ -23,6 +23,7 @@ function Host() {
         patchFilters={patchFilters}
         toggleCharValue={toggleCharValue}
         resetFilters={resetFilters}
+        priceTypes={[]}
       />
     </>
   );

--- a/frontend/src/features/product/__tests__/ProductListPage.test.tsx
+++ b/frontend/src/features/product/__tests__/ProductListPage.test.tsx
@@ -36,6 +36,9 @@ describe('ProductListPage', () => {
       http.get('/api/products/characteristic-types/', () =>
         HttpResponse.json({ count: 0, next: null, previous: null, results: [] }),
       ),
+      http.get('/api/pricing/price-types/', () =>
+        HttpResponse.json({ count: 0, next: null, previous: null, results: [] }),
+      ),
     );
 
     renderWithProviders(
@@ -64,6 +67,9 @@ describe('ProductListPage', () => {
         HttpResponse.json({ count: 0, next: null, previous: null, results: [] }),
       ),
       http.get('/api/products/characteristic-types/', () =>
+        HttpResponse.json({ count: 0, next: null, previous: null, results: [] }),
+      ),
+      http.get('/api/pricing/price-types/', () =>
         HttpResponse.json({ count: 0, next: null, previous: null, results: [] }),
       ),
     );

--- a/frontend/src/features/product/__tests__/importPersistence.test.ts
+++ b/frontend/src/features/product/__tests__/importPersistence.test.ts
@@ -53,7 +53,7 @@ describe('product import persistence', () => {
   });
 
   it('fills missing fields with defaults', () => {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify({ version: 2, sessionId: 'x' }));
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ version: 3, sessionId: 'x' }));
     const loaded = loadPersistedState();
     expect(loaded?.sessionId).toBe('x');
     expect(loaded?.mode).toBe('saved');

--- a/frontend/src/features/product/api.ts
+++ b/frontend/src/features/product/api.ts
@@ -34,6 +34,14 @@ function buildListParams(filters: ProductFilters): URLSearchParams {
       params.append(`char__${name}`, value);
     }
   }
+  if (filters.price_types?.length) {
+    for (const slug of filters.price_types) {
+      params.append('price_types', slug);
+    }
+  }
+  if (filters.price_type) params.set('price_type', filters.price_type);
+  if (filters.price_min !== undefined) params.set('price_min', String(filters.price_min));
+  if (filters.price_max !== undefined) params.set('price_max', String(filters.price_max));
   return params;
 }
 

--- a/frontend/src/features/product/components/ColumnPicker.tsx
+++ b/frontend/src/features/product/components/ColumnPicker.tsx
@@ -1,0 +1,37 @@
+import { ActionIcon, Checkbox, Popover, Stack, Text } from '@mantine/core';
+import { IconColumns } from '@tabler/icons-react';
+import type { PriceType } from '@/features/pricing/types';
+
+interface ColumnPickerProps {
+  priceTypes: PriceType[];
+  selectedPriceTypes: string[];
+  onToggle: (slug: string) => void;
+}
+
+export function ColumnPicker({ priceTypes, selectedPriceTypes, onToggle }: ColumnPickerProps) {
+  return (
+    <Popover width={220} position="bottom-end" withArrow shadow="md">
+      <Popover.Target>
+        <ActionIcon variant="default" size="lg" aria-label="Выбрать колонки">
+          <IconColumns size={16} />
+        </ActionIcon>
+      </Popover.Target>
+      <Popover.Dropdown>
+        <Stack gap="xs">
+          <Text size="sm" fw={500}>Ценовые колонки</Text>
+          {priceTypes.length === 0 && (
+            <Text size="xs" c="dimmed">Типы цен не найдены</Text>
+          )}
+          {priceTypes.map((pt) => (
+            <Checkbox
+              key={pt.name}
+              label={pt.label}
+              checked={selectedPriceTypes.includes(pt.name)}
+              onChange={() => onToggle(pt.name)}
+            />
+          ))}
+        </Stack>
+      </Popover.Dropdown>
+    </Popover>
+  );
+}

--- a/frontend/src/features/product/components/ProductFiltersSidebar.tsx
+++ b/frontend/src/features/product/components/ProductFiltersSidebar.tsx
@@ -1,4 +1,5 @@
-import { Button, Divider, Select, Stack, TextInput } from '@mantine/core';
+import { Button, Divider, Group, NumberInput, Select, Stack, Text, TextInput } from '@mantine/core';
+import type { PriceType } from '@/features/pricing/types';
 import { useBrands } from '../hooks/useBrands';
 import { useCategories } from '../hooks/useCategories';
 import { useProductFacets } from '../hooks/useProductFacets';
@@ -10,6 +11,7 @@ export interface ProductFiltersSidebarProps {
   patchFilters: (patch: Partial<ProductFilters>) => void;
   toggleCharValue: (name: string, value: string) => void;
   resetFilters: () => void;
+  priceTypes: PriceType[];
 }
 
 export function ProductFiltersSidebar({
@@ -17,6 +19,7 @@ export function ProductFiltersSidebar({
   patchFilters,
   toggleCharValue,
   resetFilters,
+  priceTypes,
 }: ProductFiltersSidebarProps) {
   const { data: categories } = useCategories();
   const { data: brands } = useBrands();
@@ -74,6 +77,42 @@ export function ProductFiltersSidebar({
           onToggle={(value) => toggleCharValue(name, value)}
         />
       ))}
+      <Divider my="sm" />
+      <Text size="sm" fw={500} mb="xs">Фильтр по цене</Text>
+      <Select
+        placeholder="Тип цены"
+        data={priceTypes.map((pt) => ({ value: pt.name, label: pt.label }))}
+        value={filters.price_type ?? null}
+        onChange={(val) =>
+          patchFilters({ price_type: val ?? undefined, price_min: undefined, price_max: undefined })
+        }
+        clearable
+        size="sm"
+      />
+      {filters.price_type && (
+        <Group gap="xs" mt="xs">
+          <NumberInput
+            placeholder="От"
+            value={filters.price_min ?? ''}
+            onChange={(val) =>
+              patchFilters({ price_min: typeof val === 'number' ? val : undefined })
+            }
+            min={0}
+            size="sm"
+            style={{ flex: 1 }}
+          />
+          <NumberInput
+            placeholder="До"
+            value={filters.price_max ?? ''}
+            onChange={(val) =>
+              patchFilters({ price_max: typeof val === 'number' ? val : undefined })
+            }
+            min={0}
+            size="sm"
+            style={{ flex: 1 }}
+          />
+        </Group>
+      )}
       <Button variant="subtle" onClick={resetFilters}>
         Сбросить
       </Button>

--- a/frontend/src/features/product/components/ProductTable.tsx
+++ b/frontend/src/features/product/components/ProductTable.tsx
@@ -9,6 +9,7 @@ export interface ProductTableProps {
   brands: Brand[];
   onDelete: (product: Product) => void;
   deletingId?: number;
+  priceCols?: Array<{ slug: string; label: string }>;
 }
 
 function makeMap<T extends { id: number }>(items: T[]): Map<number, T> {
@@ -21,6 +22,7 @@ export function ProductTable({
   brands,
   onDelete,
   deletingId,
+  priceCols,
 }: ProductTableProps) {
   const categoryMap = makeMap(categories);
   const brandMap = makeMap(brands);
@@ -35,6 +37,7 @@ export function ProductTable({
           <Table.Th>Бренд</Table.Th>
           <Table.Th>Статус</Table.Th>
           <Table.Th>Обновлён</Table.Th>
+          {priceCols?.map((c) => <Table.Th key={c.slug}>{c.label}</Table.Th>)}
           <Table.Th />
         </Table.Tr>
       </Table.Thead>
@@ -51,6 +54,13 @@ export function ProductTable({
             <Table.Td>{p.brand !== null ? brandMap.get(p.brand)?.name ?? '—' : '—'}</Table.Td>
             <Table.Td>{p.status || '—'}</Table.Td>
             <Table.Td>{new Date(p.updated_at).toLocaleString()}</Table.Td>
+            {priceCols?.map((c) => (
+              <Table.Td key={c.slug}>
+                {p.prices?.[c.slug] != null
+                  ? p.prices![c.slug]!.toLocaleString('ru-RU', { minimumFractionDigits: 2 })
+                  : '—'}
+              </Table.Td>
+            ))}
             <Table.Td>
               <Group gap="xs" justify="flex-end">
                 <ActionIcon

--- a/frontend/src/features/product/hooks/useColumnPicker.ts
+++ b/frontend/src/features/product/hooks/useColumnPicker.ts
@@ -1,0 +1,26 @@
+import { useState } from 'react';
+import {
+  type ColumnPickerState,
+  defaultColumnPickerState,
+  loadColumnPickerState,
+  saveColumnPickerState,
+} from '../persistence';
+
+export function useColumnPicker() {
+  const [state, setState] = useState<ColumnPickerState>(
+    () => loadColumnPickerState() ?? defaultColumnPickerState(),
+  );
+
+  const togglePriceType = (slug: string) => {
+    const next: ColumnPickerState = {
+      ...state,
+      selectedPriceTypes: state.selectedPriceTypes.includes(slug)
+        ? state.selectedPriceTypes.filter((s) => s !== slug)
+        : [...state.selectedPriceTypes, slug],
+    };
+    setState(next);
+    saveColumnPickerState(next);
+  };
+
+  return { selectedPriceTypes: state.selectedPriceTypes, togglePriceType };
+}

--- a/frontend/src/features/product/hooks/usePriceTypes.ts
+++ b/frontend/src/features/product/hooks/usePriceTypes.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import { listPriceTypes } from '@/features/pricing/api';
+import { pricingKeys } from '@/features/pricing/queryKeys';
+
+export function usePriceTypes() {
+  return useQuery({
+    queryKey: pricingKeys.priceTypes(),
+    queryFn: listPriceTypes,
+    staleTime: 5 * 60_000,
+  });
+}

--- a/frontend/src/features/product/hooks/useProductFiltersFromUrl.ts
+++ b/frontend/src/features/product/hooks/useProductFiltersFromUrl.ts
@@ -28,6 +28,12 @@ function parseFilters(searchParams: URLSearchParams): ProductFilters {
   if (brand) filters.brand = Number(brand);
   const status = searchParams.get('status');
   if (status) filters.status = status;
+  const price_type = searchParams.get('price_type');
+  if (price_type) filters.price_type = price_type;
+  const price_min = searchParams.get('price_min');
+  if (price_min) filters.price_min = Number(price_min);
+  const price_max = searchParams.get('price_max');
+  if (price_max) filters.price_max = Number(price_max);
   return filters;
 }
 
@@ -46,6 +52,9 @@ function serializeFilters(filters: ProductFilters): URLSearchParams {
       params.append(`${CHAR_PREFIX}${name}`, value);
     }
   }
+  if (filters.price_type) params.set('price_type', filters.price_type);
+  if (filters.price_min !== undefined) params.set('price_min', String(filters.price_min));
+  if (filters.price_max !== undefined) params.set('price_max', String(filters.price_max));
   return params;
 }
 
@@ -74,7 +83,10 @@ export function useProductFiltersFromUrl(): UseProductFiltersResult {
         patch.category !== undefined ||
         patch.brand !== undefined ||
         patch.status !== undefined ||
-        patch.chars !== undefined;
+        patch.chars !== undefined ||
+        patch.price_type !== undefined ||
+        patch.price_min !== undefined ||
+        patch.price_max !== undefined;
       if (resetsPage && patch.page === undefined) next.page = 1;
       setFilters(next);
     },

--- a/frontend/src/features/product/pages/ProductListPage.tsx
+++ b/frontend/src/features/product/pages/ProductListPage.tsx
@@ -13,19 +13,27 @@ import { IconDatabaseImport, IconPlus, IconSettings } from '@tabler/icons-react'
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { Link, useNavigate } from 'react-router-dom';
 import { deleteProduct } from '../api';
+import { ColumnPicker } from '../components/ColumnPicker';
 import { ProductFiltersSidebar } from '../components/ProductFiltersSidebar';
 import { ProductTable } from '../components/ProductTable';
 import { useBrands } from '../hooks/useBrands';
 import { useCategories } from '../hooks/useCategories';
+import { useColumnPicker } from '../hooks/useColumnPicker';
 import { useProductFiltersFromUrl } from '../hooks/useProductFiltersFromUrl';
 import { useProductList } from '../hooks/useProductList';
+import { usePriceTypes } from '../hooks/usePriceTypes';
 import { productKeys } from '../queryKeys';
 
 export function ProductListPage() {
   const navigate = useNavigate();
   const qc = useQueryClient();
   const { filters, patchFilters, toggleCharValue, resetFilters } = useProductFiltersFromUrl();
-  const { data, isLoading } = useProductList(filters);
+  const { selectedPriceTypes, togglePriceType } = useColumnPicker();
+  const { data: priceTypes = [] } = usePriceTypes();
+  const priceCols = priceTypes
+    .filter((pt) => selectedPriceTypes.includes(pt.name))
+    .map((pt) => ({ slug: pt.name, label: pt.label }));
+  const { data, isLoading } = useProductList({ ...filters, price_types: selectedPriceTypes });
   const { data: categories } = useCategories();
   const { data: brands } = useBrands();
 
@@ -74,11 +82,19 @@ export function ProductListPage() {
               patchFilters={patchFilters}
               toggleCharValue={toggleCharValue}
               resetFilters={resetFilters}
+              priceTypes={priceTypes}
             />
           </Card>
         </Grid.Col>
         <Grid.Col span={{ base: 12, md: 9 }}>
           <Stack>
+            <Group justify="flex-end" mb="xs">
+              <ColumnPicker
+                priceTypes={priceTypes}
+                selectedPriceTypes={selectedPriceTypes}
+                onToggle={togglePriceType}
+              />
+            </Group>
             {isLoading && <Loader />}
             {!isLoading && (data?.results.length ?? 0) === 0 && (
               <Card withBorder padding="lg">
@@ -93,6 +109,7 @@ export function ProductListPage() {
                   products={data!.results}
                   categories={categories ?? []}
                   brands={brands ?? []}
+                  priceCols={priceCols}
                   deletingId={deleteMutation.variables}
                   onDelete={(p) => {
                     if (confirm(`Удалить «${p.name}»?`)) deleteMutation.mutate(p.id);

--- a/frontend/src/features/product/persistence.ts
+++ b/frontend/src/features/product/persistence.ts
@@ -79,3 +79,36 @@ export function clearPersistedState(): void {
     // ignore
   }
 }
+
+export interface ColumnPickerState {
+  version: 1;
+  selectedPriceTypes: string[];
+}
+
+export const COLUMN_PICKER_KEY = 'product-columns-v1';
+
+export function defaultColumnPickerState(): ColumnPickerState {
+  return { version: 1, selectedPriceTypes: [] };
+}
+
+export function loadColumnPickerState(): ColumnPickerState | null {
+  try {
+    const raw = localStorage.getItem(COLUMN_PICKER_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<ColumnPickerState>;
+    if (parsed?.version !== 1) {
+      localStorage.removeItem(COLUMN_PICKER_KEY);
+      return null;
+    }
+    return { ...defaultColumnPickerState(), ...parsed } as ColumnPickerState;
+  } catch {
+    try { localStorage.removeItem(COLUMN_PICKER_KEY); } catch { /* ignore */ }
+    return null;
+  }
+}
+
+export function saveColumnPickerState(state: ColumnPickerState): void {
+  try {
+    localStorage.setItem(COLUMN_PICKER_KEY, JSON.stringify(state));
+  } catch { /* QuotaExceeded — ignore */ }
+}

--- a/frontend/src/features/product/types.ts
+++ b/frontend/src/features/product/types.ts
@@ -115,6 +115,7 @@ export interface Product {
   image_urls: string[];
   created_at: string;
   updated_at: string;
+  prices?: Record<string, number | null>;
 }
 
 export interface ProductWritePayload {
@@ -136,6 +137,10 @@ export interface ProductFilters {
   chars: Record<string, string[]>;
   page: number;
   pageSize: number;
+  price_type?: string;
+  price_min?: number;
+  price_max?: number;
+  price_types?: string[];
 }
 
 export const DEFAULT_PAGE_SIZE = 50;


### PR DESCRIPTION
## Summary

- Column picker: ColumnPicker Popover (button above table) lets users select which PriceType slugs to show as extra columns; selection persists in localStorage (product-columns-v1)
- Dynamic price columns: ProductTable renders one column per selected PriceType showing product.prices[slug] formatted as ru-RU locale with 2 decimal places
- Price filter in sidebar: ProductFiltersSidebar gets a new section with PriceType Select and min/max NumberInput inputs; values go into ?price_type=, ?price_min=, ?price_max= URL params and reset page to 1
- New features/pricing/ slice (types, api, queryKeys) - listPriceTypes fetches from /api/pricing/price-types/ with page_size=1000 and warns to console if count > results.length (silent-truncation guard)
- Fixed pre-existing importPersistence test (version 2 to 3 schema mismatch) and a cross-file localStorage contamination in ImportPage tests

## Test plan

- [x] pnpm typecheck passes (0 errors)
- [x] pnpm test - 24 test files, 108 tests, all green
- [ ] Manual: open /products, click column picker icon, enable a price type, verify column appears
- [ ] Manual: use price filter sidebar, select type + min/max, verify URL updates and list refetches

Generated with Claude Code