### PR TITLE
Make the prod dumps in backups/ usable, with an eval and a guard

### DIFF
--- a/.claude/agents/django-orm-perf.md
+++ b/.claude/agents/django-orm-perf.md
@@ -1,6 +1,6 @@
 ---
 name: django-orm-perf
-description: Finds N+1 queries and hot-path inefficiencies in Django views, django-tables2 columns, templates, and bulk import tasks — including saves that trigger MainProduct._build_searchvector's PIM network call once per row. Use when a list page is slow, before adding a table column that traverses a relation, or when touching bulk import or price-update code.
+description: Finds N+1 queries and hot-path inefficiencies in Django views, django-tables2 columns, templates, and bulk import tasks — including saves that trigger MainProduct._build_searchvector's PIM network call once per row. Use when a list page is slow, before adding a table column that traverses a relation, or when touching bulk import or price-update code. Reads code rather than query plans; points at the prod-snapshot skill when a finding needs real row counts to confirm.
 tools: Read, Grep, Glob
 model: sonnet
 ---
@@ -97,3 +97,9 @@ concrete fix in this repo's idiom. Rank by rows-affected × frequency. Say plain
 when you are inferring rather than measuring — you are reading code, not
 profiling. If a path is already correctly batched, note it briefly so the user
 knows it was checked.
+
+When a finding turns on real volume — whether the planner actually uses the GIN
+index, how many rows a loop really walks — say so and point at the `prod-snapshot`
+skill, which restores the production dump in `backups/` into a throwaway database
+(156k `MainProduct`, 168k `SupplierProduct`, 527k `PriceTag`). The dev database is
+empty, so an estimate you cannot check against it is not a measurement.

--- a/.claude/hooks/guard_prod_data.py
+++ b/.claude/hooks/guard_prod_data.py
@@ -1,0 +1,78 @@
+"""PreToolUse guard: keep production dumps off the live dev database.
+
+`backups/` holds real production data. The `prod-snapshot` skill restores it into
+a separate `pricemanager_snapshot` database precisely so `price_manager_db` never
+holds prod rows and never gets dropped by a stray restore flag. This guard refuses
+the two ways that rule gets broken:
+
+  * `pg_restore ... -d price_manager_db` — pours prod data into the dev database.
+  * `dropdb price_manager_db` / `DROP DATABASE price_manager_db` — the existing
+    `guard_compose_down.py` only catches `docker compose down -v`, so these walk
+    straight past it and destroy the same volume's contents.
+
+Like the other guards this is a net, not a gate: read-only `psql -d
+price_manager_db -c "SELECT ..."` is untouched, and anything aimed at
+`pricemanager_snapshot` or `test_price_manager_db` is none of its business.
+
+**It matches on mention, deliberately.** Any command naming the live database
+alongside `pg_restore` or a drop verb is refused, wherever in the line the name
+sits — parsing `-d` positionally would let `pg_restore <archive> price_manager_db`
+and similar orderings through, and a guard that is narrow about the target is
+worse than one that occasionally over-fires. The cost is that talking *about*
+these commands trips it too: `grep -r "dropdb price_manager_db"` is denied. Quote
+the string differently, or run it yourself.
+"""
+import json
+import re
+import sys
+
+LIVE_DB = "price_manager_db"
+
+# \b keeps `test_price_manager_db` out of this: the char before `price` is `_`,
+# which is a word character, so no boundary matches there.
+NAMES_LIVE_DB = re.compile(rf"\b{LIVE_DB}\b")
+
+RESTORES = re.compile(r"\bpg_restore\b")
+DROPS = re.compile(r"\bdropdb\b|\bDROP\s+DATABASE\b", re.IGNORECASE)
+
+RESTORE_REASON = (
+    f"Blocked: this restores a production dump into `{LIVE_DB}`, the live dev database. "
+    "Restore into a separate database instead — `createdb -U priceuser pricemanager_snapshot`, "
+    "then `pg_restore ... -d pricemanager_snapshot`. See the `prod-snapshot` skill. "
+    "If you genuinely mean to overwrite the dev database, run it yourself."
+)
+
+DROP_REASON = (
+    f"Blocked: this drops `{LIVE_DB}`, the live dev database. Snapshot work belongs in "
+    "`pricemanager_snapshot`, which is safe to drop. See the `prod-snapshot` skill. "
+    "If you genuinely mean to drop the dev database, run it yourself."
+)
+
+
+def deny(reason: str) -> None:
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason,
+        }
+    }))
+
+
+def main() -> None:
+    try:
+        command = json.load(sys.stdin).get("tool_input", {}).get("command", "")
+    except (json.JSONDecodeError, ValueError):
+        return  # Malformed payload: stay out of the way rather than block real work.
+
+    if not NAMES_LIVE_DB.search(command):
+        return
+
+    if RESTORES.search(command):
+        deny(RESTORE_REASON)
+    elif DROPS.search(command):
+        deny(DROP_REASON)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -29,6 +29,12 @@
             "command": "python \"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}/.claude/hooks/guard_compose_down.py\"",
             "statusMessage": "Checking for volume deletion...",
             "timeout": 15
