### PR TITLE
fix(supplier_product_manager): NULL, а не 0, для строк, пропавших из файла

### DIFF
--- a/.claude/knowledge/supplier_product_manager.md
+++ b/.claude/knowledge/supplier_product_manager.md
@@ -69,15 +69,31 @@ one — changes the signature and forces a fresh parse. Serving the cached rows
 after an upload would be the bug; the cache exists to skip repeated reads of an
 *unchanged* file, not to pin a snapshot.
 
-**Rows missing from the new file are zeroed, not nulled.** `load_setting`
-(`:484`–`:491`) runs `missing_sps.update(stock=0)` and, per mapped price
-column, `missing_sps.update(**{column: 0})`. It was `None` until commit
-`8774795`. The 0 is load-bearing downstream — [[product_price_manager]]'s
-`test_pricemanager_with_duplicate_supplier_products_prefers_positive_value`
-encodes the rule that a zero price loses to a positive one, which only has
-meaning because absent rows arrive as 0. Note the carve-out the test exercises:
-only columns the setting still **maps** get zeroed, so deleting a `Link` freezes
-that field at its last imported value rather than clearing it.
+**Rows missing from the new file are nulled, not zeroed — absence lives on the
+raw layer and is resolved on the derived one.** `load_setting` (`:490`–`:503`)
+runs `missing_sps.update(stock=None)` and, per mapped price column,
+`missing_sps.update(**{column: None})`. A vanished row means the supplier gave
+no figure, so `SupplierProduct` records that absence; it never invents a synced
+`0`. Every consumer resolves it for itself: [[main_product_manager]]'s
+`update_stocks` coalesces a NULL supplier stock to `0` (unknown stock is not
+sellable) and [[product_price_manager]]'s `PriceTag.get_sprice`
+(`models.py:412`) reads a NULL price as `Decimal('0')`. Note the carve-out:
+only columns the setting still **maps** get cleared, so deleting a `Link`
+freezes that field at its last imported value.
+
+The history here has flipped twice and both flips left a trap, so do not
+re-derive it from either artifact:
+
+- `8774795` ("Handle NULL/0 sync…") switched the raw layer from `None` to `0`
+  **and** in the same commit made the derived layer NULL-safe
+  (`Max(Coalesce(source, 0))` in `PriceManager`, list normalisation in
+  `get_sprice`). The second half made the first half redundant.
+- `11da6e4` then kept the `0` and justified it with
+  `test_pricemanager_with_duplicate_supplier_products_prefers_positive_value`.
+  **That test does not exist** — it is in no file in the repo, and was cited
+  here and in the test docstring for weeks. #137 restored the NULL, matching
+  the two-layer rule the `update_stocks` docstring
+  (`main_product_manager/utils.py:386`) already states in code.
 
 **`auto_detect_link_keys` (`:92`) matches in two passes**, and only the second
 is order-sensitive: exact normalized-name match first across all columns, then a

--- a/.claude/knowledge/supplier_product_manager.md
+++ b/.claude/knowledge/supplier_product_manager.md
@@ -89,11 +89,20 @@ re-derive it from either artifact:
   (`Max(Coalesce(source, 0))` in `PriceManager`, list normalisation in
   `get_sprice`). The second half made the first half redundant.
 - `11da6e4` then kept the `0` and justified it with
+  [[product_price_manager]]'s
   `test_pricemanager_with_duplicate_supplier_products_prefers_positive_value`.
