### PR TITLE
Stop cancelling main CI runs, correct the stale gate claims

### DIFF
--- a/.claude/agents/ci-failure-analyst.md
+++ b/.claude/agents/ci-failure-analyst.md
@@ -117,11 +117,17 @@ changed** — say so and stop. Do not let anyone "fix" a test to match.
 **This is the judgment the caller cannot make from the log alone, and the reason
 this agent exists.** Never report a failure as the branch's without checking.
 
-`main` has **no branch protection and CI is not a required check**, so red commits
-do land on it. It has happened: run `33840300451`, a deliberate
-`TEMP: baseline CI run on unmodified main`, came back `Ran 257 tests` /
-`FAILED (failures=8, errors=25)`. Every branch cut from that `main` inherited 33
-failures it did not cause.
+`main` is protected: `Django test suite` is a required check via ruleset
+22286885 with `bypass_actors: []`, so a red PR does not merge. That closed the
+main route to a red `main` on **2026-09-04, 16:59 UTC**. It did not close every
+route — the ruleset sets `strict_required_status_checks_policy: false`, so a PR
+green against a *stale* base can still redden `main` after merging, and anything
+older than that timestamp never passed the gate at all.
+
+Red commits did land, before the ruleset: run `33840300451` (2026-09-04, 05:23
+UTC), a deliberate `TEMP: baseline CI run on unmodified main`, came back
+`Ran 257 tests` / `FAILED (failures=8, errors=25)`. Every branch cut from that
+`main` inherited 33 failures it did not cause.
 
 The clearest case on record is run `33858890306` on `fix/138-update-stocks-null-to-zero`.
 Issue #138 is a `main_product_manager` bug. That run's real failures were in

--- a/.claude/skills/implement-issue/SKILL.md
+++ b/.claude/skills/implement-issue/SKILL.md
@@ -28,9 +28,14 @@ pre-existing failures"*.
 So: **local tests are the fast inner loop; CI is the verdict.** Never open a PR
 claiming green on the strength of a local run alone.
 
-Second-order, and worth knowing before you trust a green `main`: **`main` has no
-branch protection and CI is not a required check.** Nothing on GitHub's side
-stops a red PR from merging. The check in §8 is the only gate this repo has.
+Second-order, and worth knowing before you trust a green `main`: **`main` is
+protected.** `Django test suite` is a required check via ruleset 22286885 with
+`bypass_actors: []`, so a red PR does not merge and not even an admin merges
+around it. That is not the same as `main` being green by construction — the
+ruleset sets `strict_required_status_checks_policy: false`, so a PR green against
+a *stale* base can still redden `main` once merged, and commits that landed
+before the ruleset existed (2026-09-04, 16:59 UTC) never passed it at all. §8 is
+still where you learn about your own branch.
 
 ## 0. No issue number given
 
@@ -265,10 +270,12 @@ returns benign `duplicate key value violates unique constraint` lines emitted by
 tests that were *passing*. The real Django lines are ~2000 lines up.
 
 The analyst also settles the question you cannot answer from the log alone:
-**whether the failure is yours.** `main` has no branch protection and CI is not a
-required check, so red commits land on it — run `33858890306` on `fix/138` failed
-in `product_price_manager` and `supplier_product_manager`, two apps that branch
-never touched. It returns one of four verdicts:
+**whether the failure is yours.** The ruleset stops a red PR merging, but it does
+not make an inherited failure impossible: a branch cut from a `main` older than
+the gate, or from one reddened by a PR that was green against a stale base, still
+carries failures it did not cause. Run `33858890306` on `fix/138` is the worked
+example — it failed in `product_price_manager` and `supplier_product_manager`,
+two apps that branch never touched. It returns one of four verdicts:
 
 | Verdict | What you do |
 |---|---|
@@ -351,9 +358,11 @@ fails closed. Do not treat that refusal as the gate being broken.
   read from the legacy `branches/main/protection` endpoint, which 404s when
   protection comes from a ruleset. It was wrong.)
 - GitHub, not the workflow, waits for green and performs the merge.
