### PR TITLE
fix(celery): дубль ключа 'update-logs' убирал update_logs из расписания

### DIFF
--- a/price_manager/core/tests.py
+++ b/price_manager/core/tests.py
@@ -1,7 +1,14 @@
+import ast
+from pathlib import Path
+
+from django.conf import settings
 from django.core.cache import cache
 from django.db import connection
-from django.test import TransactionTestCase
+from django.test import SimpleTestCase, TransactionTestCase
 from django.utils import timezone
+
+from price_manager.celery import app as celery_app
+from price_manager.settings import celery as celery_settings
 
 from .models import TaskRunHistory
 from .task_runner import execute_locked_task
@@ -105,3 +112,40 @@ class ExecuteLockedTaskAtomicTests(TransactionTestCase):
         # The error-path history row is written outside the runner's transaction,
         # so it survives the rollback.
         self.assertTrue(TaskRunHistory.objects.filter(task_name="test.rollback", status="error").exists())
+
+
+class CeleryBeatScheduleTests(SimpleTestCase):
+    """The two ways a CELERY_BEAT_SCHEDULE entry silently stops running.
+
+    Neither raises anywhere: beat just schedules less than the file appears to
+    say, and the only symptom is a task that quietly stops showing up in
+    TaskRunHistory. Commit e0a5070 hit the first one -- it added a
+    delete_outdated_logs entry under the key 'update-logs' that was already
+    taken, so main_product_manager.update_logs stopped being scheduled while
+    the file still listed it.
+    """
+
+    def test_no_entry_is_overwritten_by_a_duplicate_key(self):
+        # Has to read the source, not settings.CELERY_BEAT_SCHEDULE. By the time
+        # the module is imported the duplicate is already gone: the dict just
+        # holds one fewer entry, every remaining key is distinct, and nothing
+        # runtime-visible says a task went missing.
+        tree = ast.parse(Path(celery_settings.__file__).read_text(encoding='utf-8'))
+        literal = next(
+            node.value
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Assign)
+            and any(getattr(t, 'id', None) == 'CELERY_BEAT_SCHEDULE' for t in node.targets)
+        )
+        keys = [key.value for key in literal.keys]
+        duplicates = sorted({key for key in keys if keys.count(key) > 1})
+        self.assertEqual(duplicates, [], f'CELERY_BEAT_SCHEDULE keys repeated: {duplicates}')
+        self.assertEqual(len(keys), len(settings.CELERY_BEAT_SCHEDULE))
+
+    def test_every_scheduled_task_is_registered(self):
+        # autodiscover_tasks() is lazy; nothing has forced the app tasks modules
+        # to import in a test process.
+        celery_app.loader.import_default_modules()
+        for key, entry in settings.CELERY_BEAT_SCHEDULE.items():
+            with self.subTest(entry=key):
+                self.assertIn(entry['task'], celery_app.tasks)

--- a/price_manager/price_manager/settings/celery.py
+++ b/price_manager/price_manager/settings/celery.py
@@ -39,10 +39,10 @@ CELERY_BEAT_SCHEDULE = {
         'task': 'main_product_manager.update_logs',
         'schedule': CELERY_LOG_UPDATE_MINUTES * 60,
     },
