### PR TITLE
Docstring get_fitting_mps описывает фактический выбор строки поставщика (#142)

### DIFF
--- a/.claude/knowledge/product_price_manager.md
+++ b/.claude/knowledge/product_price_manager.md
@@ -26,14 +26,16 @@ The arithmetic is `source → dest`, where:
 `PriceTag` records what the rule said *then*, not what it says now. Unique on
 `(mp, p_manager, dest)` — that triple is the identity used by every upsert.
 
-## `get_fitting_mps()` (`:133`) — docstring is stale, don't trust it
+## `get_fitting_mps()` (`:135`) — one supplier row per product, by construction
 
 Returns the matching `MainProduct` queryset **annotated with `changed_price`**,
 the post-markup value, computed via a `Subquery` over `_changed_price`
-(`:244`). The docstring (`:138`) still claims supplier-price sourcing "takes
-the minimum" across a product's supplier rows — verbatim: `(при подсечете от
-цен поставщика берет минимальное значение)` (typo "подсечете" is in the
-source). It doesn't, and hasn't since `supplier_product_manager` made
+(`:248`).
+
+Until #142 the docstring promised that supplier-price sourcing "takes the
+minimum" across a product's supplier rows — verbatim: `(при подсечете от цен
+поставщика берет минимальное значение)`, typo "подсечете" included. It never
+did, and could not since `supplier_product_manager` made
 `SupplierProduct.main_product` a `unique=True` FK (migration
 `0009_alter_supplierproduct_main_product_unique`,
 `supplier_product_manager/models.py:24`–`:30`). The uniqueness is on
@@ -41,16 +43,20 @@ source). It doesn't, and hasn't since `supplier_product_manager` made
 be sourced from at most one `SupplierProduct`, from at most one supplier,
 globally. There is nothing left to minimise over, and only one `PriceManager`
 (via its `supplier` scope) can ever reach a given product through SP_PRICES.
+The docstring (`:137`–`:142`) now records the real behaviour; any other doc or
+comment promising a minimum predates #142.
 
-The SP_PRICES branch (`:186`–`:199`) actually takes the **latest row by
-`updated_at`**: `products.filter(main_product=OuterRef('pk')).order_by
-('-updated_at').values(source)[:1]`, wrapped in `Coalesce(..., Decimal('0'))`
-— a tie-break that can no longer tie now that the FK is unique.
-`PriceTag.get_sprice()` (`:408`–`:416`) does the identical latest-row lookup on
-the instance side (`self.mp.supplierproducts.order_by('-updated_at').first()`)
-before multiplying by `self.mp.supplier.currency.value`. `PriceTag
-.get_aggfunc()` (`:402`, returns bare `max`) is a same-era leftover — nothing
-in `models.py` calls it; only a test (`tests.py:193`) exercises it directly.
+The SP_PRICES branch (`:191`–`:202`) takes the **latest row by `updated_at`**:
+`products.filter(main_product=OuterRef('pk')).order_by('-updated_at')
+.values(source)[:1]`, wrapped in `Coalesce(..., Decimal('0'))` — a tie-break
+that can no longer tie now that the FK is unique. `PriceTag.get_sprice()`
+(`:407`–`:418`) does the identical latest-row lookup on the instance side
+(`self.mp.supplierproducts.order_by('-updated_at').first()`) before multiplying
+by `self.mp.supplier.currency.value`.
+
+`PriceTag.get_aggfunc()` — a same-era leftover returning a bare `max` that
+nothing but its own test ever called — was deleted in #142, together with
+`test_pricetag_get_aggfunc_callable`.
 
 **Don't write code or tests that assume several `SupplierProduct` rows feed
 one `MainProduct`'s price** — that shape is no longer reachable at the DB
@@ -59,7 +65,7 @@ level. See [[supplier_product_manager]] for the constraint itself and why it's
 reason, documented in a comment right above the field).
 
 Everything downstream — `save`, `apply`, `delete`, `deprecate` — calls this.
-`get_price_querry` (`:140`) has a commented-out earlier version directly above
+`get_price_querry` (`:144`) has a commented-out earlier version directly above
 the live one; don't mistake the dead block for the implementation.
 
 ## Lifecycle methods have side effects — all four of them
@@ -78,13 +84,13 @@ the live one; don't mistake the dead block for the implementation.
 - **`deprecate():317`** — deletes the rule's pricetags, sets `deprecated=True`,
   nulls dest prices. The soft-delete counterpart to `delete()`.
 
-`update_pricetags():249` is the incremental version of the `save()` upsert — it
+`update_pricetags():253` is the incremental version of the `save()` upsert — it
 only creates tags for products that don't have one yet.
 
-## `update_prices()` (`models.py:456`)
+## `update_prices()` (`models.py:455`)
 
 The bulk entry point, wrapped by `product_price_manager.update_prices`
-(`tasks.py:9`). Its inner `get_updated_mps(pricetags)` (`:457`) **merges by
+(`tasks.py:9`). Its inner `get_updated_mps(pricetags)` (`:456`) **merges by
 product pk**: when several pricetags touch the same `MainProduct` with different
 `dest` fields, it accumulates each `dest` onto one instance so a single write
 carries all of them. Keep that merge if you refactor — dropping it means later

--- a/price_manager/product_price_manager/models.py
+++ b/price_manager/product_price_manager/models.py
@@ -137,7 +137,9 @@ class PriceManager(models.Model):
     Возвращает продукты подходящие под данный менеджер наценок \\
     Возвращает querryset с аннотацией:\\
     - changed_price - цена после применения наценки\\
-      (при подсечете от цен поставщика берет минимальное значение)
+      (при подсчете от цен поставщика берет последнюю строку
+      SupplierProduct по updated_at; строка всегда ровно одна —
+      SupplierProduct.main_product объявлен unique=True)
     """
     def get_price_querry(price_from, price_to, price_prefix):
       # query = Q(**{f'{price_prefix}__isnull': False})
@@ -402,13 +404,6 @@ class PriceTag(models.Model):
     else:
       return f'{PRICE_TYPES[self.dest]}: {self.fixed_price}'
   
-  @staticmethod
-  def get_aggfunc():
-    '''
-    Функция для аггрегации цен поставщика
-    '''
-    return max
-
   def get_sprice(self):
     if self.source in ('fixed_price', None):
       return self.fixed_price

--- a/price_manager/product_price_manager/tests.py
+++ b/price_manager/product_price_manager/tests.py
@@ -190,10 +190,6 @@ class PriceTagAndPriceManagerRuntimeTests(TestCase):
 
         self.assertEqual(pt.get_sprice(), Decimal('30'))
 
-    def test_pricetag_get_aggfunc_callable(self):
-        agg = PriceTag.get_aggfunc()
-        self.assertEqual(agg([Decimal('1'), Decimal('3')]), Decimal('3'))
-
     def test_pricetag_get_sprice_treats_null_source_as_fixed_price(self):
         mp = self.create_mp('M-FIX-NULL', 'Fixed source is null')
         pt = PriceTag.objects.create(


### PR DESCRIPTION
Closes #142

## Что сделано

**1. Docstring `get_fitting_mps()` (`product_price_manager/models.py:137`)**

Обещание «берет минимальное значение» заменено на фактическое поведение — последняя строка по `updated_at` — с указанием, почему строка всё равно ровно одна. Опечатка «подсечете» убрана.

```diff
-      (при подсечете от цен поставщика берет минимальное значение)
+      (при подсчете от цен поставщика берет последнюю строку
+      SupplierProduct по updated_at; строка всегда ровно одна —
+      SupplierProduct.main_product объявлен unique=True)
```

**2. `PriceTag.get_aggfunc()` — удалён вместе с тестом**

Из двух вариантов выбрано удаление: варианту «оставить с объяснением» нечего было бы объяснить. Единственный потребитель — собственный тест `test_pricetag_get_aggfunc_callable`, который проверял, что встроенный `max` выбирает большее из двух `Decimal`. Проверено `grep` по всему репозиторию без фильтра по типу файла: других ссылок нет (остальные попадания — несвязанный `AggFuncType` из pandas в `venv/`).

**3. `.claude/knowledge/product_price_manager.md`**

Секция про `get_fitting_mps` описывала docstring как устаревший, а `get_aggfunc` — как живой остаток; оба утверждения стали неверны. Секция переписана вокруг устойчивого факта (одна строка `SupplierProduct` на `MainProduct` by construction), номера строк, сдвинутые этим изменением, обновлены: `:133→:135`, `:244→:248`, `:186–199→:191–202`, `:408–416→:407–418`, `:140→:144`, `update_prices` `:456→:455`, `update_pricetags` `:249→:253`.

## Поведение не менялось

Уникальность `SupplierProduct.main_product` не тронута. Удалённый метод не вызывался ниоткуда.

## Проверка

```
docker compose exec -T celery_worker python manage.py test product_price_manager --keepdb
Ran 15 tests in 1.577s — OK
```

16 → 15 тестов, ровно «на один тест меньше», как и предсказано в задаче.

## Что осталось за рамками

Номера строк в секции *Lifecycle methods* (`:273/:298/:306/:309/:312/:317`) были сдвинуты **до** этого изменения — фактически `save` на `:277`, `apply` на `:302`, `delete` на `:316`. Это не следствие #142, поэтому не трогал; просится отдельным проходом.

В docstring намеренно не описано поведение `Coalesce(..., Decimal('0'))` для отсутствующей строки: ветка `fix/137-null-for-missing-supplier-rows` как раз про это, и утверждение про NULL-vs-ноль там, скорее всего, изменится.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