-- The one remaining switch is the repo setting **`allow_auto_merge`**. While it
-  is `false` the workflow still runs, still evaluates, and reports that a PR
-  qualifies without arming anything.
+- The repo setting **`allow_auto_merge`** is **`true`**, so the gate is live: a
+  correctly labelled PR in the class really is armed, and GitHub merges it the
+  moment the required check goes green. (The workflow still handles the `false`
+  case — it runs, evaluates, and reports that a PR qualifies without arming
+  anything — but that is no longer the state of this repo.)
 
 **Never merge the PR yourself.** Merging is GitHub's, once the required check is
 green — or the maintainer's. It is never yours, in any class.

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -41,7 +41,10 @@ name: Auto-merge (narrow class)
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, labeled, unlabeled]
+    # `ready_for_review` is load-bearing: the job below skips drafts, so a PR
+    # opened as a draft and later marked ready fires nothing this workflow acts
+    # on, and stays unarmed until some later push happens to wake it.
+    types: [opened, reopened, synchronize, labeled, unlabeled, ready_for_review]
 
 concurrency:
   group: auto-merge-${{ github.event.pull_request.number }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,15 @@ on:
 
 # A new push to the same branch supersedes the run in flight. Matters once an
 # agent loop is force-pushing fixups onto its own PR branch.
+#
+# `main` is exempt. Its runs are the baselines `ci-failure-analyst` subtracts
+# against to tell a branch's own failures from ones it inherited, and a run
+# cancelled mid-flight leaves no failing-test list to compare with. Two merges
+# in quick succession would otherwise erase the baseline for the SHA between
+# them -- exactly the SHA a branch cut from it needs.
 concurrency:
   group: ci-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   test:


### PR DESCRIPTION
Three one-line fixes, plus the documentation drift the third one exposed. No
application code changes — `.github/` and `.claude/` only.

## Что сделано

### 1. `ci.yml` — `main` no longer cancels its own runs

`cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}`

The group was added so an agent loop force-pushing fixups supersedes its own
run in flight. That is right for feature branches and wrong for `main`: its runs
are the baselines `ci-failure-analyst` §3 subtracts against to tell a branch's
own failures from inherited ones, and a cancelled run leaves no failing-test
list to compare with. Two merges in quick succession would erase the baseline
for exactly the SHA a branch cut between them needs.

This is two parts built days apart quietly interfering. It has not fired yet —
the last several `main` runs are all `success`, none cancelled — so this is
pre-emptive.

### 2. `auto-merge.yml` — `ready_for_review` added to the trigger types

The job carries `if: github.event.pull_request.draft == false`, so a draft PR's
`opened` run is skipped. Marking it ready then fired no event in the list, and
the PR stayed unarmed until some unrelated later push happened to wake it.

### 3. The stale branch-protection claim, in the three places it survived

`34b3015` corrected §10's "`main` has no branch protection" claim. The same
claim survived in three other passages — two of them in the very file whose §10
says it was wrong, so `implement-issue` was contradicting itself:

| Where | Was |
|---|---|
| `implement-issue/SKILL.md:32` | "the check in §8 is the only gate this repo has" |
| `implement-issue/SKILL.md:268` | §8's rationale for spawning the analyst |
| `ci-failure-analyst.md:120` | "so red commits do land on it" |

Ruleset **22286885** has required `Django test suite` on the default branch with
`bypass_actors: []` since **2026-09-04 16:59 UTC**. All three now say so, and
each also names the gap that remains: the ruleset sets
`strict_required_status_checks_policy: false`, so a PR green against a *stale*
base can still redden `main` after it merges.

**The evidence in those passages is kept, not deleted.** Runs `33840300451`
(05:23 UTC) and `33858890306` (09:32 UTC) both predate the ruleset by hours, so
they still show exactly what an inherited failure looks like. That distinction
is load-bearing for §8: inherited failures are rarer now, not impossible, so the
analyst's attribution step still earns its place. Striking the premise alone
would have made the whole section read as obsolete.

### 4. §10's `allow_auto_merge` sentence

It read as though the setting were still `false`. It is `true` — enabled after
#152 merged — so the gate is live and arms real PRs rather than evaluating into
a void. The `false` branch is kept as a parenthetical, since the workflow still
handles it.

## Проверка

- `grep -rn "no branch protection\|not a required check" .claude/` → no matches.
  All four files that discuss the gate now agree.
- Timeline verified against the API, not from memory: ruleset `created_at`
  2026-09-04T21:59+05:00 (16:59 UTC); both cited red runs precede it; every
  `main` run after it is `success`.
- **The workflow YAML was not machine-parsed locally** — no PyYAML in the system
  Python and the Docker engine was down. The two workflow runs appearing on this
  PR *are* that check: GitHub parses both files to schedule them, so a malformed
  `ci.yml` would produce no CI run at all.

## Класс слияния

`docs-only` by the §10 reading — no behaviour change in the application, and the
two workflow edits change scheduling, not what CI asserts.

**Deliberately not labelled `auto-merge-safe`.** Every changed path is under
`.github/` or `.claude/`, which invariant 4 refuses unconditionally. This PR is
the case that rule exists for: an agent editing the gate that governs its own
merges. The Auto-merge workflow should run and report NOT ELIGIBLE.

## Замечания ревью

No reviewer agents dispatched — `price-manager-conventions` reviews changed
Django code against repo invariants and this diff contains none.

One thing left alone deliberately: `ci-failure-analyst.md:138` still says
"`main` is green as of the last three runs". That is true but now understated —
every `main` run since the ruleset is green. It is not stale, so it sits outside
this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
