### PR TITLE
test(product_price_manager): fix the 5 errors and 1 failure from #136

### DIFF
--- a/.claude/knowledge/product_price_manager.md
+++ b/.claude/knowledge/product_price_manager.md
@@ -1,10 +1,10 @@
 # product_price_manager
 
 The markup engine: takes a source price, applies a rule, writes a destination
-price onto `MainProduct`. This is the app that **bridges** the catalogs — it
-imports from `supplier_manager`, `supplier_product_manager` *and*
-`main_product_manager` (`models.py:3`–`:5`). Changes here have the widest blast
-radius per line in the repo.
+price onto `MainProduct` (cross-app imports per CLAUDE.md's *Key cross-app
+dependencies*). Changes here have the widest blast radius per line in the
+repo — `save()`/`apply()`/`delete()`/`deprecate()` on `PriceManager` all
+rewrite product data catalog-wide, not just the rule row.
 
 ## Two models
 
@@ -21,17 +21,42 @@ The arithmetic is `source → dest`, where:
   never write back to one.
 - Modifiers: `markup` (multiplier), `increase` (additive), `fixed_price`.
 
-**`PriceTag:325`** — the per-product-per-rule **snapshot**. It copies `source`,
+**`PriceTag:326`** — the per-product-per-rule **snapshot**. It copies `source`,
 `dest`, `markup`, `increase`, `fixed_price` off the rule at write time. So a
 `PriceTag` records what the rule said *then*, not what it says now. Unique on
 `(mp, p_manager, dest)` — that triple is the identity used by every upsert.
 
-## `get_fitting_mps()` (`:133`) — read the docstring before touching it
+## `get_fitting_mps()` (`:133`) — docstring is stale, don't trust it
 
 Returns the matching `MainProduct` queryset **annotated with `changed_price`**,
 the post-markup value, computed via a `Subquery` over `_changed_price`
