### PR TITLE
fix(product): make Product.name nullable-unique and stop writing '' sentinels

### DIFF
--- a/price_manager/product/migrations/0006_alter_product_name.py
+++ b/price_manager/product/migrations/0006_alter_product_name.py
@@ -1,0 +1,67 @@
+from django.db import migrations, models
+from django.db.models import Count
+
+
+def nullify_empty_sentinels(apps, schema_editor):
+    """Convert the '' sentinel to NULL for `name` and `number`, then verify
+    `name` can actually take a unique constraint.
+
+    0005 bulk-creates a Product per MainProduct.pim_id without touching
+    `name`, so under name's old NOT NULL definition every seeded row carries
+    ''. Postgres treats NULLs as distinct in a unique index but '' as equal,
+    so the constraint added below would collide on all of them at once.
+
+    `number` needs the same cleanup for a different reason: pim_sync wrote
+    '' whenever PIM had no number. It is already unique+nullable (0004), so
+    at most one such row can exist -- but it blocks the next nameless
+    product from ever syncing, which is the bug this migration's companion
+    change to pim_sync fixes.
+    """
+    Product = apps.get_model('product', 'Product')
+    Product.objects.filter(name='').update(name=None)
+    Product.objects.filter(number='').update(number=None)
+
+    # PIM is not known to guarantee unique product names -- variants sharing
+    # one display name are the usual way this breaks. Surface the conflict
+    # with the offending values instead of a bare IntegrityError naming only
+    # an index.
+    duplicates = list(
+        Product.objects.filter(name__isnull=False)
+        .values('name')
+        .annotate(n=Count('name'))
+        .filter(n__gt=1)
+        .values_list('name', flat=True)[:10]
+    )
+    if duplicates:
+        raise RuntimeError(
+            'Cannot make Product.name unique: duplicate names present. '
+            f'First {len(duplicates)}: {duplicates}. '
+            'Either deduplicate these rows or drop unique=True from '
+            'Product.name in product/models.py and regenerate this migration.'
+        )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('product', '0005_seed_products_from_main_product_pim_ids'),
+    ]
+
+    # Three steps, deliberately. The column must become nullable before the
+    # data migration can write NULLs into it, and the '' rows must be gone
+    # before the unique constraint goes on. Collapsing these into a single
+    # AlterField passes CI -- where 0005 seeds nothing into an empty test
+    # database -- and fails on any populated one.
+    operations = [
+        migrations.AlterField(
+            model_name='product',
+            name='name',
+            field=models.CharField(blank=True, max_length=512, null=True, verbose_name='Название'),
+        ),
+        migrations.RunPython(nullify_empty_sentinels, reverse_code=migrations.RunPython.noop),
+        migrations.AlterField(
+            model_name='product',
+            name='name',
+            field=models.CharField(blank=True, max_length=512, null=True, unique=True, verbose_name='Название'),
+        ),
+    ]

--- a/price_manager/product/services/pim_sync.py
+++ b/price_manager/product/services/pim_sync.py
@@ -81,8 +81,12 @@ def sync_product_from_pim(pim_id: str, data: dict | None = None) -> Product:
         data = _fetch_pim_product(pim_id)
 
     product, _ = Product.objects.get_or_create(pim_id=pim_id)
-    product.number = data.get('number') or ''
-    product.name = data.get('name') or ''
+    # `or None`, not `or ''`: both fields are unique, and Postgres treats
+    # NULLs as distinct in a unique index but '' as equal. Coercing a
+    # missing value to '' lets the first product without a number/name
+    # save and makes every later one fail with an IntegrityError.
+    product.number = data.get('number') or None
+    product.name = data.get('name') or None
     product.raw_data = data
 
     category_ids = data.get('categoriesIds') or []

--- a/price_manager/product/tests/test_models.py
+++ b/price_manager/product/tests/test_models.py
@@ -54,3 +54,21 @@ class ProductModelTests(TestCase):
         Product.objects.create(pim_id='p1', number='N1', name='A')
         with self.assertRaises(IntegrityError):
             Product.objects.create(pim_id='p2', number='N1', name='B')
+
+    def test_name_unique(self):
+        Product.objects.create(pim_id='p1', number='N1', name='A')
+        with self.assertRaises(IntegrityError):
+            Product.objects.create(pim_id='p2', number='N2', name='A')
+
+    def test_products_without_name_coexist(self):
+        # Postgres treats NULLs as distinct in a unique index but '' as equal,
+        # so a nameless product must store NULL. pim_sync used to coerce to ''
+        # here, which made the second one fail to save.
+        Product.objects.create(pim_id='p1', number='N1', name=None)
+        Product.objects.create(pim_id='p2', number='N2', name=None)
+        self.assertEqual(Product.objects.filter(name__isnull=True).count(), 2)
+
+    def test_products_without_number_coexist(self):
+        Product.objects.create(pim_id='p1', number=None, name='A')
+        Product.objects.create(pim_id='p2', number=None, name='B')
+        self.assertEqual(Product.objects.filter(number__isnull=True).count(), 2)


### PR DESCRIPTION
Fixes the migration drift that [#132](https://github.com/Pesshiii/price_manager/pull/132)'s new `makemigrations --check` step caught on its first run.

## The drift

`product/models.py:51` declares `name = CharField(max_length=512, unique=True, null=True, blank=True)`. Migration state still had `0001_initial`'s `CharField(db_index=True, max_length=512)` — NOT NULL, not unique.

## Why a bare `AlterField` would have been worse than the drift

`0005` bulk-creates a `Product` per `MainProduct.pim_id` and never touches `name`, so under the old NOT NULL definition **every seeded row carries `''`**. Postgres treats NULLs as distinct in a unique index but `''` as equal, so the constraint collides on all of them at once.

On CI this is invisible — the test database is empty, `0005` seeds nothing from `MainProduct`, and the constraint goes onto an empty table. It would have gone green here and failed on deploy.

So `0006` is three ordered operations, not one:

1. `AlterField` — make the column nullable (no constraint yet)
2. `RunPython` — convert `''` → `NULL` for both `name` and `number`
3. `AlterField` — add `unique=True`

Step 2 also raises with the offending values if duplicate *non-empty* names exist, rather than letting step 3 fail with a bare `IntegrityError` naming only an index.

## The same bug, already live, on `number`

`number` has been `unique=True, null=True` since `0004`, but `pim_sync.py` wrote `data.get('number') or ''`. The first PIM product without a number saved; every later one raised `IntegrityError`. Both fields now coerce to `None`, with a comment so it doesn't get "simplified" back.

## Tests

Three regression tests: `name` uniqueness holds for real values, and multiple products with no `name` / no `number` coexist.

## Not fixed here

`pim_sync.py:90` sets `product.category_path`, which **is not a field on `Product`** — the computed value is silently dropped on `save()`. `supplier_feed/api/views.py:267-269`'s docstring claims it's persisted. Pre-existing and separate from this migration; filed on its own.

## Test plan

- [ ] CI — **will not run until #132 merges**, since `main` has no workflow yet. Merge #132 first, then this PR gets a real run.
- [ ] Before deploying: check a populated database for duplicate non-empty `Product.name` values. The migration will refuse rather than corrupt, but better to know first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
