### PR TITLE
Add retiring-stack guard hook, widen the record nudge to committed work

### DIFF
--- a/.claude/hooks/guard_retiring_stack.py
+++ b/.claude/hooks/guard_retiring_stack.py
@@ -1,0 +1,93 @@
+"""PreToolUse guard: make an edit to the retiring API-first stack a conscious choice.
+
+`CLAUDE.md` is unambiguous — `pricing`, `supplier`, `supplier_feed` and
+`dataframe` are being retired and take no new features. That rule is currently
+enforced by prose alone, which works on a person who has read the file and not
+at all on an unattended agent that grepped for a symbol and landed in
+`supplier/` instead of `supplier_manager/`. Those two names are one keystroke
+apart and confusing them is the single most likely way new code ends up in a
+dead app.
+
+So this asks rather than blocks. Bug fixes, test removal and explicitly
+requested work in these apps are all legitimate; a new model or route is not,
+and a hook cannot tell them apart. Asking puts the judgement back where it
+belongs while still catching the accident.
+
+Two deliberate exclusions:
+
+- **`product` is not gated.** It is being actively recreated as a PIM-linked
+  mirror and reconnected to the legacy stack, so edits there are normal work.
+  Gating it would fire constantly and train the reflex to approve without
+  reading, which would cost more than it saves. `product-keeper` owns that line.
+- **Only `Edit`/`Write` are matched.** A file rewritten through `Bash` (`sed -i`,
+  a heredoc) does not pass through here. Closing that would mean parsing
+  arbitrary shell, which is a worse trade than the gap.
+
+Both failure modes are fail-open, by choice: an unreadable payload or a path
+that does not resolve under the repo root stays silent rather than blocking real
+work. One consequence worth knowing — a *relative* `file_path` is resolved
+against the process cwd, so it only classifies correctly while that cwd is the
+repo root. Claude Code passes absolute paths, so this is latent, not live.
+"""
+import json
+import sys
+from pathlib import Path
+
+# .claude/hooks/guard_retiring_stack.py -> repo root holding docker-compose.yml
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# The retiring API-first apps, minus `product` -- see the module docstring.
+RETIRING = {"pricing", "supplier", "supplier_feed", "dataframe"}
+
+REASON = (
+    "`price_manager/{app}/` belongs to the retiring API-first stack. CLAUDE.md: "
+    '"The API-driven stack is being retired. Do not build new features here." '
+    "The live equivalent is usually a differently-named app -- `supplier` is "
+    "retiring, `supplier_manager` is the one being built on.\n\n"
+    "Approve this only for a bug fix, a test removal, or work that was asked "
+    "for by name. Do not approve a new model, route, serializer or feature. "
+    "Deleting one of these apps or its `/api/` route needs its own "
+    "confirmation that no external consumer exists -- CLAUDE.md calls that an "
+    "open question. Ask `retiring-stack-keeper` if the line is unclear."
+)
+
+
+def retiring_app(file_path: str) -> str | None:
+    """The retiring app this path sits in, or None.
+
+    Layout is <repo>/price_manager/<app>/..., and the repo directory is itself
+    named price_manager, so the check has to run on the path relative to the
+    repo root rather than on any bare `price_manager` segment.
+    """
+    if not file_path:
+        return None
+    try:
+        parts = Path(file_path).resolve().relative_to(REPO_ROOT).parts
+    except (ValueError, OSError):
+        return None  # Outside the repo, or unresolvable: not ours to police.
+    if len(parts) >= 3 and parts[0] == "price_manager" and parts[1] in RETIRING:
+        return parts[1]
+    return None
+
+
+def main() -> None:
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        return  # Malformed payload: stay out of the way rather than block real work.
+
+    app = retiring_app((payload.get("tool_input") or {}).get("file_path", ""))
+    if not app:
+        return
+
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "ask",
+            "permissionDecisionReason": REASON.format(app=app),
+        }
+    }))
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/suggest_record.py
+++ b/.claude/hooks/suggest_record.py
@@ -10,9 +10,17 @@ per (session, app-set) pair — the digest in .claude/.record_nudge folds in the
 session id, so one session is not nagged repeatedly, but a later session working
 in the same app still gets asked.
 