+          },
+          {
+            "type": "command",
+            "command": "python \"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}/.claude/hooks/guard_prod_data.py\"",
+            "statusMessage": "Checking prod-dump target database...",
+            "timeout": 15
           }
         ]
       },

--- a/.claude/skills/prod-snapshot/SKILL.md
+++ b/.claude/skills/prod-snapshot/SKILL.md
@@ -1,0 +1,181 @@
+---
+name: prod-snapshot
+description: Restore the newest production dump from backups/ into a throwaway pricemanager_snapshot database and investigate it. Use when a question needs production scale or production data shape — query plans over 156k MainProducts, 527k PriceTags, real supplier column mappings, the real MPTT category tree — and a hand-built fixture cannot answer it. Never for tests that must pass in CI, and never for anything whose values leave this machine.
+---
+
+# Investigating against a production snapshot
+
+`backups/` holds pg_dump custom-format snapshots of the production database
+(`pricemanager_YYYYMMDD_HHMMSS.dump`). They are gitignored (`.gitignore:17`) and
+hold real business and personal data. The dev database is empty, so this is the
+only real data available locally.
+
+## When to reach for this (the eval)
+
+Restore only when the answer depends on production **scale** or **shape**, and a
+fixture cannot supply it:
+
+| Warranted | Why the snapshot, not a fixture |
+|---|---|
+| Query-plan / N+1 work (`django-orm-perf`) | 156k MainProduct, 168k SupplierProduct, 527k PriceTag; GIN `search_vector` planning only diverges at volume |
+| Excel import column mapping (`supplier_product_manager`) | 85 real `Setting`s, 830 `Link`s, 34 `DictItem`s across 42 suppliers — real header shapes no one invents |
+| MPTT category tree behaviour (`supplier_manager`) | 816 categories, 5 levels deep |
+| `update_prices()` / markup rules (`product_price_manager`) | 118 real rules against a real price spread — 76,833 products with `basic_price > 0`, 92,461 with `prime_cost > 0` |
+| Screens that only break at real volume (`ui-review`) | infinite scroll, table rendering, autocomplete |
+
+Do **not** restore for:
+
+- Anything a fixture can express. Default to a fixture.
+- **Anything CI must reproduce.** `backups/` is gitignored and
+  `.github/workflows/ci.yml` runs the suite against an empty pgvector service. A
+  test that needs this snapshot passes on your machine and fails or silently
+  skips in CI. Prod data is for **investigation**; convert every finding into a
+  committed fixture before it becomes a test.
+- Schema / migration drift — `.claude/hooks/check_migrations.py` covers that with no data.
+- Anything you would have to copy a value out of.
+
+## Rules
+
+1. **Never restore over `price_manager_db`.** Always a separate database.
+   `.claude/hooks/guard_prod_data.py` refuses the obvious ways to break this.
+2. **Read-only.** Investigate; do not write back and do not point the running app at it.
+3. **Nothing derived from it leaves this machine.** No dump-derived values in
+   commits, PR bodies, GitHub issues, or Telegram messages — `.claude/telegram-bot/`
+   posts to a group chat and the `tg-*` skills file public issues. The dump holds
+   `auth_user` (12 real accounts, emails + password hashes), `core_cartitem`, and
+   supplier pricing. Row counts and aggregates only.
+4. Drop the snapshot database when done.
+
+## Pick a mode before you migrate
+
+Migrating the snapshot is not free. `supplier_product_manager/migrations/0008_decouple_and_unique_main_product.py:28`
+deletes **every** `PriceTag`, zeroes `stock`, `prime_cost`, `wholesale_price`,
+`basic_price`, `m_price` and `wholesale_price_extra` on every `MainProduct`, then
+splits shared products (156,481 -> 164,325 rows).
+
+| | A — raw | B — ORM-ready (default) | C — fully migrated |
+|---|---|---|---|
+| Steps | restore only | + migrate `main_product_manager`, `product_price_manager` | + migrate `supplier_product_manager` |
+| Tooling | SQL; ORM limited to `.count()` / `.values()` | full ORM | full ORM |
+| Prices, `PriceTag`s, linkage | intact | **intact** | destroyed |
+| Use for | quick SQL probes | almost everything | only when you need `SupplierProduct.main_product`'s current uniqueness constraint |
+
+In mode A any query that materializes a model instance (`.first()`, `.get()`,
+`.all()`) fails with
+`ProgrammingError: column main_product_manager_mainproduct.kaspi_price does not exist`
+— the snapshot predates that field. `.count()` and `.values(...)` still work.
+Mode B is the fix and costs nothing: both apps' pending migrations are field
+alterations only.
+
+## How
+
+Every container-side absolute path needs `MSYS_NO_PATHCONV=1` on Git Bash (see
+Traps). The stack must be up: `docker compose up -d`.
+
+```bash
+# 0. Newest dump, copied into the db container, and a preflight on its origin.
+DUMP=$(ls -t backups/*.dump | head -1); echo "$DUMP"
+docker compose cp "$DUMP" db:/tmp/snap.dump
+MSYS_NO_PATHCONV=1 docker compose exec -T db pg_restore -l /tmp/snap.dump | sed -n '1,12p'
+
+# 1. A separate database. Never price_manager_db.
+docker compose exec -T db createdb -U priceuser pricemanager_snapshot
+
+# 2. Restore. ~25s for a 48MB dump, 611 TOC entries.
+MSYS_NO_PATHCONV=1 docker compose exec -T db pg_restore \
+  --no-owner --no-privileges --exit-on-error \
+  -U priceuser -d pricemanager_snapshot /tmp/snap.dump
+```
+
+Instead of `docker compose cp`, you can mount the directory once by adding this
+under `db.volumes` in `docker-compose.yml`, then using `/backups/<file>.dump`:
+
+```yaml
+      - ./backups:/backups:ro
+```
+
+**Mode A stops here.** Query with SQL:
+
+```bash
+docker compose exec -T db psql -U priceuser -d pricemanager_snapshot -c "<SQL>"
+```
+
+**Mode B** — migrate the two safe apps *by label*; a bare `migrate` fails (see Traps):
+
+```bash
+for app in main_product_manager product_price_manager; do
+  docker compose exec -T -e POSTGRES_DB=pricemanager_snapshot web \
+    python manage.py migrate "$app"
+done
+```
+
+Every `manage.py` call against the snapshot carries `-e POSTGRES_DB=pricemanager_snapshot`
+(`settings/databases.py:9` reads that env var). Omit it and you are talking to the
+live dev database.
+
+```bash
+docker compose exec -T -e POSTGRES_DB=pricemanager_snapshot web python manage.py shell -c "
+from main_product_manager.models import MainProduct
+print(MainProduct.objects.filter(basic_price__gt=0).count())"
+```
+
+**Mode C** — only if you need it, knowing it destroys prices and PriceTags:
+
+```bash
+docker compose exec -T -e POSTGRES_DB=pricemanager_snapshot web \
+  python manage.py migrate supplier_product_manager
+```
+
+Teardown:
+
+```bash
+docker compose exec -T db dropdb -U priceuser pricemanager_snapshot
+MSYS_NO_PATHCONV=1 docker compose exec -T db rm -f /tmp/snap.dump
+```
+
+## Traps
+
+- **Git Bash mangles container paths.** Without `MSYS_NO_PATHCONV=1`,
+  `/tmp/snap.dump` is rewritten to a Windows path before Docker sees it, and
+  pg_restore reports "No such file or directory" — which reads like a missing
+  file, not a path bug. Carry the flag on the teardown `rm` too: a rewritten path
+  would make `rm -f` exit 0 without deleting anything.
+- **`--exit-on-error` is not optional.** Without it pg_restore walks past failures
+  and hands you a partial database that looks fine.
+- **The image must be `pgvector/pgvector:pg17`.** The dump requires `btree_gin`,
+  `pg_trgm` and `vector`; plain `postgres:17` fails on the last one. The compose
+  `db` service is already the right image.
+- **A bare `manage.py migrate` fails** with
+  `ProgrammingError: column "sku" of relation "product_product" already exists`.
+  The snapshot's `product` app is the old API-first schema (`embedding`,
+  `embedding_text_hash`, `characteristics`, `image_urls`, `brand_id`, `status`) at
+  `product.0011_*`, while this repo's `product` was recreated from a fresh
+  `0001_initial`. Django name-matches `0001_initial`, then applies
+  `0002_product_sku` onto the old table. **Never migrate the `product` app on a
+  snapshot** — nothing in the legacy stack imports it.
+- **PG18 dump into a PG17 server is not an officially supported direction.** It
+  worked cleanly for the 2026-09-03 dump (archive 1.16, exit 0), but re-run step 0
+  after any production upgrade rather than assuming it keeps working.
+- The snapshot carries tables no current model owns — `product_importjob`,
+  `product_characteristicmutationjob`, `pricing_*`, `supplier_feed_*`,
+  `dataframe_*`. Expected; they are the retired lineage.
+
+## What is in there (2026-09-03 dump, verified 2026-09-07)
+
+| Table | Rows |
+|---|---|
+| `django_admin_log` | 961,146 |
+| `product_price_manager_pricetag` | 526,679 (0 in mode C) |
+| `supplier_product_manager_supplierproduct` | 168,004 |
+| `main_product_manager_mainproduct` | 156,481 (164,325 in mode C) |
+| `main_product_manager_mainproductlog` | 57,263 |
+| `core_taskrunhistory` | 9,141 |
+| `core_persistentnotification` | 1,168 |
+| `supplier_product_manager_link` | 830 |
+| `supplier_manager_category` | 816 (max MPTT level 5) |
+| `supplier_manager_manufacturer` | 632 |
+| `supplier_manager_discount` | 626 |
+| `product_price_manager_pricemanager` | 118 |
+| `supplier_product_manager_setting` | 85 |
+| `supplier_manager_supplier` | 42 |
+| `auth_user` | 12 |

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,15 @@ media/
 backups/
 *~
 