-  **That test does not exist** — it is in no file in the repo, and was cited
-  here and in the test docstring for weeks. #137 restored the NULL, matching
-  the two-layer rule the `update_stocks` docstring
-  (`main_product_manager/utils.py:386`) already states in code.
+  **That test had been deleted 50 minutes earlier**, by `c819a63` — an
+  ancestor of `11da6e4` itself. And it was deleted for a reason that retires
+  the argument outright: migration `0009` made `SupplierProduct.main_product`
+  a `unique=True` FK, so one `MainProduct` can hold at most one
+  `SupplierProduct` and the duplicate-row choice that test covered can no
+  longer arise. #137 restored the NULL, matching the two-layer rule the
+  `update_stocks` docstring (`main_product_manager/utils.py:386`) already
+  states in code.
+
+Verify a cited test still exists before you trust it — `git log --all -S`
+distinguishes "never existed" from "deleted last hour", and here the two led
+to different conclusions.
 
 **`auto_detect_link_keys` (`:92`) matches in two passes**, and only the second
 is order-sensitive: exact normalized-name match first across all columns, then a

--- a/price_manager/supplier_product_manager/functions.py
+++ b/price_manager/supplier_product_manager/functions.py
@@ -487,14 +487,20 @@ def load_setting(pk):
 
     missing_sps = SupplierProduct.objects.filter(supplier=setting.supplier).exclude(pk__in=map(lambda sp: sp.pk, sps))
 
+    # A row that vanished from the new file has no figure at all, so the raw
+    # layer stores NULL - "the supplier did not tell us" - and never a synced 0.
+    # Consumers resolve that absence themselves: update_stocks() coalesces it to
+    # 0 because unknown stock is not sellable, and PriceTag.get_sprice() reads a
+    # NULL price as 0. Only columns the setting still maps are cleared, so
+    # deleting a Link freezes its field at the last imported value.
     if 'stock' in df.columns:
         setting.supplier.stock_updated_at = timezone.now()
-        missing_sps.update(stock=0)
+        missing_sps.update(stock=None)
     if not set(SP_PRICES).intersection(set(df.columns)) == set():
         setting.supplier.price_updated_at = timezone.now()
         for column in df.columns:
            if column in SP_PRICES:
-              missing_sps.update(**{column:0})
+              missing_sps.update(**{column:None})
     setting.supplier.save()
     push_supplier_products_to_pim(sps)
     return sps

--- a/price_manager/supplier_product_manager/tests.py
+++ b/price_manager/supplier_product_manager/tests.py
@@ -392,12 +392,17 @@ class BasicLoadTests(TestCase):
         self.supplier.refresh_from_db()
         self.assertIsNotNone(self.supplier.stock_updated_at)
         self.assertIsNotNone(self.supplier.price_updated_at)