-Limitation: it reads `git diff --name-only HEAD` plus untracked files, so it only
-sees *uncommitted* work. A session that commits everything before stopping leaves
-nothing for this to detect and will not be nudged.
+It measures the session against the **merge-base with main**, not against `HEAD`,
+so committed branch work counts as well as uncommitted edits. `HEAD` alone was
+the original behaviour and it had the failure backwards: a session that commits
+looked like it had changed nothing, so the sessions that did the most work in an
+app — every unattended `/implement-issue` run, which commits everything — were
+exactly the ones never nudged.
+
+The cost of the wider base is that a long-lived branch also counts commits from
+earlier sessions on it. That is why the nudge is capped at once per
+(session, app-set): a stale app in the set costs one line of a message that is
+already being shown, and never a repeat.
 """
 import hashlib
 import json
@@ -40,23 +48,45 @@ KEEPERS = {
 }
 
 
+def git(*args: str) -> subprocess.CompletedProcess | None:
+    """Run git in the repo. None on any tooling failure, never an exception."""
+    try:
+        return subprocess.run(
+            ["git", *args],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return None  # No git, or too slow: never hold up a stop over tooling.
+
+
+def diff_base() -> str:
+    """The commit this session's work should be measured from.
+
+    On a feature branch that is where the branch left main, so the whole branch
+    counts. On main itself the merge-base collapses to HEAD, which restores the
+    uncommitted-only behaviour without needing a special case. `origin/main` is
+    tried first so a stale local `main` cannot widen the base to weeks of work.
+    """
+    for ref in ("origin/main", "main"):
+        proc = git("merge-base", "HEAD", ref)
+        if proc is not None and proc.returncode == 0 and proc.stdout.strip():
+            return proc.stdout.strip()
+    return "HEAD"
+
+
 def changed_files() -> list[str]:
-    """Tracked edits plus untracked additions, relative to the repo root."""
+    """Branch commits plus uncommitted edits plus untracked additions."""
     out = []
     for args in (
-        ["diff", "--name-only", "HEAD"],
+        ["diff", "--name-only", diff_base()],
         ["ls-files", "--others", "--exclude-standard"],
     ):
-        try:
-            proc = subprocess.run(
-                ["git", *args],
-                cwd=REPO_ROOT,
-                capture_output=True,
-                text=True,
-                timeout=10,
-            )
-        except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
-            return []  # No git, or too slow: never hold up a stop over tooling.
+        proc = git(*args)
+        if proc is None:
+            return []
         if proc.returncode == 0:
             out.extend(line for line in proc.stdout.splitlines() if line.strip())
     return out
@@ -100,7 +130,7 @@ def main() -> None:
 
     # The Telegram bot session stops after every group message, including the
     # silent capture-only turns that are most of a busy group. It never edits
-    # code, so this nudge can never fire usefully there -- and the two git
+    # code, so this nudge can never fire usefully there -- and the three git
     # subprocesses below would run per message. start-bot.ps1 sets the flag.
     if os.environ.get("TG_BOT_SESSION"):
         return

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -31,6 +31,17 @@
             "timeout": 15
           }
         ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python \"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}/.claude/hooks/guard_retiring_stack.py\"",
+            "statusMessage": "Checking retiring-stack boundary...",
+            "timeout": 15
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/.claude/skills/implement-issue/SKILL.md
+++ b/.claude/skills/implement-issue/SKILL.md
@@ -81,11 +81,14 @@ Two caveats on that gate, both real:
 - `product` is the exception — it is being actively **recreated** as a PIM-linked
   mirror. Fixes and reconnection work there are legitimate; new API surface is
   not. Ask `product-keeper` if the line is unclear.
-- **You are currently the only thing enforcing this.** `/agent-brief`
-  deliberately omits the boundary from every brief on the grounds that "the
-  retiring-stack boundary from `CLAUDE.md` is enforced by a hook, not restated in
-  every brief" — and that hook does not exist yet. Until it does, this gate is
-  not redundant with anything.
+- **A hook backs this up, but only partly.**
+  `.claude/hooks/guard_retiring_stack.py` turns an `Edit`/`Write` under
+  `pricing`, `supplier`, `supplier_feed` or `dataframe` into a permission
+  prompt, which is what `/agent-brief` is relying on when it omits the boundary
+  from every brief. It does **not** cover `product` (deliberately — that app is
+  being recreated), and it does not see a file rewritten through `Bash`. It also
+  fires one file at a time, so it catches the slip and not the plan. Deciding
+  *before* you start is still your job; the hook is the net, not the gate.
 
 ## 2. Ask the keeper — in ASK mode
 
@@ -277,13 +280,15 @@ it does not understand burns CI minutes and buries the useful signal.
 /record-insight <app>
 ```
 
-**This step is here because the hook cannot cover it.**
-`.claude/hooks/suggest_record.py` nudges at session end by reading
-`git diff --name-only HEAD` plus untracked files — its own docstring names the
-limitation: *"A session that commits everything before stopping leaves nothing
-for this to detect and will not be nudged."* This skill commits everything. So
-the automatic nudge is guaranteed **not** to fire on exactly the sessions that
-did the most work in an app.
+**Do it here; do not wait for the hook.**
+`.claude/hooks/suggest_record.py` now measures the session against the
+merge-base with `main`, so it does see the commits this skill makes — it used to
+diff against `HEAD` alone, which made a committing session look like it had
+changed nothing. But it fires once, at **session** stop, for the union of every
+app touched. One session that drains three issues gets a single nudge naming
+three apps, long after the details of the first one have gone. Recording per
+issue, while the surprise is still fresh, is the difference between a knowledge
+file entry worth reading and a vague one.
 
 Without this step the knowledge files freeze, which `CLAUDE.md` calls out as the
 failure the whole keeper system exists to prevent.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,8 @@ The API-first rewrite did not work out. `product` is currently being **recreated
 
 Retirement status is otherwise clean: nothing in the legacy apps imports `product`, `pricing`, `supplier`, `supplier_feed`, or `dataframe`. Those five reference only each other and are reachable only via `/api/`.
 
+A `PreToolUse` hook (`.claude/hooks/guard_retiring_stack.py`) turns an edit under `pricing`, `supplier`, `supplier_feed` or `dataframe` into a permission prompt — `supplier` and `supplier_manager` are one keystroke apart and that is the usual way code lands in a dead app. It is a net, not a gate: `product` is excluded on purpose (it is being recreated), and a file rewritten through `Bash` does not pass through it.
+
 ## Where the UI lives: `core`
 
 `core` is the largest and most active app, and holds most of the front end:


### PR DESCRIPTION
Two hooks. Both close gaps the repo had already written around — in one case
literally, in a skill that assumed the hook existed.

## 1. `guard_retiring_stack.py` — new, `PreToolUse` on `Edit|Write`

Turns an edit under `pricing`, `supplier`, `supplier_feed` or `dataframe` into a
permission prompt.

`CLAUDE.md` says these apps take no new features, but that rule was enforced by
prose alone — which works on someone who has read the file and not at all on an
agent that grepped for a symbol and landed in `supplier/` instead of
`supplier_manager/`. Those two names are one keystroke apart and confusing them is
the likeliest way new code ends up in a dead app.

It **asks rather than blocks**. Bug fixes, test removal and explicitly requested
work in these apps are all legitimate; a new model or route is not, and a hook
cannot tell them apart. Asking puts the judgement back where it belongs while
still catching the accident.

Two deliberate exclusions, both in the module docstring:

- **`product` is not gated** — it is being actively recreated as a PIM-linked
  mirror, so edits there are normal work. Gating it would fire constantly and
  train the reflex to approve without reading, which costs more than it saves.
- **Only `Edit`/`Write` are matched** — a file rewritten through `Bash` does not
  pass through. Closing that would mean parsing arbitrary shell, a worse trade
  than the gap.

`agent-brief` already omitted this boundary from every brief *"on the grounds
that the retiring-stack boundary from CLAUDE.md is enforced by a hook, not
restated in every brief"* — a hook that did not exist. That line is now true, no
edit needed.

## 2. `suggest_record.py` — widened to the merge-base with `main`

The old `git diff --name-only HEAD` had the failure backwards: it saw only
*uncommitted* work, so a session that commits — every unattended
`/implement-issue` run — looked like it had changed nothing and was never nudged.
The knowledge files would have frozen on exactly the sessions that did the most
work in an app, which is the rot `CLAUDE.md` says the keeper system exists to
prevent.

On `main` the merge-base collapses to `HEAD`, so the old behaviour is preserved
with no special case. The cost is that a long-lived branch also counts earlier
commits on it — mitigated by the existing once-per-(session, app-set) cap.

## Docs updated alongside

`/implement-issue` described both hooks as they *were*, quoting the old docstring
verbatim and stating the guard "does not exist yet". Both passages rewritten.
Step 9 keeps the manual `/record-insight` but for the correct reason now: the
hook fires once per **session** for the union of apps touched, so a session
draining three issues gets one late nudge naming three apps. Two lines added to
`CLAUDE.md` beside the rule the guard enforces.

## Testing

`guard_retiring_stack.py`, by piped payload:

- `pricing`, `supplier`, `supplier_feed`, `dataframe` → `ask`, for both existing
  and not-yet-created files (the new-file case is what the hook is really for)
- `supplier_manager`, `product`, `core`, `price_manager/settings/`, paths outside
  the repo, missing `file_path`, `null` `tool_input`, malformed JSON → silent
- absolute Windows, absolute POSIX and repo-relative paths all classify the same

`suggest_record.py`, on a throwaway branch with a **committed** change to `core/`:

- `git diff --name-only HEAD` → empty (what the old hook saw: nothing)
- new hook → nudges for `core` ✅
- on the `main` tip, `diff_base()` returns `HEAD` exactly, and nothing is falsely
  detected
- dedup cap, `stop_hook_active`, `TG_BOT_SESSION` exemption and malformed-payload
  silence all still hold

## What a reviewer should check

**I could not verify the guard firing through the harness.** Every test above
pipes a payload to the script, which bypasses matcher dispatch — those tests
would pass identically if the `settings.json` wiring were wrong. A real `Write`
to `price_manager/pricing/` during the session went through with no prompt,
because Claude Code snapshots hooks at session start and this branch edits
`settings.json` mid-session.

The entry is structurally identical to the `check_migrations` entry that
demonstrably works in this repo (`matcher: "Edit|Write"`, no `if`), and Docker
was down so `check_migrations`' own silence could not be used to triangulate. Worth
one confirmation in a fresh session: ask Claude to `Write` a throwaway file under
`price_manager/pricing/` and check the prompt appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
