### PR TITLE
Add narrow-class auto-merge gate (Markdown and tests only)

### DIFF
--- a/.claude/skills/implement-issue/SKILL.md
+++ b/.claude/skills/implement-issue/SKILL.md
@@ -305,29 +305,58 @@ If nothing surprised you, say so and skip it — `/record-insight` itself says a
 empty record is better than a padded one. But decide that deliberately, once,
 rather than by omission.
 
-## 10. Declare the merge class — and stop there
+## 10. Declare the merge class, and label only what the gate can verify
 
-Classify the diff and put the verdict in the PR body:
+**Two different things share the word "class" here. Keep them apart.**
+
+### The declaration — for a human, in the PR body
+
+Classify the diff and put the verdict under `## Класс слияния`:
 
 - **`docs-only`** — `*.md`, docstrings, comments. No behaviour change.
 - **`tests-only`** — `tests.py` / `tests/` and nothing else.
 - **`code`** — anything touching views, models, migrations, tasks, templates,
   settings.
 
-The first two are the class the maintainer chose to auto-merge one day. **That
-day is not today**, and this skill must not pretend otherwise: the repo has
-`allow_auto_merge: false` and `main` carries no branch protection, so there is no
-mechanism to attach a label to and no required check to gate on. Wiring it up
-means enabling auto-merge on the repo, making `Django test suite` a required
-check, and adding the workflow — three things that do not exist.
+This is the broad, human-readable reading of the diff. Always state it.
 
-So: **state the class, do not apply a label.** A label nothing consumes is how
-this repo ended up with a dead `codex` label. The declaration in the PR body is
-useful to a human reading the queue today, and it is the thing an auto-merge
-workflow would read tomorrow.
+### The label — for the gate, and stricter
 