-(`:244`). When the source is a supplier price it takes the **minimum** across
-that product's supplier rows.
+(`:244`). The docstring (`:138`) still claims supplier-price sourcing "takes
+the minimum" across a product's supplier rows — verbatim: `(при подсечете от
+цен поставщика берет минимальное значение)` (typo "подсечете" is in the
+source). It doesn't, and hasn't since `supplier_product_manager` made
+`SupplierProduct.main_product` a `unique=True` FK (migration
+`0009_alter_supplierproduct_main_product_unique`,
+`supplier_product_manager/models.py:24`–`:30`). The uniqueness is on
+`main_product` alone, not `(main_product, supplier)` — so a `MainProduct` can
+be sourced from at most one `SupplierProduct`, from at most one supplier,
+globally. There is nothing left to minimise over, and only one `PriceManager`
+(via its `supplier` scope) can ever reach a given product through SP_PRICES.
+
+The SP_PRICES branch (`:186`–`:199`) actually takes the **latest row by
+`updated_at`**: `products.filter(main_product=OuterRef('pk')).order_by
+('-updated_at').values(source)[:1]`, wrapped in `Coalesce(..., Decimal('0'))`
+— a tie-break that can no longer tie now that the FK is unique.
+`PriceTag.get_sprice()` (`:408`–`:416`) does the identical latest-row lookup on
+the instance side (`self.mp.supplierproducts.order_by('-updated_at').first()`)
+before multiplying by `self.mp.supplier.currency.value`. `PriceTag
+.get_aggfunc()` (`:402`, returns bare `max`) is a same-era leftover — nothing
+in `models.py` calls it; only a test (`tests.py:193`) exercises it directly.
+
+**Don't write code or tests that assume several `SupplierProduct` rows feed
+one `MainProduct`'s price** — that shape is no longer reachable at the DB
+level. See [[supplier_product_manager]] for the constraint itself and why it's
+`unique=True` rather than `OneToOneField` (a `related_name` compatibility
+reason, documented in a comment right above the field).
 
 Everything downstream — `save`, `apply`, `delete`, `deprecate` — calls this.
 `get_price_querry` (`:140`) has a commented-out earlier version directly above
@@ -46,20 +71,20 @@ the live one; don't mistake the dead block for the implementation.
 - **`apply():298`** is the one that moves money: filters to products whose dest
   differs from `changed_price`, bulk-creates `MainProductLog` rows, refreshes
   pricetags, then `.update(dest=F('changed_price'), price_updated_at=now)`.
-  Contains leftover `print()` debugging (`:305`–`:308`) that fires on every
+  Contains leftover `print()` debugging (`:306`–`:309`) that fires on every
   non-empty apply — noise in worker logs, not an error.
-- **`delete():311`** **nulls the dest price on every fitting product** before
+- **`delete():312`** **nulls the dest price on every fitting product** before
   deleting the rule. Deleting a rule is destructive to product data.
-- **`deprecate():316`** — deletes the rule's pricetags, sets `deprecated=True`,
+- **`deprecate():317`** — deletes the rule's pricetags, sets `deprecated=True`,
   nulls dest prices. The soft-delete counterpart to `delete()`.
 
 `update_pricetags():249` is the incremental version of the `save()` upsert — it
 only creates tags for products that don't have one yet.
 
-## `update_prices()` (`models.py:455`)
+## `update_prices()` (`models.py:456`)
 
 The bulk entry point, wrapped by `product_price_manager.update_prices`
-(`tasks.py:9`). Its inner `get_updated_mps(pricetags)` (`:456`) **merges by
+(`tasks.py:9`). Its inner `get_updated_mps(pricetags)` (`:457`) **merges by
 product pk**: when several pricetags touch the same `MainProduct` with different
 `dest` fields, it accumulates each `dest` onto one instance so a single write
 carries all of them. Keep that merge if you refactor — dropping it means later
@@ -75,3 +100,8 @@ The app's other two tasks are thin re-exports of
 `PriceManager` and `PriceTag` fields, understand that the copy is the audit
 trail. See [[main_product_manager]] for the dest price fields and
 [[supplier_product_manager]] for `SP_PRICES`.
+
+Test suite trap: any test that creates two `SupplierProduct` rows against one
+`MainProduct` to exercise "minimum across rows" behaviour will fail with
+`IntegrityError` on the unique constraint, not with a wrong price — the
+constraint fires before any pricing code runs.

--- a/price_manager/product_price_manager/tests.py
+++ b/price_manager/product_price_manager/tests.py
@@ -12,7 +12,7 @@ from .views import PriceManagerCreate
 
 class PriceManagerDiscountFilteringTests(TestCase):
     def setUp(self):
-        self.currency = Currency.objects.create(name='KZT', value=Decimal('1'))
+        self.currency, _ = Currency.objects.get_or_create(name='KZT', defaults={'value': Decimal('1')})
         self.supplier = Supplier.objects.create(
             name='Supplier A',
             currency=self.currency,
@@ -32,7 +32,7 @@ class PriceManagerDiscountFilteringTests(TestCase):
             **prices,
         )
 
-    def test_sp_source_uses_only_filtered_discount_group_for_min_price(self):
+    def test_sp_source_uses_only_filtered_discount_group(self):
         target_mp = self.create_main_product('MP-1', 'Target MP')
         excluded_mp = self.create_main_product('MP-2', 'Excluded MP')
 
@@ -43,14 +43,6 @@ class PriceManagerDiscountFilteringTests(TestCase):
             name='Valid discount row',
             supplier_price=Decimal('100'),
             discount=self.discount_a,
-        )
-        SupplierProduct.objects.create(
-            main_product=target_mp,
-            supplier=self.supplier,
-            article='SP-2',
-            name='Wrong discount row with lower price',
-            supplier_price=Decimal('10'),
-            discount=self.discount_b,
         )
         SupplierProduct.objects.create(
             main_product=excluded_mp,
@@ -113,17 +105,9 @@ class PriceManagerDiscountFilteringTests(TestCase):
         fitting_ids = set(manager.get_fitting_mps().values_list('id', flat=True))
         self.assertSetEqual(fitting_ids, {target_mp.id})
 
-    def test_without_discounts_sp_source_keeps_original_behavior(self):
+    def test_sp_source_without_discount_filter_admits_any_group(self):
         target_mp = self.create_main_product('MP-5', 'No discount limit MP')
 
-        SupplierProduct.objects.create(
-            main_product=target_mp,
-            supplier=self.supplier,
-            article='SP-6',
-            name='Price 100',
-            supplier_price=Decimal('100'),
-            discount=self.discount_a,
-        )
         SupplierProduct.objects.create(
             main_product=target_mp,
             supplier=self.supplier,
@@ -193,14 +177,7 @@ class PriceTagAndPriceManagerRuntimeTests(TestCase):
             main_product=mp,
             supplier=self.supplier,
             article='S-2',
-            name='SP row 1',
-            supplier_price=Decimal('10'),
-        )
-        SupplierProduct.objects.create(
-            main_product=mp,
-            supplier=self.supplier,
-            article='S-3',
-            name='SP row 2',
+            name='SP row',
             supplier_price=Decimal('15'),
         )
         pt = PriceTag.objects.create(
@@ -322,35 +299,6 @@ class PriceTagAndPriceManagerRuntimeTests(TestCase):
         mp.refresh_from_db()
         self.assertEqual(mp.basic_price, Decimal('0'))
 
-    def test_pricemanager_with_duplicate_supplier_products_prefers_positive_value(self):
-        mp = self.create_mp('M-DUP', 'Duplicate rows', basic_price=Decimal('777'))
-        SupplierProduct.objects.create(
-            main_product=mp,
-            supplier=self.supplier,
-            article='S-DUP-1',
-            name='SP zero',
-            supplier_price=Decimal('0'),
-        )
-        SupplierProduct.objects.create(
-            main_product=mp,
-            supplier=self.supplier,
-            article='S-DUP-2',
-            name='SP positive',
-            supplier_price=Decimal('12'),
-        )
-        manager = PriceManager.objects.create(
-            name='PM-DUP-POSITIVE',
-            supplier=self.supplier,
-            source='supplier_price',
-            dest='basic_price',
-            markup=Decimal('0'),
-            increase=Decimal('0'),
-        )
-
-        manager.apply()
-        mp.refresh_from_db()
-        self.assertEqual(mp.basic_price, Decimal('24'))
-
     def test_no_crash_when_source_price_missing(self):
         mp = self.create_mp('M-5', 'Missing source')
         SupplierProduct.objects.create(
@@ -406,7 +354,7 @@ class PriceManagerNameGenerationTests(TestCase):
         self.assertIn('Supplier Name', generated_name)
         self.assertIn('Базовая цена', generated_name)
         self.assertIn('Цена поставщика в валюте поставщика', generated_name)
-        self.assertIn('РРЦ Да', generated_name)
+        self.assertIn('РРЦ: Да', generated_name)
         self.assertIn('VIP', generated_name)
         self.assertIn('100', generated_name)
         self.assertIn('200', generated_name)


### PR DESCRIPTION
Closes #136.

The `product_price_manager` suite had 5 errors and 1 failure on a clean CI database. All three root causes turned out to be **stale test expectations — no production code is changed here.**

## What was wrong

**1. KZT fixture collided with the migration seed** (3 errors)
`supplier_manager`'s initial migration seeds `Currency(name="KZT")` via `get_or_create`, so the fixture's `create()` always hit the unique constraint. Now `get_or_create(name='KZT', defaults={'value': Decimal('1')})` — lookup on the unique column only.

**2. Tests asserted duplicate supplier rows** (2 errors)
`supplier_product_manager` migration `0009` made `SupplierProduct.main_product` a `unique=True` FK, so one `MainProduct` holds at most one `SupplierProduct`. `test_pricemanager_with_duplicate_supplier_products_prefers_positive_value` is deleted — the choice it covered no longer exists. `test_pricetag_get_sprice_sp_source_uses_supplierproduct_and_currency` keeps its `Decimal('30')` expectation on a single row (15 × USD rate 2).

**3. Stale string expectation** (1 failure)
`_build_generated_name` emits `РРЦ: Да` with a colon, consistent with every other segment it joins. The expectation was corrected; the user-visible format is untouched.

## Beyond the issue's brief

The brief listed **two** tests hitting the uniqueness constraint. There are actually **four** — two of the three `PriceManagerDiscountFilteringTests` also build two `SupplierProduct` rows per product. CI never reported them because `setUp` died on the Currency error first, so they never reached the constraint. Fixing only the fixture would have turned 3 errors into 2 different ones.

Both now use one row per product with assertions unchanged. The no-filter case keeps its wrong-group row, so it still contrasts meaningfully with the filtered case rather than becoming a vacuous single-row check.

Two test names described the retired minimum-across-rows selection and were renamed to match what they now prove — flagging it since #136 refers to the old names:

| Old | New |
|---|---|
| `test_sp_source_uses_only_filtered_discount_group_for_min_price` | `test_sp_source_uses_only_filtered_discount_group` |
| `test_without_discounts_sp_source_keeps_original_behavior` | `test_sp_source_without_discount_filter_admits_any_group` |

## Verification

```
docker compose exec -T celery_worker python manage.py test product_price_manager --keepdb
Ran 16 tests — OK          (was 17: 5 errors, 1 failure)

python manage.py makemigrations --check --dry-run
No changes detected
```

Run with `--keepdb` as the issue specifies, which exercises the `get_or_create` *get* branch — the one that was failing. CI runs migrations on a clean database, where the seed is present either way.

## Second commit

`docs(knowledge)` records the underlying trap: `get_fitting_mps()`'s docstring still claims it takes the **minimum** across a product's supplier rows, but both selection sites (the SP_PRICES `Subquery` and `PriceTag.get_sprice()`) take the latest row by `updated_at` — a tie-break that can no longer tie now the FK is unique. That drift is what produced both the broken tests and the stale names. **The docstring itself is left alone** — out of scope for this issue, and a candidate for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