-    def test_zeroes_mapped_prices_and_stock_for_missing_rows(self):
-        """A row absent from the new file keeps the fields the setting no longer
-        maps - supplier_price here, whose Link is deleted below - and is zeroed,
-        not nulled, for the price and stock columns still mapped. Downstream
-        pricing depends on that 0; see product_price_manager's
-        test_pricemanager_with_duplicate_supplier_products_prefers_positive_value.
+    def test_nulls_mapped_prices_and_stock_for_missing_rows(self):
+        """A row absent from the new file is nulled, not zeroed, for the price
+        and stock columns the setting still maps: the supplier gave no figure,
+        and the raw layer records absence rather than inventing a synced 0.
+        Consumers resolve that absence themselves - update_stocks() coalesces a
+        NULL supplier stock to 0 because unknown stock is not sellable, and
+        PriceTag.get_sprice() reads a NULL price as 0.
+
+        The carve-out: fields the setting no longer maps are frozen at their
+        last imported value, not cleared. supplier_price stays 1 here because
+        its Link is deleted below.
         """
         setting = Setting.objects.create(
             name="Загрузка артикул",
@@ -433,7 +438,7 @@ class BasicLoadTests(TestCase):
             )
         
         correct_values = [
-                {"article": "А-1", "name": "Товар 1", "supplier_price": 1, "rrp":0, "stock":0, "manufacturer": Manufacturer.objects.get_or_create(name="Производитель 1")[0]},
+                {"article": "А-1", "name": "Товар 1", "supplier_price": 1, "rrp":None, "stock":None, "manufacturer": Manufacturer.objects.get_or_create(name="Производитель 1")[0]},
             ]
         
 


### PR DESCRIPTION
Закрывает #137 — последний невыполненный критерий приёмки: «Выбранная семантика «отсутствует → NULL/0» согласована с #138».

## Что осталось от #137

Пять из шести причин закрыты коммитом `11da6e4` на `main` (фикстура `Discount`, алиас `«цена»`, кеш-тест, оба теста автоопределения). Задача осталась открытой из-за шестой: `11da6e4` выбрал `0` на сыром слое, а последний комментарий триажа (09:39:49Z, на две минуты позже отчёта и на 45 минут раньше самого коммита) зафиксировал обратное правило.

## Почему выбран NULL

**Обоснование `0` ссылалось на тест, удалённый за 50 минут до цитирования.** `11da6e4` защищал `0` как load-bearing для `product_price_manager.test_pricemanager_with_duplicate_supplier_products_prefers_positive_value`:

```
8774795  16 апр         тест добавлен
c819a63  4 сен 14:34    тест удалён
11da6e4  4 сен 15:24    тест процитирован как обоснование
```

`c819a63` — предок самого `11da6e4`. Причина удаления снимает аргумент целиком: миграция `0009` сделала `SupplierProduct.main_product` FK с `unique=True`, поэтому один `MainProduct` держит максимум один `SupplierProduct`, и выбор между дубликатами, который покрывал тот тест, **возникнуть не может**. Сырой `0` защищали сценарием, который уже невозможен на уровне ограничения БД.

**Правило уже записано в коде — на `main`, в `main_product_manager/utils.py:386`:** отсутствие хранится как `NULL` на сыром слое и разрешается в `0` на производном.

**Производный слой стал NULL-безопасным в том же коммите `8774795`, который ввёл сырой `0`** — вторая половина коммита сделала первую избыточной:

| Потребитель | Обработка NULL |
|---|---|
| `PriceManager.apply` | `Max(Coalesce(source, 0))` — NULL-дубликат проигрывает положительной цене |
| `PriceTag.get_sprice` (`models.py:412`) | `price if price is not None else Decimal('0')` |
| `update_stocks` (`utils.py:406`) | `Coalesce(Subquery(...), Value(0))` — неизвестный остаток непродаваем |
| `resolve_conflicts` (`functions.py:151`) | уже пропускает поля со значением `None` |

## Изменения

- `load_setting` пишет `None` вместо `0` для пропавших строк — по остатку и по каждой отображённой ценовой колонке.
- Тест переименован в `test_nulls_mapped_prices_and_stock_for_missing_rows`; старое имя описывало противоположный контракт. Carve-out сохранён: колонки, которые настройка больше не отображает, замораживаются на последнем импортированном значении, а не обнуляются.
- Файл знаний переписан: оба переворота зафиксированы вместе с историей цитаты — чтобы правило не выводили заново из ссылки на удалённый тест.

## На что стоит посмотреть при ревью

Потребители, которые не нормализуют значение, от правки **выигрывают**, а не ломаются: колонка `MainProduct` объявлена с `default='—'` (`tables.py:39`), поэтому пропавшая строка теперь читается как «нет данных», а не как цена 0.

Одно косметическое место осталось нетронутым намеренно — `main_product_manager/resources.py:196` собирает строку экспорта как `f"{sp.supplier.name}: {sp.supplier_price}({sp.rrp})"` и для такой строки выдаст `None(None)`. Это `main_product_manager`, который #137 запрещает трогать; если нужно — отдельной задачей.

Миграции не нужны: все четыре поля (`stock`, `supplier_price`, `rrp`, `discount_price`) уже `null=True`.

## Проверка

```
docker compose exec -T celery_worker python manage.py test supplier_product_manager --keepdb
```

- `supplier_product_manager` — `Ran 24 tests ... OK`
- Полный прогон — `Ran 285 tests ... OK`
- `makemigrations --check --dry-run` — `No changes detected`

Локальные прогоны сделаны с `--keepdb`; чистую БД проверяет CI на этом PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
