### PR TITLE
fix(main_product_manager): update_stocks батчится по-настоящему вместо 16 полных проходов

### DIFF
--- a/.claude/knowledge/main_product_manager.md
+++ b/.claude/knowledge/main_product_manager.md
@@ -209,25 +209,27 @@ control it updated 0 of 5 products in `UpdateStocksBatchingTests`, not merely
 the tail. `MainProduct.pk` is a `BigAutoField` whose sequence is never reset,
 so live pks sit far above `count()` in any real or test DB, and a single
 deleted row (`count() < max(pk)`) is enough to trigger the same gap in
-production. `update_stocks` (`utils.py:414-422`) instead snapshots
+production. `update_stocks` (`utils.py:456-464`) instead snapshots
 `pks = list(MainProduct.objects.order_by('pk').values_list('pk', flat=True))`
 once, then `chunk = pks[i:i+batch_size]` bounds the query with
 `pk__gte=chunk[0], pk__lte=chunk[-1]` — equivalent to `pk__in=chunk` (chunk is
 a contiguous slice of every existing pk in order, so nothing sits strictly
 between its ends) without shipping a `batch_size`-long IN list. Same
-gap-safe idiom as `iter_pim_id_pk_batches` (`utils.py:573-588`), which feeds
-`reindex_pim_ids_batch`'s `pk__in=pks` (`utils.py:603`).
+gap-safe idiom as `iter_pim_id_pk_batches` (`utils.py:615-629`), which feeds
+`reindex_pim_ids_batch`'s `pk__in=pks` (`utils.py:645`).
 
-`timezone.now()` (`utils.py:407`) is read once, above the loop — read
+`timezone.now()` (`utils.py:449`) is read once, above the loop — read
 per-iteration it produces one distinct `stock_updated_at` per chunk instead
 of one per run; guarded by
 `UpdateStocksBatchingTests.test_one_run_stamps_one_timestamp`
 (`tests.py:202`).
 
-`UpdateStocksBatchingTests` (`tests.py:136-211`) is what actually exercises
+`UpdateStocksBatchingTests` (`tests.py:136-227`) is what actually exercises
 multi-batch behaviour: `batch_size=2` over 5 products with distinct stocks
 (so a chunk-scoping slip shows in the logs, not just the counts), a
-deleted-row pk gap not dropping the tail, and the timestamp guard above.
+deleted-row pk gap not dropping the tail, the timestamp guard above, and
+`logs=False` (`tests.py:213`) — the one branch the loop adds statements to
+without bounding a log list, and which no caller reaches.
 
 `batch_size` had no caller until this fix — `update_stocks_task`
 (`main_product_manager/tasks.py:66-72`, `product_price_manager/tasks.py:18-23`)

--- a/.claude/knowledge/main_product_manager.md
+++ b/.claude/knowledge/main_product_manager.md
@@ -183,10 +183,12 @@ added the header row.
 
 ## `update_stocks` and `render_stock_msg` — NULL vs `0`, three copies of the check
 
-`update_stocks`'s docstring (`utils.py:428-438`) covers why the candidate
+`update_stocks`'s docstring (`utils.py:428-447`) covers why the candidate
 filter tests `stock__isnull` separately rather than coalescing both sides —
 that bug silently skipped never-synced products forever.
-`UpdateStocksNullSafeTests` (`tests.py:51`) guards it.
+`UpdateStocksNullSafeTests` (`tests.py:51`) guards it; each of its tests
+creates a single `MainProduct`, so none of them exercise batching — see the
+next section.
 
 The render-path version of the same NULL is fixed in two of three places.
 `render_stock_msg` (`tables.py:166-186`) branches on `record.stock is None`
@@ -197,3 +199,37 @@ explicitly, though it still returns the zero-case value — a deliberate
 default, not a silent conflation. Unfixed:
 `core/templates/shopping_tab/includes/stock_badge.html:2,4` still tests
 truthy `product.stock` — see [[core]], named here, not owned here.
