### PR TITLE
Record main_product_manager traps found triaging #155, fix line rot

### DIFF
--- a/.claude/knowledge/main_product_manager.md
+++ b/.claude/knowledge/main_product_manager.md
@@ -5,18 +5,18 @@
 
 ## The trap that costs the most: `.save()` can be an HTTP request
 
-`MainProduct._build_searchvector()` (`main_product_manager/models.py:134`) calls
+`MainProduct._build_searchvector()` (`main_product_manager/models.py:148`) calls
 the external PIM API from inside a model method:
 
-- `_resolve_pim_id(self)` when `pim_id` is unset (`utils.py:184`)
-- then `get_pim_data(self.pim_id)` (`utils.py:122`)
+- `_resolve_pim_id(self)` when `pim_id` is unset (`utils.py:195`)
+- then `get_pim_data(self.pim_id)` (`utils.py:133`)
 
 Anything that rebuilds search vectors row by row makes **one network round-trip
 per row**. When reviewing a loop over `MainProduct`, trace whether it reaches
-`rebuild_search_vector()` (`models.py:157`); if it does, that is the finding
+`rebuild_search_vector()` (`models.py:171`); if it does, that is the finding
 regardless of how the queryset was built.
 
-`MainProduct.save()` (`models.py:163`) is a bare `super().save()` — it does
+`MainProduct.save()` (`models.py:177`) is a bare `super().save()` — it does
 *not* rebuild the vector. The rebuild is always explicit. Don't "fix" the
 override by adding a rebuild call into it; that would turn every save in the
 codebase into a PIM call.
@@ -28,10 +28,9 @@ that calls PIM inside the runner holds one open across the network.
 
 There used to be a comment at both scan sites claiming that hoisting the
 `bulk_update` out of the API loop kept the transaction from spanning the HTTP
-calls. **It does not.** `execute_locked_task` opens the transaction before
-calling the runner, so it stays open for the entire loop regardless of where
-the write lands. The real fix is `atomic=False` at the call site — see
-[[core]]:
+calls. **It does not** — `execute_locked_task` opens the transaction before
+calling the runner, so it stays open for the whole loop regardless of where
+the write lands. The fix is `atomic=False` at the call site — see [[core]]:
 
 - `tasks.py` `create_pim_links_task` → `utils.py` `create_pim_links`
 - `tasks.py` `reindex_pim_ids_batch_task` → `utils.py` `reindex_pim_ids_batch`
@@ -44,43 +43,101 @@ committed progress the next run continues from — which is what you want, since
 `_search_pim_id`'s `pim_no_match:` cache writes escape a rollback anyway.
 
 Do **not** wrap `push_missing_pim_products` in a transaction "to compensate":
-it is `_push_pim_products` underneath, which interleaves HTTP, `bulk_update`
-and `sleep` per chunk, so a wrap would reintroduce the same defect and would
-also break its documented promise that one failing chunk doesn't lose the
-others.
+it's `_push_pim_products` underneath, interleaving HTTP, `bulk_update` and
+`sleep` per chunk — wrapping it would reintroduce the same defect and break
+its promise that one failing chunk doesn't lose the others. New PIM-touching
+tasks should pass `atomic=False` rather than reshuffling writes.
 