+# Spreadsheet extracts. The rules above cover the dumps themselves, but a prod
+# extract written out as CSV/XLSX under the repo would otherwise commit cleanly.
+# Deliberate test fixtures live in an app's fixtures/ dir and stay tracked --
+# note the `**`, since apps sit at depth 3 (price_manager/<app>/fixtures/).
+*.csv
+*.xls
+*.xlsx
+!**/fixtures/**
+
 # IDE specific files
 .idea/
 .vscode/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,3 +26,4 @@ They are still served at `/api/dataframe/`, `/api/supplier-feed/`, `/api/supplie
 - **Always commit migrations.** They are tracked normally.
 - **Each app has a knowledge keeper.** Consult `<app>`'s keeper agent before working in it (e.g. `core-keeper`, `main-product-keeper`), and record what you learn back with `/record-insight <app>`. Files live in `.claude/knowledge/`; see CLAUDE.md for the full table.
 - **Most of the front end is in `core`** — 102 of 146 templates, and the whole shopping-tab/cart feature in `core/views.py`.
+- **`backups/` holds production dumps.** Use the `prod-snapshot` skill; never restore over `price_manager_db`; never let a dump-derived value reach a commit, issue or Telegram message. They are for investigation, not for tests — `backups/` is gitignored, so CI cannot see them and a test that needs one fails there.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,3 +146,13 @@ PostgreSQL 17 (`pgvector/pgvector:pg17` image). One full-text index type is in u
 - `GinIndex` on `MainProduct.search_vector` and `supplier_manager.Category.search_vector`, built with `config='russian'`.
 
 There is **no pgvector/HNSW/embedding usage anywhere in the Python code** — semantic search went away with the API rewrite. The image still ships the extension; nothing depends on it.
+
+## Production snapshots — `backups/`
+
+`backups/` holds pg_dump custom-format snapshots of the production database (`pricemanager_YYYYMMDD_HHMMSS.dump`). The dev database is empty, so these are the only real data on the machine: 156k `MainProduct`, 168k `SupplierProduct`, 527k `PriceTag`, 816 categories, 85 supplier column-mapping `Setting`s. **The `prod-snapshot` skill is the way in** — it carries the verified restore procedure and the traps (a bare `manage.py migrate` fails on the snapshot; migrating `supplier_product_manager` deletes every `PriceTag` and zeroes every price field).
+
+Three rules govern their use, and they are not the skill's to relax:
+
+- **Investigation only, never a test dependency.** `backups/` is gitignored and `.github/workflows/ci.yml` runs the suite against an empty pgvector service. A test that needs a snapshot passes locally and fails or silently skips in CI. Turn every finding into a committed fixture before it becomes a test.
+- **Never restore over `price_manager_db`.** Always a separate database — `pricemanager_snapshot`. `.claude/hooks/guard_prod_data.py` refuses the obvious ways to break this (`pg_restore -d price_manager_db`, `dropdb`/`DROP DATABASE` on it); it is a net, not a gate.
+- **Nothing derived from a snapshot leaves the machine.** No dump-derived values in commits, PR bodies, GitHub issues, or Telegram messages — `.claude/telegram-bot/` posts to a group chat and the `tg-*` skills file public issues. The dump holds `auth_user` (real accounts, emails and password hashes), `core_cartitem` and supplier pricing. Aggregates and row counts only.


### PR DESCRIPTION
`backups/` holds production dumps and nothing told an agent they were there, when restoring one was warranted, or how to do it. The dev database is empty, so these are the only real data on a dev machine — 156k `MainProduct`, 168k `SupplierProduct`, 527k `PriceTag`, 816 categories, 85 supplier column-mapping `Setting`s.

This adds a `prod-snapshot` skill (the eval plus the procedure), a guard hook, and the repo-wide rules in `CLAUDE.md`/`AGENTS.md`.

## Verified, not described

Every command in the skill was executed against `pricemanager_20260903_142838.dump` in throwaway containers. Three findings shaped it:

- **The PG18 dump restores cleanly into the PG17 compose db** (archive 1.16, exit 0, ~25s). That direction is not officially supported, so the skill opens with a `pg_restore -l` preflight instead of assuming it still holds after the next production upgrade.
- **A bare `manage.py migrate` fails on a snapshot** with `column "sku" of relation "product_product" already exists`. The dump's `product` app is the old API-first schema (`embedding`, `characteristics`, `image_urls`) at `product.0011_*`, while this repo's `product` was recreated from a fresh `0001_initial`. Django name-matches `0001_initial` and applies `0002_product_sku` onto the old table. The skill migrates by app label and never touches `product`.
- **Migrating `supplier_product_manager` destroys exactly what you would restore for.** `migrations/0008_decouple_and_unique_main_product.py:28` deletes every `PriceTag` and zeroes all six `MainProduct` price fields, then splits shared products. Hence three documented modes, with the ORM-ready one that keeps prices intact as the default.

## The eval

The load-bearing rule: `backups/` is gitignored and CI runs the suite against an empty pgvector service, so a snapshot is for **investigation only** — a test that depends on one passes locally and fails or silently skips here. Every finding becomes a committed fixture before it becomes a test. The skill also forbids dump-derived values reaching commits, issues or Telegram messages, since `.claude/telegram-bot/` posts to a group chat and the `tg-*` skills file public issues.

## The guard

`guard_prod_data.py` enforces the one rule worth enforcing rather than trusting: restores and drops aimed at `price_manager_db`. `guard_compose_down.py` only ever caught `docker compose down -v`.

It matches on **mention** rather than parsing the target flag — a guard that is narrow about the target lets positional-dbname orderings through. The cost is that grepping for those strings trips it too; the docstring says so, and it fired on the commit message for this very PR. 18/18 cases pass, including both snapshot-migrate modes from the skill (so it does not obstruct the workflow it protects) and the `test_price_manager_db` substring trap.

## Also

Stray `*.csv`/`*.xls`/`*.xlsx` are now ignored so a prod extract cannot commit cleanly, with an exception for `fixtures/` — spelled `**` and tested at depth 3, since apps sit at `price_manager/<app>/`. That is the same trap that made the old `*/migrations/*.py` rule a no-op.

## Note for review

This is `.claude/` config plus docs; it changes no application code, so the test suite is unaffected. It falls outside the auto-merge class (a `.py` file outside tests), so it needs a human merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