+
+## `update_stocks` batching — the pk-range trap (c284b65)
+
+Chunk bounds must come from a real pk snapshot, never from
+`range(0, count(), batch_size)`. `pk__gte=i, pk__lt=i+batch_size` looks like
+the natural way to slice that range and is badly wrong: as a negative
+control it updated 0 of 5 products in `UpdateStocksBatchingTests`, not merely
+the tail. `MainProduct.pk` is a `BigAutoField` whose sequence is never reset,
+so live pks sit far above `count()` in any real or test DB, and a single
+deleted row (`count() < max(pk)`) is enough to trigger the same gap in
+production. `update_stocks` (`utils.py:414-422`) instead snapshots
+`pks = list(MainProduct.objects.order_by('pk').values_list('pk', flat=True))`
+once, then `chunk = pks[i:i+batch_size]` bounds the query with
+`pk__gte=chunk[0], pk__lte=chunk[-1]` — equivalent to `pk__in=chunk` (chunk is
+a contiguous slice of every existing pk in order, so nothing sits strictly
+between its ends) without shipping a `batch_size`-long IN list. Same
+gap-safe idiom as `iter_pim_id_pk_batches` (`utils.py:573-588`), which feeds
+`reindex_pim_ids_batch`'s `pk__in=pks` (`utils.py:603`).
+
+`timezone.now()` (`utils.py:407`) is read once, above the loop — read
+per-iteration it produces one distinct `stock_updated_at` per chunk instead
+of one per run; guarded by
+`UpdateStocksBatchingTests.test_one_run_stamps_one_timestamp`
+(`tests.py:202`).
+
+`UpdateStocksBatchingTests` (`tests.py:136-211`) is what actually exercises
+multi-batch behaviour: `batch_size=2` over 5 products with distinct stocks
+(so a chunk-scoping slip shows in the logs, not just the counts), a
+deleted-row pk gap not dropping the tail, and the timestamp guard above.
+
+`batch_size` had no caller until this fix — `update_stocks_task`
+(`main_product_manager/tasks.py:66-72`, `product_price_manager/tasks.py:18-23`)
+both call `runner=update_stocks` bare, and `run_task.py`'s `--batch-size`
+flag only reaches `create_pim_links`/`reindex_pim_ids` (`run_task.py:67`).

--- a/price_manager/main_product_manager/tests.py
+++ b/price_manager/main_product_manager/tests.py
@@ -133,6 +133,84 @@ class UpdateStocksNullSafeTests(TestCase):
         self.assertTrue(MainProductLog.objects.filter(main_product=mp, stock=0).exists())
 
 
+class UpdateStocksBatchingTests(TestCase):
+    """update_stocks walks the catalog in pk chunks of `batch_size`.
+
+    UpdateStocksNullSafeTests cannot cover that: each of those creates a single
+    MainProduct, so the loop runs exactly one iteration whether or not it
+    really batches. These pass a batch_size small enough to need several.
+    """
+
+    def setUp(self):
+        self.currency = Currency.objects.get_or_create(name='KZT', value=1)[0]
+        self.supplier = Supplier.objects.create(
+            name='Batch supplier',
+            currency=self.currency,
+            price_update_rate='',
+            stock_update_rate='',
+            delivery_days_available=1,
+            delivery_days_navailable=2,
+        )
+
+    def _product_with_stock(self, index, stock):
+        mp = MainProduct.objects.create(
+            supplier=self.supplier,
+            article=f'BT-{index}',
+            name=f'Batched {index}',
+            stock=None,
+        )
+        SupplierProduct.objects.create(
+            main_product=mp,
+            supplier=self.supplier,
+            article=f'SP-BT-{index}',
+            name='Stock row',
+            stock=stock,
+        )
+        return mp
+
+    def test_every_batch_is_updated_and_logged(self):
+        """Distinct stock per product, so a chunk-scoping slip shows up in the
+        logs rather than hiding behind matching counts."""
+        products = [self._product_with_stock(i, i) for i in range(1, 6)]
+
+        self.assertEqual(update_stocks(batch_size=2), 5)
+
+        for expected, mp in enumerate(products, start=1):
+            mp.refresh_from_db()
+            self.assertEqual(mp.stock, expected)
+            self.assertEqual(
+                list(MainProductLog.objects.filter(main_product=mp).values_list('stock', flat=True)),
+                [expected],
+            )
+        self.assertEqual(MainProductLog.objects.count(), 5)
+
+    def test_pk_gap_does_not_drop_the_tail(self):
+        """Chunk bounds come from real pks, not offsets over count().
+
+        A deleted product leaves count() < max(pk), which is exactly when
+        offset-derived pk ranges stop short and silently skip the highest pks.
+        """
+        products = [self._product_with_stock(i, i) for i in range(1, 6)]
+        products.pop(2).delete()
+
+        self.assertEqual(update_stocks(batch_size=2), 4)
+
+        for expected, mp in zip([1, 2, 4, 5], products):
+            mp.refresh_from_db()
+            self.assertEqual(mp.stock, expected)
+
+    def test_one_run_stamps_one_timestamp(self):
+        """timezone.now() is read once, above the loop — batching a run must
+        not spread it across several stock_updated_at values."""
+        for i in range(1, 6):
+            self._product_with_stock(i, i)
+
+        update_stocks(batch_size=2)
+
+        stamps = set(MainProduct.objects.values_list('stock_updated_at', flat=True))
+        self.assertEqual(len(stamps), 1)
+
+
 from unittest.mock import Mock, patch
 
 from django.core.cache import cache