-New PIM-touching tasks should pass `atomic=False` rather than reshuffling
-writes.
+## The PIM cache's render-path cost
+
+`get_pim_data` (`utils.py:133`) on a cache miss does **both** things: it
+queues async population via `_queue_pim_population` (`utils.py:141`) and
+then falls through, on the very next line, to a synchronous
+`_fetch_pim_product(...)` (`utils.py:142`) — the queue call is not an early
+return. A cold cache means a blocking PIM HTTP round-trip inline in the
+request. `get_file_url` (`utils.py:340`) has the same blocking shape on a
+miss (`site.get(FileRecord(...))`, `utils.py:349`), minus the queueing.
+
+`prefetch_pim_data` (`utils.py:322`) loops products one at a time — no
+`cache.get_many`, no batching — and `MainProductTableView.get_context_data`
+(`views.py:159`) then calls `get_file_url` again for every entry it gets
+back (`views.py:169-171`): up to **2N** PIM calls per cold table page. The
+main page paginates 5 categories per page (`Paginator(cat_filter.qs, 5)`,
+`views.py:86`), each firing its own `hx-trigger="load"` table fetch
+(`tables_bycat.html:53,82`) — so a cold main page runs several of these
+2N-call loads concurrently.
+
+`prefetch_pim_data` returns `{product.pk: data}`; `tables.py` reads it by
+`record.pk` (`tables.py:147`) — a future regroup-by-`pim_id` has to move
+that keying.
 
 ## Why the search vector uses `Value()`, not field references
 
 `_build_searchvector` builds `SearchVector(Value(supplier_name), ...)` rather
-than `SearchVector('supplier__name')`. The comment at `models.py:140` says why:
-`bulk_update()` / `.update()` do not allow joined fields in a SET expression.
-If you switch these to field references the update will fail at the DB layer,
-not at import time.
+than `SearchVector('supplier__name')`. The comment at `models.py:154-155` says
+why: `bulk_update()` / `.update()` do not allow joined fields in a SET
+expression. If you switch these to field references the update will fail at
+the DB layer, not at import time.
 
 Weights: PIM categories/tags/name = A, `sku`/`article` = B, PIM descriptions +
 supplier + manufacturer = C, own `description` = D. `config='russian'`
-throughout, backed by a `GinIndex` declared in `Meta.indexes` (`models.py:34`).
+throughout, backed by a `GinIndex` declared in `Meta.indexes` (`models.py:44`).
+
+## `MainProductFilter` — `.order_by()` bleeding into `GROUP BY`
+
+`search_method` (`filters.py:181-187`) ends on `.order_by("-rank")` as its
+last call — confirmed at the call site. Django folds a column from an
+explicit `order_by()` into `GROUP BY` once something downstream calls
+`.values(...).annotate(...)` on the same queryset, so (high-confidence, not
+run against a live query plan)
+`MainProductFilter(request.GET).qs.values('pim_id').annotate(count=Count('pk'))`
+would yield one row per `(pim_id, rank)` instead of one per `pim_id` — **only
+when a search term is present**, so it looks fine against an empty search.
+Fix: a bare `.order_by()` before `.values()`. Distinct from the old
+`Meta.ordering`-into-`GROUP BY` bug fixed in Django 3.1 — `Meta.ordering =
+['id']` here (`models.py:42`) doesn't trigger that one.
+
+Same family: `categories_method` (`filters.py:194-201`) ends on `.distinct()`
+because the categories M2M join duplicates rows — why `CategoryFilter` uses
+`Count(F('mainproducts'), distinct=True)` (`supplier_manager/filters.py:20`)
+instead of a plain `Count`. Any new per-group count needs the same
+`distinct=True` while that join is on the queryset. See [[supplier_manager]].
+
+## `_search_pim_id` docstring does not match its code
+
+The docstring (`utils.py:159-170`) promises a search of `ContributorProduct`
+"by priceManagerId, then by sku/number", reading `masterRecordId` to reach
+the merged `Product`. The code (`utils.py:175-182`) does neither: a
+single-element `searches` list — `Where(attribute='number', type='like',
+value=product.sku)` — queried straight against `EntityList(name='Product',
+...)`. No `ContributorProduct` step, no `masterRecordId`, no
+`priceManagerId` fallback — verified by reading both, not inferred.
+
+Practical consequence: `sku` is nullable (`models.py:49-52`), so a
+`MainProduct` with no `sku` can **never** resolve a `pim_id` through this
+path — a firmer explanation for stuck-NULL `pim_id`s than the backlog and
+the 4h no-match cache (`_PIM_NO_MATCH_TTL`, `utils.py:154`) alone.
 
 ## The 11 Celery tasks
 
