### PR TITLE
Docstring _search_pim_id описывает фактический поиск по sku (#164)

### DIFF
--- a/.claude/knowledge/main_product_manager.md
+++ b/.claude/knowledge/main_product_manager.md
@@ -24,6 +24,11 @@ and `sleep` interleaved per chunk, underneath `_push_pim_products`) in a
 transaction "to compensate" — that breaks its promise that one failing chunk
 doesn't lose the others.
 
+One caveat on "idempotent, resumes cleanly": `_search_pim_id`'s
+no-match cache conflates a PIM *error* with a genuine no-match (see its
+section below), so a re-scan restarted within the 4h window after an outage
+silently skips the rows the outage hit instead of retrying them.
+
 ## The PIM cache's render-path cost — and why it bites tests too
 
 `get_pim_data` (`utils.py:133`) on a cache miss does **both**: queues async
@@ -107,20 +112,64 @@ workaround in place; the trap is real, not hypothetical, so don't drop
 either without re-deriving why `search_rank` lives as a separate
 `@staticmethod`.
 
-## `_search_pim_id` docstring does not match its code
+## `_search_pim_id`: one `like` on `number`, and three unchecked edges
 
-The docstring (`utils.py:159-170`) promises a search of `ContributorProduct`
-"by priceManagerId, then by sku/number", reading `masterRecordId` to reach the
-merged `Product`. The code (`utils.py:175-182`) does neither: a single-element
-`searches` list — `Where(attribute='number', type='like', value=product.sku)`
-— queried straight against `EntityList(name='Product', ...)`. No
-`ContributorProduct` step, no `masterRecordId`, no `priceManagerId` fallback
-— verified by reading both, not inferred.
+`_search_pim_id` (`utils.py:158`) resolves `pim_id` with a single
+`Where(attribute='number', type='like', value=product.sku)` queried straight
+against `EntityList(name='Product', select=['id'])` — a direct `Product`
+search, one round-trip. No `ContributorProduct` step, no `masterRecordId`, no
+`priceManagerId` fallback.
 
