### PR TITLE
docs: correct the LoginRequiredMiddleware claim in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ Retirement status is otherwise clean: nothing in the legacy apps imports `produc
 - **102 of the repo's 146 templates** are under `core/templates/`, including templates owned by other apps' views (`supplier/`, `manufacturer/`, `currency/`, `category/`, `main/`, `upload/`, `registration/`).
 - `core/views.py` (~640 lines) owns the **shopping-tab / cart** feature — `ShoppingTab*` (list, detail, delete, export, import + preview/run) and `CartItem*` (detail, quick-add, product select, add, confirm/unconfirm, remove). Templates in `core/templates/shopping_tab/`.
 - `core/models.py` → `CartItem`, `ShoppingTab`, `ShoppingTabExport`, `PersistentNotification`, `TaskRunHistory`.
-- `core/middleware.py` → `LoginRequiredMiddleware` (global login gate, with HTMX-aware redirects) and `toaster_middleware`.
+- `core/middleware.py` → `LoginRequiredMiddleware` (global login gate; anonymous requests under `/api/` get 401 JSON instead of a redirect) and `toaster_middleware`.
 - `core/utils.py` → shopping-tab spreadsheet reading (pandas) and export helpers.
 - `core/viewmixins.py` → `HtmxMixin` is **dead code**; don't use it.
 


### PR DESCRIPTION
## What changed

One line in `CLAUDE.md`, in the "Where the UI lives: `core`" section. No Python.

```diff
- `LoginRequiredMiddleware` (global login gate, with HTMX-aware redirects)
+ `LoginRequiredMiddleware` (global login gate; anonymous requests under `/api/` get 401 JSON instead of a redirect)
```

## Why

The "HTMX-aware redirects" part was false. `core/middleware.py` contains no `request.htmx` branch anywhere:

- `LoginRequiredMiddleware.__call__` (`core/middleware.py:36-48`) short-circuits at `:37-38` for any authenticated request, and otherwise calls plain Django `redirect_to_login` at `:48`.
- `request.htmx` appears 14× in `core/views.py` and 1× in `core/viewmixins.py` — **zero** times in `core/middleware.py`.
- The only special-casing is path-based: `path.startswith("/api/")` returns 401 JSON instead of a redirect (`:45-46`).
- `django_htmx.middleware.HtmxMiddleware` is registered separately in `price_manager/price_manager/settings/third_party.py:19` and only sets `request.htmx`; it does not rewrite 3xx responses.

The likely source of the error is the unused `reswap` import at `core/middleware.py:8` (`from django_htmx.http import reswap, trigger_client_event`), which sits at the top of the file but serves only `toaster_middleware`.

This matters more than a typical doc nit: seven keeper agents and every AFK session treat `CLAUDE.md` as the repo's source of truth and are explicitly instructed *not* to restate it, so a wrong invariant there propagates silently into their answers with nothing downstream to catch it.

## Note for the reviewer

The replacement says **"anonymous requests under `/api/`"**, not "`/api/` paths". A plain "`/api/` paths get 401 JSON" would have replaced one wrong invariant with another — two guards run before the `/api/` check:

- `:37-38` short-circuits every authenticated request, so an authenticated `/api/` call never 401s here;
- `_is_exempt()` at `:42-43` clears `LOGIN_EXEMPT_API_PREFIXES` (`:64`), so exempt `/api/` prefixes don't either.

The `toaster_middleware` half of the bullet is untouched — that one genuinely does fire an HTMX client event (`:102`).

## Spot-check of the rest of the section (no changes needed)

| Claim | Result |
|---|---|
| 102 of the repo's 146 templates | **Exact.** 146 `.html` repo-wide; 102 under `core/templates/`. Rest: `main_product_manager` 16, `supplier_manager` 12, `product_price_manager` 7, `supplier_product_manager` 6, `blogapp` 3 |
| Template dirs owned by other apps' views | All 7 present (`supplier/ manufacturer/ currency/ category/ main/ upload/ registration/`) |
| `core/views.py` (~640 lines) | 639 |
| The five `core/models.py` models | Correct — `LevelChoices`/`StatusChoices` are `TextChoices` enums, rightly excluded |
| The seven `CartItem*` views | All present and correctly named |
| `core/utils.py` pandas + export helpers | `read_shopping_tab_dataframe:101`, `build_shopping_tab_export:186` |
| `HtmxMixin` is dead code | **Confirmed.** Zero references to `HtmxMixin` or `viewmixins` outside the file itself |

Deliberately left alone:

- **`AGENTS.md`** — checked, carries no middleware bullet at all, so the claim isn't there to fix. Its one overlapping fact (`102 of 146` at `:28`) is correct.
- **The `ShoppingTab*` list at `CLAUDE.md:65`** omits `ShoppingTabExportDownloadView` and `ShoppingTabAddItemView`, but that's a non-exhaustive summary rather than drift — `.claude/knowledge/core.md` already carries the fuller enumeration. That's the documented division of labor working.
- **`.claude/knowledge/core.md:124-130`** was already correct on the 401-JSON behaviour and the full exemption list. Since keepers aren't supposed to restate `CLAUDE.md`, the exemption detail stays there and the `CLAUDE.md` line stays a one-liner.

A repo-wide grep for `HTMX-aware` / `HTMX aware` across all `.md` files now returns zero — the bad invariant existed in exactly one place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