-All in `tasks.py`, all routed through `execute_locked_task` — this app is the
-best-behaved one in the repo on that convention. Two of them take
-`time_limit=None, soft_time_limit=None` deliberately (`reindex_pim_ids`,
-`reindex_pim_ids_batch`, `tasks.py:163` and `:179`) because a full catalog
-re-scan outruns any sane limit.
+All 11 `@shared_task`-decorated functions in `tasks.py` are routed through
+`execute_locked_task` — this app is the best-behaved one in the repo on that
+convention. Two take `time_limit=None, soft_time_limit=None` deliberately
+(`reindex_pim_ids`, `reindex_pim_ids_batch`, `tasks.py:166` and `:187`)
+because a full catalog re-scan outruns any sane limit.
 
 The fan-out pattern is worth knowing: `reindex_pim_ids_task` uses
-`iter_pim_id_pk_batches()` (`utils.py:533`) to chunk pks, then queues one
+`iter_pim_id_pk_batches()` (`utils.py:558`) to chunk pks, then queues one
 `reindex_pim_ids_batch_task` per chunk so batches run in parallel across
 workers. `task_name` for those is uniquified per chunk
-(`f"...reindex_pim_ids_batch:{pks[0]}-{pks[-1]}"`, `tasks.py:182`) — otherwise
+(`f"...reindex_pim_ids_batch:{pks[0]}-{pks[-1]}"`, `tasks.py:190`) — otherwise
 they would all contend on one Redis lock and all but the first would skip.
 
-`sync_main_products_task` (`tasks.py:143`) is the one that does *not* go through
-`execute_locked_task`.
+`sync_main_products_task` (`tasks.py:143`) is a 12th function in the file but
+not itself a Celery task: no `@shared_task`, just a plain function that
+chains the 11 into one `apply_async()` workflow (`chain(...)`, `tasks.py:144`).
+That's the mechanism, not an exception — each task in the chain still goes
+through `execute_locked_task` on its own.
 
 ## `create_pim_links` vs `reindex_pim_ids`
 
@@ -92,19 +149,36 @@ Easy to confuse:
 
 ## Price fields
 
-Six of them on `MainProduct` (`models.py:73`–`:102`): `prime_cost`,
+Seven of them on `MainProduct` (`models.py:82-116`): `prime_cost`,
 `wholesale_price`, `basic_price`, `m_price`, `wholesale_price_extra`,
-`discount_price`. The ordered tuple is `MP_PRICES`; `price_list()`
-(`models.py:127`) returns only the non-null ones with their Russian
-`verbose_name`. `product_price_manager` writes these — see
+`kaspi_price` (added by `migrations/0009_mainproduct_kaspi_price.py`),
+`discount_price`. The ordered tuple `MP_PRICES` (`models.py:14-22`);
+`price_list()` (`models.py:141`) returns only the non-null ones with their
+Russian `verbose_name`. `product_price_manager` writes these — see
 [[product_price_manager]].
 
-`MainProductLog` (`models.py:167`) is the price/stock history row.
+`MainProductLog` (`models.py:181`) is the price/stock history row.
+
+## `pim_id` schema history explains "many `MainProduct`s, one `pim_id`"
+
+`migrations/0004_mainproduct_pim_id.py:16` originally added `pim_id` with
+`unique=True`; `migrations/0005_mainproduct_categories_m2m.py:32-36` (the
+`AlterField` near the end) dropped it. Today it's a plain nullable
+`CharField` (`models.py:46-48`) with **no `db_index`** — `Meta.indexes`
+declares only the `GinIndex` on `search_vector` (`models.py:44`). Any
+grouping or lookup by `pim_id` is therefore an unindexed scan today.
+
+The multiplicity — several `MainProduct`s (from different suppliers)
+legitimately sharing one `pim_id`, since it points at a verified/merged PIM
+`Product` rather than a per-supplier `ContributorProduct` — is asserted in
+`sync_pim_relations`'s docstring (`utils.py:295-301`) and relied on by its
+plural `filter(pim_id=...).update(...)` (`utils.py:308`) and by
+`_note_pim_404`'s bulk `update(pim_id=None)` (`utils.py:126`).
 
 ## `update_stocks` — the two NULLs mean different things
 