-Consequence: `sku` is nullable (`models.py:50-53`), so a `MainProduct` with no
-`sku` can **never** resolve a `pim_id` through this path — a firmer
-explanation for stuck-NULL `pim_id`s than the backlog and the 4h no-match
-cache (`_PIM_NO_MATCH_TTL`, `utils.py:154`) alone.
+The docstrings on `_search_pim_id`, `_fetch_pim_product` and
+`get_pim_data_for_product` claimed that `ContributorProduct`/`masterRecordId`/
+priceManagerId path until it was corrected as a docs-only fix. It was once
+true: `86f3289` collapsed a two-element `searches` list (priceManagerId, then
+sku) to one and dropped its `if product.sku` guard, and `48c31f8` swapped the
+entity from `ContributorProduct`/`masterRecordId` to `Product`/`id`. Neither
+touched the prose, so the docstring outlived its code by two commits; it was
+reported as having been read as the real lookup path during #164's triage
+(not visible in that issue's body or comments — grepped). The vestigial
+one-element loop went with the docstring fix. (`_fetch_pim_product`'s
+companion point — a `pim_id` is a `Product` id, not a `ContributorProduct` id
+— is still true and is why one `pim_id` legitimately spans several
+`MainProduct`s; `sync_pim_relations:300` says so and is accurate.)
+
+Three things the search does not check. All are current behaviour, all are
+undocumented outside the docstring, and none has been fixed:
+
+- **First match wins.** The loop returns the first non-empty id in the
+  response with no count or ambiguity check, so a `like` that matches several
+  Products links to whichever PIM returns first.
+- **`sku` is nullable** (`models.py:50-53`) — but a no-sku product is *not*
+  skipped. `Where.value` is `Optional[str]` and `Where.get()` omits the
+  `value` key from the query string entirely when it is None
+  (`pim_api/__init__.py:24-25`), so the request still goes out as an
+  unconstrained `like` on `number`. What PIM returns for a valueless filter
+  is not knowable from this repo — but if it returns anything, first-match-wins
+  above will link the product to an arbitrary `Product`. Do not repeat the
+  older, tidier claim that a no-sku product "can never resolve": that is an
+  assumption, and the query-string construction contradicts it.
+- **A PIM error is cached as a definitive miss.** The `try/except` sits
+  *inside* what used to be the loop, and `except` only calls
+  `_record_pim_error` — no `return`, no re-raise — so control falls through to
+  `cache.set(no_match_key, True, _PIM_NO_MATCH_TTL)` on a transient network or
+  API error exactly as on a genuine "not in PIM". An outage during a scan
+  writes a 4h no-match flag for every product it touched, and the early return
+  at the top then skips those rows with no network call until it expires.
+  Only `get_pim_data_for_product`'s 404-recovery path clears the flag early
+  (`cache.delete(f"pim_no_match:{product.pk}")`) — nothing else does.
+
+The last two are why a `MainProduct` gets stuck with `pim_id = NULL`, and the
+first is why a non-NULL `pim_id` is not proof of a *correct* link — relevant
+to #164, where 156 359 products carry a `pim_id` but only 465 have categories.
+
+**Stale UI copy this produces, not yet fixed:**
+`templates/mainproduct/partials/detail.html:78` tells the user, in Russian,
+"Проверьте соответствие priceManagerId/названия" — but the lookup matches
+`number`/sku only; neither `priceManagerId` nor the product name participates.
+Correct copy needs to name `sku`/`number` and cover the no-sku case. After the
+docstring fix this line is the last surviving `priceManagerId` reference in the
+repo outside `pim_api` itself (grepped, not assumed).
 
 ## The 11 Celery tasks, and one that isn't
 

--- a/price_manager/main_product_manager/utils.py
+++ b/price_manager/main_product_manager/utils.py
@@ -63,10 +63,12 @@ def maybe_notify_pim_error(user) -> None:
 
 
 def _fetch_pim_product(pim_id: str) -> tuple[dict | None, bool]:
-    """Fetch a verified PIM `Product` (master record) by id straight from the API (no cache).
+    """GET a PIM `Product` by id straight from the API (no cache).
 
-    pim_id is the id of the verified/merged PIM `Product`, not a `ContributorProduct` —
-    see _search_pim_id for how it's resolved via ContributorProduct.masterRecordId.
+    pim_id is a PIM `Product` id — either one already stored on the MainProduct,
+    or one _search_pim_id found by matching sku against `Product.number`. It is
+    not a `ContributorProduct` id, which is why a single pim_id legitimately
+    spans several MainProducts (see sync_pim_relations).
 
     Returns (data, not_found) — not_found is True only on an explicit 404,
     so callers can tell "PIM deleted/renumbered this id" apart from a
@@ -156,37 +158,54 @@ _PIM_POPULATE_QUEUED_TTL = 60 * 10  # throttle for the cache-miss population tri
 
 
 def _search_pim_id(product) -> str | None:
-    """Resolve a MainProduct's pim_id: the verified PIM `Product` (master record) id.
+    """Resolve a MainProduct's pim_id by matching its sku against PIM `Product.number`.
 
-    A product isn't directly linked to a `Product` — it's found by searching
-    `ContributorProduct` (by priceManagerId, then by sku/number) and reading its
-    `masterRecordId`, which points at the merged/verified `Product`. A
-    ContributorProduct without a masterRecordId yet (not verified in PIM) counts
-    as no match.
+    One request: a `like` search on `Product.number` for `product.sku`, taking
+    the first id in the response. The `Product` is queried directly — there is
+    no `ContributorProduct` lookup and no `masterRecordId` hop, and
+    `priceManagerId` is not consulted.
 
-    Throttled by a no-match cache (_PIM_NO_MATCH_TTL) so unmatched products
-    are only retried periodically instead of on every lookup/task run.
+    Three things the code does not check, all of them current behaviour:
+
+    - **First match wins.** `like` can match several Products; nothing counts
+      or disambiguates them, so an sku that is a prefix of others links to
+      whichever PIM happens to return first.
+    - **`sku` is nullable** (`models.py:50-53`), and `Where` omits `value` from
+      the query string entirely when it is None (`pim_api/__init__.py:24-25`).
+      A product with no sku is therefore not skipped — it sends an
+      *unconstrained* `like` filter on `number`. What PIM returns for that is
+      not knowable from this repo.
+    - **An API error is indistinguishable from a miss.** The `except` records
+      the error and falls through to the no-match cache below, so a PIM outage
+      suppresses retries for _PIM_NO_MATCH_TTL exactly as a genuine miss does.
+      A scan interrupted by an outage resumes by skipping the rows the outage
+      hit, without a network call, until the flag expires.
+
+    Throttled by that no-match cache (_PIM_NO_MATCH_TTL) so unmatched products
+    are only retried periodically instead of on every lookup/task run; only
+    get_pim_data_for_product's 404-recovery path clears the flag early.
     Does not persist the result — callers decide how/when to save it.
     """
     no_match_key = f"pim_no_match:{product.pk}"
     if cache.get(no_match_key):
         return None
 
-    searches = [Where(attribute='number', type='like', value=product.sku)]
-
-    for where in searches:
-        t0 = time.monotonic()
-        try:
-            result = site.get(
-                EntityList(name='Product', select=['id'], where=[where])
+    t0 = time.monotonic()
+    try:
+        result = site.get(
+            EntityList(
+                name='Product',
+                select=['id'],
+                where=[Where(attribute='number', type='like', value=product.sku)],
             )
-            for item in result.get('list', []):
-                product_id = item.get('id')
-                if product_id:
-                    return product_id
-            # No match is normal — don't treat as error, just set no-match cache below
-        except Exception as exc:
-            _record_pim_error("_search_pim_id", exc, int((time.monotonic() - t0) * 1000))
+        )
+        for item in result.get('list', []):
+            product_id = item.get('id')
+            if product_id:
+                return product_id
+        # No match is normal — don't treat as error, just set no-match cache below
+    except Exception as exc:
+        _record_pim_error("_search_pim_id", exc, int((time.monotonic() - t0) * 1000))
 
     cache.set(no_match_key, True, _PIM_NO_MATCH_TTL)
     return None
@@ -206,8 +225,9 @@ def get_pim_data_for_product(product, refresh: bool = False) -> dict | None:
 
     If the stored pim_id 404s _PIM_404_THRESHOLD times in a row (deleted/
     renumbered in PIM), get_pim_data clears it from the DB — detected here via
-    refresh_from_db — and it's re-resolved by priceManagerId/sku before
-    retrying once.
+    refresh_from_db — and it's re-resolved by sku before retrying once. The
+    no-match cache is dropped first; without that, _search_pim_id's 4h throttle
+    would short-circuit the re-resolve. This is the only place that clears it.
     """
     if not product.pim_id:
         _resolve_pim_id(product)


### PR DESCRIPTION
Только документация: три docstring в `main_product_manager/utils.py` описывали механизм, которого в коде нет. Поведение не меняется — единственная правка кода схлопывает вырожденный цикл и сохраняет семантику.

## Что было не так

Docstring обещал поиск по `ContributorProduct` (сначала `priceManagerId`, затем sku) с переходом по `masterRecordId` на объединённый `Product`. Код делает один прямой запрос:

```python
Where(attribute='number', type='like', value=product.sku)
site.get(EntityList(name='Product', select=['id'], where=[where]))
```

Ни запроса `ContributorProduct`, ни `priceManagerId`, ни `masterRecordId`.

Когда-то docstring был верен. Расхождение развели два коммита, не тронувшие прозу:

| Коммит | Что сделал |
|---|---|
| `86f3289` | схлопнул двухэлементный `searches` (priceManagerId → sku) в один и убрал охрану `if product.sku` |
| `48c31f8` | заменил `ContributorProduct`/`masterRecordId` на `Product`/`id` |

## Что в PR

**Три docstring** (третий — тот же неверный тезис в том же файле, поэтому исправлен заодно):

- `_search_pim_id` — переписан по факту. Сохранены троттлинг no-match кеша (`_PIM_NO_MATCH_TTL`) и то, что результат не сохраняется — решают вызывающие.
- `_fetch_pim_product` — убрано унаследованное утверждение. Заодно снято «verified/merged (master record)»: это из той же несуществующей модели, что и `masterRecordId`, и ничем в репозитории не подтверждается. Вызов — обычный `GET Product/{id}`.
- `get_pim_data_for_product` — «re-resolved by priceManagerId/sku» → по sku.

**Цикл `for where in searches` схлопнут** в прямой вызов. Список из одного элемента — остаток удалённого поиска по `priceManagerId` (см. `86f3289`), а не точка расширения, поэтому не оставлен с комментарием. Отдельный хунк, откатывается независимо.

## Три края, которые старый docstring скрывал — задокументированы, код не менялся

1. **Побеждает первое совпадение.** `like` может вернуть несколько `Product`; количество не проверяется.
2. **`sku` nullable, но товар без sku не пропускается.** `Where.get()` вовсе опускает `value` из query string при `None` (`pim_api/__init__.py:24-25`) — уходит фильтр `like` по `number` без значения. В файле знаний раньше стояло, что такой товар «никогда не разрешится»; это была догадка, и построение query string ей противоречит.
3. **Ошибка API неотличима от промаха.** `except` не возвращает управление, выполнение доходит до `cache.set(no_match_key, ...)`. Недоступность PIM гасит повторные попытки на 4 часа так же, как настоящий промах — а сплошной проход после сбоя «продолжится», молча пропустив ровно те строки, которые сбой задел.

Пункт 3 подрывает обоснование `atomic=False` у сплошных задач («resume cleanly») — соответствующий раздел в файле знаний поправлен. Пункты 1 и 3 заведены как отдельная задача на исправление поведения.

## Файл знаний

Раздел назывался «`_search_pim_id` docstring does not match its code» — после этой правки он описывал бы расхождение, которого больше нет, то есть ровно ту гниль, против которой заведён. Переписан на механизм; история с SHA осталась как история.

Там же отмечено, что `main_product_manager/templates/mainproduct/partials/detail.html:78` до сих пор просит пользователя «Проверьте соответствие priceManagerId/названия», хотя поиск идёт только по `number`/sku. Это пользовательская строка — помечена, не тронута.

## Проверка

`py_compile` — единственная. Тесты не гонялись: Docker стал недоступен в середине сессии. Исполняемого кода тут нет, единственная правка кода — вынос конструктора запроса под `try` при схлопывании цикла.

Одна честная оговорка к «поведение не меняется»: `Where(...)` строился до `try`, а теперь внутри. Ошибка валидации pydantic раньше всплыла бы, теперь будет поймана и закеширована как no-match. Недостижимо на практике (`sku` — `CharField`, то есть `str | None`, а `value` — `Optional[str]`), но это не буквальный ноль.

## Про #164

Grep по телу и комментариям #164: неверный путь там не встречается — единственная ссылка на `_search_pim_id` описывает реальный запрос корректно. Так что если тезис и попал в разбор, то в обсуждении, а не в тексте issue. В файле знаний это записано как «сообщалось», а не как установленный факт.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