--- a/price_manager/main_product_manager/tests.py
+++ b/price_manager/main_product_manager/tests.py
@@ -210,6 +210,22 @@ class UpdateStocksBatchingTests(TestCase):
         stamps = set(MainProduct.objects.values_list('stock_updated_at', flat=True))
         self.assertEqual(len(stamps), 1)
 
+    def test_logs_false_updates_every_batch_without_logging(self):
+        """logs=False is the one branch the loop adds statements to without
+        bounding a log list, and no caller passes it — both update_stocks_task
+        definitions call runner=update_stocks bare, so nothing else covers it.
+        """
+        for i in range(1, 6):
+            self._product_with_stock(i, i)
+
+        self.assertEqual(update_stocks(logs=False, batch_size=2), 5)
+
+        self.assertEqual(MainProductLog.objects.count(), 0)
+        self.assertEqual(
+            sorted(MainProduct.objects.values_list('stock', flat=True)),
+            [1, 2, 3, 4, 5],
+        )
+
 
 from unittest.mock import Mock, patch
 

--- a/price_manager/main_product_manager/utils.py
+++ b/price_manager/main_product_manager/utils.py
@@ -435,22 +435,37 @@ def update_stocks(logs: bool = True, batch_size: int = 10000) -> int:
     coalescing both sides made NULL -> 0 compare equal, so those products were
     never updated and never logged. The isnull branch stops matching after the
     first run, since the row is left with a non-NULL stock.