-**Never merge the PR yourself.** Merging is the maintainer's call, in every
-class.
+`.github/workflows/auto-merge.yml` arms GitHub's native auto-merge on PRs
+labelled **`auto-merge-safe`**. Apply that label when, and only when, **every
+changed path** is either:
+
+- `*.md`, or
+- `tests.py` / anything under a `tests/` directory,
+
+**and none of them** is under `.github/` or `.claude/`, or is `CLAUDE.md` or
+`AGENTS.md`. Those govern agents and the gate itself; a PR that could auto-merge
+them could rewrite its own constraints.
+
+The label is deliberately **narrower than `docs-only`**. A docstring-only change
+to a `.py` file outside tests is honestly `docs-only` to a reader, but the
+workflow sees paths, not hunks, and cannot tell it from a logic change — so it
+does not get the label. That is not a bug in either place; it is the difference
+between what a person can judge and what a gate can prove.
+
+**The label is a request, not an authorization.** The workflow re-derives the
+class from the actual diff and refuses if it does not hold, so mislabelling
+fails closed. Do not treat that refusal as the gate being broken.
+
+### What is actually wired up
+
+- `Django test suite` **is** a required check on `main` — via **ruleset
+  22286885**, with `bypass_actors: []`, so not even an admin merges around it.
+  (Earlier revisions of this section said `main` had no protection. That was
+  read from the legacy `branches/main/protection` endpoint, which 404s when
+  protection comes from a ruleset. It was wrong.)
+- GitHub, not the workflow, waits for green and performs the merge.
+- The one remaining switch is the repo setting **`allow_auto_merge`**. While it
+  is `false` the workflow still runs, still evaluates, and reports that a PR
+  qualifies without arming anything.
+
+**Never merge the PR yourself.** Merging is GitHub's, once the required check is
+green — or the maintainer's. It is never yours, in any class.
 
 ## Report back
 

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,176 @@
+name: Auto-merge (narrow class)
+
+# Arms GitHub's native auto-merge on pull requests whose diff is provably in a
+# narrow, low-risk class: Markdown and tests, and nothing else.
+#
+# The division of labour matters:
+#
+#   * Ruleset 22286885 makes `Django test suite` a REQUIRED check on the default
+#     branch, with `bypass_actors: []` — not even an admin skips it. GitHub, not
+#     this workflow, enforces green. Once auto-merge is armed, GitHub holds the
+#     PR until the required check passes and merges it then.
+#   * This workflow only decides ELIGIBILITY. It never merges anything itself.
+#
+# So a bug here cannot merge a red PR. The worst it can do is arm a PR it should
+# not have — which is why the class check below is deliberately paranoid.
+#
+# ---------------------------------------------------------------------------
+# SECURITY INVARIANTS — do not relax these without thinking it through
+# ---------------------------------------------------------------------------
+#
+# 1. `pull_request`, NEVER `pull_request_target`. This repository is public.
+#    `pull_request_target` runs with a write token in the base-repo context, and
+#    combined with a checkout of PR head it is the classic token-exfiltration
+#    RCE. `pull_request` gives fork PRs a read-only token, which is exactly what
+#    we want.
+#
+# 2. NO CHECKOUT. This workflow never checks out the PR's code. It reads the
+#    changed-file list from the API. No checkout means no untrusted code runs
+#    here at all, so there is no surface to exploit.
+#
+# 3. THE LABEL IS A REQUEST, NOT AN AUTHORIZATION. `auto-merge-safe` only asks
+#    for consideration. This workflow independently re-derives the class from
+#    the actual diff and refuses if it does not hold. An agent that mislabels a
+#    PR does not get it merged.
+#
+# 4. THE GATE MUST NOT BE ABLE TO MERGE EDITS TO ITSELF. Any change under
+#    `.github/` or `.claude/`, or to `CLAUDE.md` / `AGENTS.md`, is refused
+#    unconditionally — even though those are mostly Markdown and would otherwise
+#    pass the allowlist. Those paths are the rules that govern agents and this
+#    gate; an agent able to auto-merge them could rewrite its own constraints.
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+
+concurrency:
+  group: auto-merge-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  # Enabling auto-merge, and disabling it again when a PR stops qualifying.
+  pull-requests: write
+  # The merge GitHub performs once checks pass runs under the identity that
+  # armed it. If the first real run shows this is not needed, narrow it.
+  contents: write
+
+jobs:
+  evaluate:
+    name: Evaluate merge class
+    runs-on: ubuntu-latest
+    # Cheap pre-filter. The authoritative checks are in the script below; this
+    # only avoids spinning a runner for the obvious no-ops.
+    if: github.event.pull_request.draft == false
+
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REPO: ${{ github.repository }}
+      PR: ${{ github.event.pull_request.number }}
+      LABEL: auto-merge-safe
+
+    steps:
+      - name: Decide, and arm or disarm
+        run: |
+          set -euo pipefail
+
+          # Returns 0 and prints nothing when auto-merge is not currently armed.
+          disarm_if_armed() {
+            local armed
+            armed=$(gh api "repos/$REPO/pulls/$PR" --jq '.auto_merge != null')
+            if [ "$armed" = "true" ]; then
+              echo "Disarming auto-merge: this PR no longer qualifies."
+              gh pr merge "$PR" --repo "$REPO" --disable-auto
+            fi
+          }
+
+          refuse() {
+            echo "NOT ELIGIBLE: $1"
+            disarm_if_armed
+            exit 0
+          }
+
+          # --- Invariant 1: same-repo only -------------------------------------
+          # A fork PR gets a read-only token here anyway, so this is belt and
+          # braces — but it makes the intent explicit rather than incidental.
+          HEAD_REPO=$(gh api "repos/$REPO/pulls/$PR" --jq '.head.repo.full_name // ""')
+          if [ "$HEAD_REPO" != "$REPO" ]; then
+            echo "NOT ELIGIBLE: pull request originates from a fork ($HEAD_REPO). Never auto-merged."
+            exit 0
+          fi
+
+          # --- The label is a request ------------------------------------------
+          if ! gh pr view "$PR" --repo "$REPO" --json labels \
+               --jq '.labels[].name' | grep -qx "$LABEL"; then
+            refuse "the '$LABEL' label is not present"
+          fi
+
+          # --- Read the diff, and prove the list is complete --------------------
+          # `gh pr view --json files` truncates on large PRs, and a truncated
+          # list of .md files reads as docs-only. Page the REST endpoint and
+          # cross-check against the PR's own changed_files count; a mismatch
+          # means we cannot see the whole diff, so we refuse.
+          gh api "repos/$REPO/pulls/$PR/files" --paginate --jq '.[].filename' > /tmp/files.txt
+          # `grep -c ''` not `wc -l`: wc undercounts a final line with no
+          # trailing newline, which would make a complete list look truncated
+          # and refuse a PR that should qualify. `|| true` because grep exits 1
+          # on an empty file and `set -e` would kill the script before the
+          # zero-files check below can report it properly.
+          SEEN=$(grep -c '' /tmp/files.txt || true)
+          CLAIMED=$(gh api "repos/$REPO/pulls/$PR" --jq '.changed_files')
+
+          if [ "$SEEN" -ne "$CLAIMED" ]; then
+            refuse "file list incomplete — saw $SEEN of $CLAIMED changed files"
+          fi
+          if [ "$SEEN" -eq 0 ]; then
+            refuse "no changed files reported"
+          fi
+
+          echo "Changed files ($SEEN):"
+          sed 's/^/  /' /tmp/files.txt
+
+          # --- Invariant 4: the gate cannot merge edits to itself ---------------
+          # Checked FIRST and unconditionally. These paths are mostly Markdown
+          # and would sail through the allowlist below; that is precisely the
+          # hole this closes. PR #151 (two files, both .md, both under .claude/)
+          # is the worked example: an agent editing the instructions that govern
+          # its own merges.
+          while IFS= read -r f; do
+            case "$f" in
+              .github/*|.claude/*|CLAUDE.md|AGENTS.md)
+                refuse "'$f' governs agents or this gate — never auto-merged"
+                ;;
+            esac
+          done < /tmp/files.txt
+
+          # --- The allowlist ----------------------------------------------------
+          # Path-verifiable classes only. Note this is STRICTER than the
+          # `## Класс слияния` declaration in the PR body: a docstring-only
+          # change to a .py file outside tests is `docs-only` to a human reader
+          # but indistinguishable from a logic change by path, so it does not
+          # qualify here. See /implement-issue §10.
+          while IFS= read -r f; do
+            case "$f" in
+              *.md)                 ;;  # Markdown, excluding the paths refused above
+              */tests.py|tests.py)  ;;  # an app's test module
+              */tests/*|tests/*)    ;;  # an app's test package
+              *)
+                refuse "'$f' is outside the auto-merge class (Markdown and tests only)"
+                ;;
+            esac
+          done < /tmp/files.txt
+
+          # --- Is the gate armed at the repo level? -----------------------------
+          # Without this, `gh pr merge --auto` errors and every qualifying PR
+          # gets a red X that looks like a broken gate rather than a disarmed
+          # one. Exit clean and say so instead.
+          if [ "$(gh api "repos/$REPO" --jq '.allow_auto_merge')" != "true" ]; then
+            echo "ELIGIBLE — but repository setting allow_auto_merge is false, so nothing is armed."
+            echo "This PR qualifies and would auto-merge once a maintainer enables auto-merge on the repo."
+            exit 0
+          fi
+
+          # --- Arm it -----------------------------------------------------------
+          # GitHub takes it from here: it waits for the required `Django test
+          # suite` check and merges only when that check is green.
+          echo "ELIGIBLE — arming auto-merge."
+          gh pr merge "$PR" --repo "$REPO" --auto --merge


### PR DESCRIPTION
Arms GitHub's native auto-merge on pull requests whose diff is provably
Markdown and tests, and nothing else. **The workflow decides eligibility only.
It never merges anything itself.**

## §10 was wrong about branch protection, and that makes this simpler

`/implement-issue` §10 said wiring this up meant three things that did not
exist: enabling auto-merge, making `Django test suite` a required check, and
adding the workflow.

It was **two**. Ruleset `22286885` — created Sep 4, after §10 was written —
already requires `Django test suite` on the default branch, with
`bypass_actors: []`, so not even an admin merges around it. §10 concluded there
was no protection because that reading came from the legacy
`branches/main/protection` endpoint, which returns 404 when protection comes
from a ruleset rather than classic branch protection.

That changes the design for the better:

| Concern | Owner |
|---|---|
| Is the PR green? | **GitHub**, via the ruleset. Auto-merge waits for the required check. |
| Should this PR be armed at all? | This workflow. |

So a bug in this workflow **cannot merge a red PR**. The worst it can do is arm
something it should not have — which is why the class check is paranoid.

§10 is corrected in this PR rather than rewritten; the stale sentence is now a
short note explaining why the earlier reading was wrong.

## The hole in the obvious allowlist

The natural class is `*.md` plus tests. Run that against **#151, merged from
this branch an hour ago**: two files, both `.md`, both under `.claude/` — an
agent auto-merging edits to the instructions that govern its own merges. **#145**
is the second case: `CLAUDE.md`, a plain root-level `.md` that governs
everything.

So paths under `.github/` or `.claude/`, and `CLAUDE.md` / `AGENTS.md`, are
refused **first and unconditionally**, before the allowlist gets a chance to pass
them. This PR is itself in that class and will refuse itself — visible in the
workflow run on this PR.

Classification was tested against real PR file lists before the workflow was
written:

| Case | Result |
|---|---|
| #151 — two `.md` files under `.claude/` | REFUSE — governs the gate |
| #145 — `CLAUDE.md` | REFUSE — governs agents |
| #143 — three real test files | **ELIGIBLE** |
| `README.md` | ELIGIBLE |
| `README.md` + `core/views.py` | REFUSE |
| `notes.md.py` | REFUSE |
| the workflow file itself | REFUSE |

## Security invariants

Each is commented in the workflow at the point it matters:

- **`pull_request`, never `pull_request_target`.** This repo is public.
  `pull_request_target` plus a checkout of PR head is the classic write-token
  RCE.
- **No checkout at all.** The file list comes from the API, so no untrusted code
  runs in this job. No checkout, no surface.
- **The label is a request, not an authorization.** The workflow re-derives the
  class from the actual diff and refuses if it does not hold, so an agent
  mislabelling its own PR fails closed.
- **Fork PRs are refused outright** (they get a read-only token anyway — this
  makes the intent explicit rather than incidental).
- **Truncation fails closed.** `gh pr view --json files` truncates on large PRs,
  and a truncated list of `.md` files reads as docs-only. The file list is paged
  from the REST endpoint and cross-checked against `changed_files`; a mismatch
  refuses.
- **A later push that breaks the class disarms auto-merge again.**

`permissions:` is declared explicitly because the repo default is `read`.
`contents: write` is included because the merge GitHub performs runs under the
identity that armed it; if the first real run shows it is unnecessary, the
comment says to narrow it.

## Two bugs that came from testing, not reading

- **`wc -l` undercounts a file with no trailing newline** (1 vs 2). That fails
  *closed*, so it was never a safety problem — but it would have made a working
  gate look broken. Now `grep -c ''`, with `|| true` because grep exits 1 on an
  empty file and `set -e` would kill the script before the zero-files check could
  report it.
- **The refusal loop reads by redirect, not by pipe.** A pipe would make the
  `while` body a subshell, so `exit` inside `refuse()` would not terminate the
  script and every refusal would be silently ignored. Verified empirically,
  because that failure mode produces no error.

## Two names for two things

§10 previously used "class" for both the PR-body declaration and the future
label. They are now separate and each is stated once:

- `## Класс слияния` in the PR body — broad, human-readable, always stated.
- `auto-merge-safe` — strictly path-verifiable, and **narrower**.

A docstring-only change to a `.py` outside tests is honestly `docs-only` to a
reader and will not get the label, because the workflow sees paths, not hunks.
That is not a bug in either place.

## Nothing is armed yet

`allow_auto_merge` is still **`false`** on the repo, so this merges nothing on
its own. The workflow still runs and reports that a PR *qualifies* rather than
erroring — otherwise every eligible PR would carry a red X that looks like a
broken gate instead of a disarmed one.

Arming it is one deliberate command, left to you:

```bash
gh api -X PATCH repos/Pesshiii/price_manager --field allow_auto_merge=true
```

## For the reviewer

- No application code changes — `.github/` and `.claude/` only.
- The `auto-merge-safe` label has been created on the repo.
- The workflow runs on this PR and should report **NOT ELIGIBLE** (no label, and
  the diff touches `.github/` and `.claude/`). That is the intended result and
  the first live exercise of the gate.
- The ruleset is deliberately untouched. It is the part that was already right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