-`utils.py:385`. Two nullable stock columns feed this, and they do not carry
-the same meaning:
+`utils.py:385`, docstring `utils.py:386-396`. Two nullable stock columns feed
+this, and they do not carry the same meaning:
 
 - `SupplierProduct.stock` NULL = the supplier told us nothing. Unknown is not
   sellable, so `new_stock` coalesces it to `0`.
@@ -115,9 +189,10 @@ The candidate filter used to coalesce *both* sides to `0`
 that had never been synced and whose supplier reported no stock was silently
 skipped forever: no write, no `MainProductLog`, not counted in the return
 value. Fixed by testing the current value's nullness explicitly:
-`filter(Q(stock__isnull=True) | ~Q(stock=F('new_stock')))`. The plain
-`~Q(stock=F('new_stock'))` alone is not enough — SQL's `NOT (NULL = 0)` is
-NULL, not true, so those rows drop out of the filter either way.
+`filter(Q(stock__isnull=True) | ~Q(stock=F('new_stock')))` (`utils.py:407`).
+The plain `~Q(stock=F('new_stock'))` alone is not enough — SQL's
+`NOT (NULL = 0)` is NULL, not true, so those rows drop out of the filter
+either way.
 
 That `isnull` branch is self-limiting: the first run leaves `stock` non-NULL,
 so the row stops matching. `test_second_run_is_a_no_op` guards it.


### PR DESCRIPTION
Docs-only. Updates `.claude/knowledge/main_product_manager.md` with what came out of briefing #155, and repairs refs that had rotted since the file was last touched.

Recorded by `main-product-keeper` via `/record-insight`; every claim was verified against current code before and after.

## Added

- **`MainProductFilter.search_method` ends on `.order_by("-rank")`** (`filters.py:187`), which folds `rank` into `GROUP BY` on a later `.values().annotate()`. A per-`pim_id` count therefore returns one row per `(pim_id, rank)` — and only when a search term is present, so it looks correct on an empty search. Cross-linked to `[[supplier_manager]]` for the matching `distinct=True` guard that exists for the same reason on the categories join.
- **The PIM cache's render-path cost.** `get_pim_data` queues async population and *then falls through* to a synchronous fetch on a cache miss — the queue call is not an early return. `get_file_url` blocks the same way, and `prefetch_pim_data` loops unbatched, so one cold table page costs up to 2N PIM calls across a five-table fan-out. The file previously documented the transaction hazard here but not this.
- **`_search_pim_id`'s docstring does not match its code** — it promises a `ContributorProduct` → `masterRecordId` two-step that the single `Where(...)` query never performs. Consequence worth having written down: a `MainProduct` with no `sku` can never resolve a `pim_id` through that path.
- **`pim_id` schema history** — added `unique=True` in `0004`, un-uniqued in `0005`, and carrying no `db_index` today.

## Corrected

- `MP_PRICES` is seven fields, not six (`kaspi_price`).
- About a dozen line refs that had drifted 11–14 lines across the search-vector, PIM and Celery-task sections.
- A passage that read as self-contradictory about `sync_main_products_task` — it is an undecorated orchestrator building a `chain(...)`, not one of the 11 `@shared_task`s, which is why it is the exception rather than a counterexample.

## Not included

Issue #155's triage also drew on a restored production snapshot. None of those figures are here: knowledge files are committed, and `prod-snapshot`'s rule 3 keeps dump-derived values out of the repo. Everything above is a code fact.

## Verification

No code changed, so there is nothing to run — the claims were checked by reading the cited lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