+
+    Walks the catalog in `batch_size` chunks of a pk snapshot taken up front,
+    so the MainProductLog list and its INSERT stay bounded instead of growing
+    with the number of changed products. The chunk bounds come from real pks
+    rather than offsets over count(), because a single gap in the id sequence
+    would make an offset-derived range stop short and silently skip the tail
+    of the catalog. Products created after the snapshot are picked up by the
+    next run. Every batch stamps the same stock_updated_at, so one run still
+    means one timestamp.
     """
     updated = 0
-    for i in range(0, MainProduct.objects.count(), batch_size):
-        stock_subq = (
-            SupplierProduct.objects
-            .filter(main_product_id=OuterRef('pk'))
-            .order_by('-updated_at')
-            .values('stock')[:1]
-        )
-        mps = MainProduct.objects.annotate(
+    now = timezone.now()
+    stock_subq = (
+        SupplierProduct.objects
+        .filter(main_product_id=OuterRef('pk'))
+        .order_by('-updated_at')
+        .values('stock')[:1]
+    )
+    pks = list(MainProduct.objects.order_by('pk').values_list('pk', flat=True))
+    for i in range(0, len(pks), batch_size):
+        chunk = pks[i:i + batch_size]
+        # chunk is a slice of every pk in pk order, so every existing product
+        # between its ends is inside it — the range bounds select exactly
+        # pk__in=chunk without shipping a batch_size-long IN list.
+        mps = MainProduct.objects.filter(pk__gte=chunk[0], pk__lte=chunk[-1]).annotate(
             new_stock=Coalesce(Subquery(stock_subq, output_field=IntegerField()), Value(0), output_field=IntegerField()),
         ).filter(Q(stock__isnull=True) | ~Q(stock=F('new_stock')))
         if logs:
             mpls = [MainProductLog(main_product=mp, stock=mp.new_stock) for mp in mps]
-            MainProductLog.objects.bulk_create(mpls)
-        updated += mps.update(stock=F('new_stock'), stock_updated_at=timezone.now())
+            MainProductLog.objects.bulk_create(mpls, batch_size=batch_size)
+        updated += mps.update(stock=F('new_stock'), stock_updated_at=now)
     return updated
 
 PIM_PRODUCT_ENTITY = 'PriceManagerProduct'


### PR DESCRIPTION
Предшествует исправлению #138 (061222c) и выходит за рамки того issue, поэтому отдельная ветка и PR.

## Что было

`update_stocks()` (`main_product_manager/utils.py:385`) выглядел как батчевый цикл, но не батчил:

```python
for i in range(0, MainProduct.objects.count(), batch_size):
    ...
    mps = MainProduct.objects.annotate(...).filter(...)   # без слайса
```

`i` не использовался, queryset внутри не был ограничен — каждая итерация работала по всей таблице. На ~156k `MainProduct` и `batch_size=10000` это ~16 полных проходов: первый делал всю работу, остальные 15 заново гоняли count/annotate/коррелированный подзапрос/update по таблице, которая уже не совпадала, и добавляли 0.

Не баг корректности — лишние проходы были no-op — но ~15x лишней работы БД в Celery-задаче по всему каталогу.

## Почему вариант «просто убрать цикл» не выбран

Неограниченный queryset означал ещё и то, что при `logs=True` в один Python-список материализовался каждый изменённый `MainProduct` **и** каждый `MainProductLog`, а `bulk_create` получал INSERT без границы. Удаление цикла сохранило бы это как есть. Батчинг ограничивает и то, и другое — поэтому цикл сделан настоящим, а `batch_size` наконец что-то значит.

## Ловушка, которую этот PR обходит

Естественный способ починить цикл в его исходной форме — вывести pk-диапазон из `count()`:

```python
for i in range(0, MainProduct.objects.count(), batch_size):
    mps = MainProduct.objects.filter(pk__gte=i, pk__lt=i + batch_size)   # НЕПРАВИЛЬНО
```

Проверено как negative control: **обновляет 0 из 5 товаров**, а не только «хвост». `MainProduct.pk` — `BigAutoField`, последовательность которого никогда не сбрасывается, поэтому живые pk лежат намного выше `count()`. В проде достаточно одной удалённой строки, чтобы `count() < max(pk)` и цикл молча пропустил конец каталога — отказ хуже исходного.

Вместо этого границы берутся из снимка pk, тем же приёмом, что уже есть в файле (`iter_pim_id_pk_batches`, `utils.py:573` → `pk__in`, `:603`):

```python
pks = list(MainProduct.objects.order_by('pk').values_list('pk', flat=True))
for i in range(0, len(pks), batch_size):
    chunk = pks[i:i + batch_size]
    mps = MainProduct.objects.filter(pk__gte=chunk[0], pk__lte=chunk[-1]).annotate(...)
```

`chunk` — непрерывный срез всех существующих pk по порядку, поэтому границы диапазона выбирают ровно `pk__in=chunk`, но без IN-списка длиной в `batch_size`.

`timezone.now()` поднят над циклом: один запуск по-прежнему означает один `stock_updated_at`. Раньше он читался на каждой итерации — это выглядело безобидно только потому, что итерации 2-16 ничего не находили.

## Семантика NULL не тронута

`SupplierProduct.stock` NULL по-прежнему сводится к 0; `MainProduct.stock` NULL по-прежнему значит «никогда не синхронизировался» и проверяется через `stock__isnull`, а не коалесцируется. Докстринг и `.claude/knowledge/main_product_manager.md` §«`update_stocks` — the two NULLs mean different things» согласованы.

## Тесты

Три существующих `UpdateStocksNullSafeTests` (`tests.py:51`) создают по **одному** `MainProduct`, поэтому `range(0, 1, 10000)` — одна итерация и под старым циклом, и под новым: они проходят одинаково в обоих случаях и ничего не доказывают про батчинг. Они не ослаблены — включая `test_second_run_is_a_no_op`.

Добавлен `UpdateStocksBatchingTests` (`tests.py:136`), `batch_size=2` на 5 товарах:

- `test_every_batch_is_updated_and_logged` — у каждого товара свой остаток, поэтому промах по границам чанка виден в логах, а не прячется за совпадающими счётчиками
- `test_pk_gap_does_not_drop_the_tail` — удалённая строка в середине; ловит именно pk-диапазон из `count()`
- `test_one_run_stamps_one_timestamp` — сторожит вынос `timezone.now()`

Оба варианта ловушки проверены как negative control и роняют эти тесты (0 != 5 и 4, 3 != 1 соответственно); второй ловится без искусственного `sleep`.

`batch_size` до сих пор никто не передавал: оба `update_stocks_task` (`main_product_manager/tasks.py:66`, `product_price_manager/tasks.py:19`) вызывают `runner=update_stocks` без аргументов, а `run_task.py` пробрасывает `--batch-size` только в `create_pim_links`/`reindex_pim_ids`. Параметр оставлен и теперь работает.

## Проверено

Изолированный стек на этом worktree (`PROJECT_NAME=pm_gagarin`), т.к. общие контейнеры смонтированы на основной checkout:

- полный набор — **287 тестов, OK**
- `makemigrations --check --dry-run` — `No changes detected` (модели не менялись)

`execute_locked_task` и `TaskRunHistory` не тронуты.

## Замечено попутно, вне рамок

- `settings/celery.py:38-45` определяет ключ `'update-logs'` дважды — второй литерал перетирает первый. Не проверял.
- `delete_outdated_logs_task` (`tasks.py:87`) при `Meta.ordering = ['-update_time']` удаляет, похоже, **новейшие** 100k строк, а не старейшие. Не проверял.
- Два `update_stocks_task` берут разные ключи блокировки, так что при одновременном расписании могут работать параллельно по одной таблице. Существовало раньше.

Каждое заведено отдельной задачей, ни одно не чинится здесь.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