-    'update-logs': {
-            'task': 'main_product_manager.delete_outdated_logs',
-            'schedule': 60,
-        },
+    'delete-outdated-logs': {
+        'task': 'main_product_manager.delete_outdated_logs',
+        'schedule': 60,
+    },
     'cleanup-supplier-files': {
         'task': 'supplier_product_manager.cleanup_supplier_files_task',
         'schedule': CELERY_SUPPLIER_FILES_CLEANUP_MINUTES * 60,


### PR DESCRIPTION
## Что сломалось

`CELERY_BEAT_SCHEDULE` объявлял ключ `'update-logs'` дважды. Словарь схлопывается, вторая запись затирает первую — и `main_product_manager.update_logs` вообще переставал запускаться по расписанию, хотя файл его по-прежнему перечислял. Работал только `delete_outdated_logs`.

Ничего при этом не падает и нигде не логируется: beat просто планирует на одну задачу меньше, чем написано в файле.

## Откуда это взялось

`git show e0a5070` («ticket: 173380», 27.07.2026). Запись `delete_outdated_logs` добавлена **ниже** существующей `update-logs`, оригинал оставлен нетронутым, отступ нового блока на уровень глубже. Это копипаста, а не сознательное отключение задачи — коммит добавлял чистку логов, а остановка их записи оказалась побочным эффектом. `update_logs_task` до сих пор зарегистрирован в `run_task.py` и сохраняет свой декоратор.

## Что изменено

Отдельный ключ `'delete-outdated-logs'` для второй записи, отступ выровнен по остальному словарю. Расписание `update-logs` не трогалось — восстановлено ровно то, что файл и так декларировал.

## Тесты

`core.tests.CeleryBeatScheduleTests` — два способа тихо потерять задачу:

- `test_no_entry_is_overwritten_by_a_duplicate_key` читает **исходник через `ast`**, а не `settings.CELERY_BEAT_SCHEDULE`. Это принципиально: первая версия теста проверяла загруженный словарь и на воспроизведённом баге **проходила** — к моменту импорта дубля уже нет, в словаре просто на одну запись меньше, все оставшиеся ключи уникальны, и по рантайму пропажу увидеть нечем. Проверено обратно: с возвращённым дублем тест падает с `CELERY_BEAT_SCHEDULE keys repeated: ['update-logs']`.
- `test_every_scheduled_task_is_registered` — каждая запись расписания ссылается на зарегистрированную задачу Celery. Ловит опечатку в имени задачи, вторую причину тихого простоя. Ни один из тестов не хардкодит текущий состав расписания, так что новая запись их не сломает.

`docker compose run --rm --no-deps -v <worktree>/price_manager:/app celery_worker python manage.py test core --keepdb` → 7 tests, OK. Монтирование именно воркtree важно: запущенный `celery_worker` примонтирован из основного чекаута, и обычный `exec` прогнал бы чужой код.

## Что стоит знать ревьюеру

**Часовой интервал по умолчанию — не то, что крутилось в проде.** `TaskRunHistory` появился 15.04.2026 и никогда не чистится. До последнего запуска `update_logs` прошло ~108 дней; при часовом интервале это было бы ~2500 запусков, а по факту их 120 — то есть примерно раз в сутки. Причина (переопределение `CELERY_LOG_UPDATE_MINUTES` в окружении прода, неполное время работы beat или пропуски по локу) из репозитория не видна: `.env` нет, `docker-compose.yml` эту переменную не задаёт. **Перед деплоем стоит выставить `CELERY_LOG_UPDATE_MINUTES` в окружении прода**, иначе задача поедет с частотой, у которой нет эксплуатационной истории. Значение по умолчанию в файле не менялось — придумывать новое число здесь неуместно.

**Два дефекта рядом, в этом PR не тронуты:**

1. `delete_outdated_logs` удаляет **самые новые** записи, а не старые. `MainProductLog.Meta.ordering = ['-update_time']`, а срез `MainProductLog.objects.all()[:100000]` в `main_product_manager/tasks.py:87` идёт без своей сортировки — то есть остаются 100k самых старых логов. Крутится каждые 60 секунд и от этого бага не зависит.
2. Отладочный `print()` очереди в `main_product_manager/utils.py:626`, внутри цикла по типам цен планировщика.

Есть ещё подозрение, что ценовая ветка фильтра в `utils.py:623-625` ловит только переходы null↔не-null (обе ветки OR требуют NULL с одной стороны), в отличие от корректной ветки по остаткам ниже. Не утверждаю: `~Q(a=F(b))` порождает SQL с обёрткой по NULL, это надо подтверждать дампом `.query`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
