### PR TITLE
fix(main_product_manager): сбой PIM — это не «товара нет в PIM»

### DIFF
--- a/.claude/knowledge/main_product_manager.md
+++ b/.claude/knowledge/main_product_manager.md
@@ -31,24 +31,24 @@ open for the whole loop regardless of where the write lands. Fix is
 
 Safe without the transaction because the Redis lock, not the transaction,
 provides mutual exclusion, and both are idempotent re-scans that resume
-cleanly from committed progress after a mid-loop failure (`_search_pim_id`'s
-no-match cache writes escape a rollback anyway). Do **not** wrap
-`push_missing_pim_products` (`_push_pim_products` underneath — HTTP,
-`bulk_update` and `sleep` interleaved per chunk) in a transaction "to
+cleanly from committed progress after a mid-loop failure
+(`_search_pim_id_result`'s no-match cache writes escape a rollback anyway).
+Do **not** wrap `push_missing_pim_products` (`_push_pim_products` underneath
+— HTTP, `bulk_update` and `sleep` interleaved per chunk) in a transaction "to
 compensate" — that breaks its promise that one failing chunk doesn't lose
 the others. New PIM-touching tasks: pass `atomic=False` rather than
 reshuffle writes.
 
 ## The PIM cache's render-path cost — and why it bites tests too
 
-`get_pim_data` (`utils.py:133`) on a cache miss does **both**: queues async
-population (`_queue_pim_population`, `utils.py:141`) and falls through, next
-line, to a synchronous `_fetch_pim_product(...)` (`utils.py:142`) — not an
+`get_pim_data` (`utils.py:136`) on a cache miss does **both**: queues async
+population (`_queue_pim_population`, `utils.py:144`) and falls through, next
+line, to a synchronous `_fetch_pim_product(...)` (`utils.py:145`) — not an
 early return, so a cold cache blocks the request on a PIM HTTP round-trip.
-`get_file_url` (`utils.py:340`) has the same shape on a miss (`:349`), minus
+`get_file_url` (`utils.py:393`) has the same shape on a miss (`:402`), minus
 the queueing.
 
-`prefetch_pim_data` (`utils.py:322`) loops products one at a time, and
+`prefetch_pim_data` (`utils.py:375`) loops products one at a time, and
 `MainProductTableView.get_context_data` (`views.py:186`) then calls
 `get_file_url` again per entry (`views.py:198`): up to **2N** PIM calls per
 cold page (the main page paginates 5 categories at a time, `views.py:89`,
@@ -69,13 +69,13 @@ reach PIM — but a test needing a populated `search_vector` should set it
 directly with `SearchVector` over local fields (`test_grouping.py:64-68`)
 instead of calling `rebuild_search_vector()`.
 
-## `get_file_url`'s return line has an operator-precedence bug (`utils.py:354`)
+## `get_file_url`'s return line has an operator-precedence bug (`utils.py:407`)
 
 `return "https://" + data.get(f'{size}ThumbnailUrl') or data.get('url') or
 data.get('downloadUrl')` — `+` binds tighter than `or`, parsing as
 `("https://" + X) or Y or Z`: the `url`/`downloadUrl` fallbacks are dead code,
 and a missing `{size}ThumbnailUrl` (`X is None`) raises an uncaught
-`TypeError` — the `try/except` (`utils.py:348-353`) closes before this line.
+`TypeError` — the `try/except` (`utils.py:401-406`) closes before this line.
 Both call sites, `views.py:198` and `render_pim_photo`
 (`tables.py:233-244`), expect a clean `None`/URL — a missing thumbnail 500s
 the table instead of falling back to `—`. Bug, not yet fixed; not this
@@ -98,20 +98,76 @@ for the same M2M-join-duplicates-rows reason; `CategoryFilter` mirrors it
 with `Count(F('mainproducts'), distinct=True)`
 (`supplier_manager/filters.py:20`) instead of a plain `Count`.
 
-## `_search_pim_id` docstring does not match its code
+## `_search_pim_id_result` — an empty search must say *why* it's empty
 
-The docstring (`utils.py:159-170`) promises a search of `ContributorProduct`
-"by priceManagerId, then by sku/number", reading `masterRecordId` to reach the
-merged `Product`. The code (`utils.py:175-182`) does neither: a single-element
-`searches` list — `Where(attribute='number', type='like', value=product.sku)`
-— queried straight against `EntityList(name='Product', ...)`. No
-`ContributorProduct` step, no `masterRecordId`, no `priceManagerId` fallback
-— verified by reading both, not inferred.
+`_search_pim_id_result(product) -> tuple[str | None, str]` (`utils.py:175`)
+is the real entry point; `_search_pim_id` (`utils.py:240`) is now a thin
+id-only wrapper kept for `_resolve_pim_id` (`utils.py:249`, called from
+`_build_searchvector`/`get_pim_data_for_product`). It fires one `like` on
+PIM's `Product.number` against `product.sku` and returns one of five
+outcomes (`utils.py:164-168`): `_SEARCH_FOUND`, `_SEARCH_ABSENT`,
+`_SEARCH_AMBIGUOUS`, `_SEARCH_ERROR`, `_SEARCH_NO_SKU`.
 
-Consequence: `sku` is nullable (`models.py:50-53`), so a `MainProduct` with no
-`sku` can **never** resolve a `pim_id` through this path — a firmer
-explanation for stuck-NULL `pim_id`s than the backlog and the 4h no-match
-cache (`_PIM_NO_MATCH_TTL`, `utils.py:154`) alone.
+**The trap this replaced**: before this commit a no-sku product fired an
+*unconstrained* `like` on `number` — `Where.get()` drops the `value` key
+when it's `None` — and could link to an arbitrary `Product`; and every empty
+return collapsed to the same "no match", including a network failure. That
+matters because `push_missing_pim_products` (`utils.py:568`) *writes to
+PIM* — it creates a `PriceManagerProduct` — so feeding it anything but a
+confirmed `_SEARCH_ABSENT` risked creating a duplicate PIM record for a
+product that might already be linked (a PIM outage mid-scan used to do this
+for every unlinked product the scan touched). Only `_SEARCH_ABSENT` may reach
+it now: `create_pim_links` (`utils.py:586`) and `reindex_pim_ids_batch`
+(`utils.py:658`) both branch on the outcome, not on `pim_id is None`. Anyone
+adding a new caller that writes on a miss must do the same, not just check
+for `None`.
+
+**The cost of that correctness, in `create_pim_links` only**: its window is
+`filter(pim_id__isnull=True)[:1000]` under `Meta.ordering = ['id']`, so it is
+the same lowest-1000 unlinked rows every run, and it used to drain because
+every product left the unlinked set — linked, or pushed to PIM and given the
+id `_push_pim_products` wrote back. An unsearchable product now does neither,
+so it would sit at the head of the window forever, costing a slot and a
+`time.sleep(delay)` per run. No-sku rows are therefore excluded from the
+queryset itself (`utils.py:587-595`); drop that exclusion if a search that
+works without an sku is ever added back. `_SEARCH_AMBIGUOUS` rows have no
+such containment — they stay in the window by design, since an ambiguous
+match is a data problem someone has to resolve in PIM.
+
+The cache key `pim_no_match:{pk}` stores the outcome string itself, not a
+bare flag — deliberately **one** key rather than two, so
+`get_pim_data_for_product`'s single `cache.delete` on its 404-recovery path
+(`utils.py:277`) still clears everything. TTLs differ by reason:
+`_PIM_SEARCH_ERROR_TTL` = 5 min for an error, `_PIM_NO_MATCH_TTL` = 4h for a
+confirmed absence or an ambiguous match (`utils.py:157-158`). A legacy bare
+`True` under the same key (written by an older revision) is dropped and
+re-searched rather than trusted (`utils.py:205-208`).
+
+`create_pim_links` and `reindex_pim_ids_batch` both raise `PimSearchError`
+(`utils.py:171`) when any search in the run went unanswered — *after* their
+`bulk_update`, so committed progress survives the exception. Worth doing
+specifically because `maybe_notify_pim_error` is DEBUG-gated (`utils.py:45`)
+and prod runs under `settings.prod`, so `_PIM_LAST_ERROR_KEY` gets written
+but never read in prod — `TaskRunHistory` (populated from
+`execute_locked_task`'s `except` branch, `core/task_runner.py:112-132`) is
+the only durable signal that the run failed. The return must stay a
+2-tuple: `_normalize_updated_count` (`core/task_runner.py:14-21`) sums every
+numeric element of a returned tuple, so a third "failed" element would
+silently inflate `updated_count` instead of surfacing separately.
+
+Consequence for `manage.py run_task`: sync mode calls the task function
+directly (`management/commands/run_task.py:81`), so `PimSearchError`
+now propagates out of `handle()` — its no-argument form (run every task in
+sequence) stops at the first failing task instead of finishing the loop.
+
+Testing: `site` is bound into `utils`'s own namespace at import
+(`utils.py:16`), so tests must patch `main_product_manager.utils.site`, not
+`main_product_manager.pim_client.site`. Before this commit nothing in the
+app stubbed `site.get` at all. `SearchPimIdOutcomeTests` and
+`PimScanPushGuardTests` (`tests.py:307`, `:433`) are the pattern to copy —
+both run under `@override_settings(CACHES=LOCMEM_CACHE)`, needed because the
+outcome cache has to be visible to in-process assertions, not the worker
+container's shared Redis.
 
 ## The 11 Celery tasks
 
@@ -120,7 +176,7 @@ best-behaved app in the repo on that convention. `reindex_pim_ids` and
 `reindex_pim_ids_batch` (`tasks.py:166`, `:187`) set
 `time_limit=None, soft_time_limit=None`: a full catalog re-scan outruns any
 sane limit. Fan-out: `reindex_pim_ids_task` chunks pks via
-`iter_pim_id_pk_batches()` (`utils.py:558`) and queues one
+`iter_pim_id_pk_batches()` (`utils.py:641`) and queues one
 `reindex_pim_ids_batch_task` per chunk to run in parallel; `task_name` is
 uniquified per chunk (`tasks.py:190`) or they'd all contend on one Redis lock.
 `sync_main_products_task` (`tasks.py:143`) is a 12th function but not a task
@@ -166,7 +222,7 @@ distinct from the `GinIndex` still only on `search_vector` (`models.py:44`).
 Multiplicity — several `MainProduct`s from different suppliers legitimately
 share one `pim_id` (it names a verified/merged PIM `Product`, not a
 per-supplier `ContributorProduct`) — asserted in `sync_pim_relations`'s
-docstring (`utils.py:295-301`), relied on by its plural
+docstring (`utils.py:348-354`), relied on by its plural
 `filter(pim_id=...).update(...)` (`:308`) and `_note_pim_404`'s bulk
 `update(pim_id=None)` (`:126`), and now also what `grouping.py` collapses
 into one head row.
@@ -207,7 +263,7 @@ added the header row.
 
 ## `update_stocks` — the two NULLs mean different things
 
-`utils.py:385`, docstring `:386-396`. Two nullable stock columns feed this
+`utils.py:438`, docstring `:439-449`. Two nullable stock columns feed this
 and don't carry the same meaning:
 
 - `SupplierProduct.stock` NULL = supplier told us nothing; unknown isn't

--- a/.claude/knowledge/main_product_manager.md
+++ b/.claude/knowledge/main_product_manager.md
@@ -24,10 +24,13 @@ and `sleep` interleaved per chunk, underneath `_push_pim_products`) in a
 transaction "to compensate" — that breaks its promise that one failing chunk
 doesn't lose the others.
 
-One caveat on "idempotent, resumes cleanly": `_search_pim_id`'s
-no-match cache conflates a PIM *error* with a genuine no-match (see its
-section below), so a re-scan restarted within the 4h window after an outage
-silently skips the rows the outage hit instead of retrying them.
+"Idempotent, resumes cleanly" is true now, and was not before: the
+no-match cache used to conflate a PIM *error* with a genuine no-match, so a
+re-scan restarted inside the 4h window after an outage silently skipped the
+rows the outage hit. The cache now records *which* it was and an error is held
+for minutes, not hours (see the section below) — and a run that hit one is
+recorded as an error instead of a success, so "it resumed" is checkable rather
+than assumed.
 
 ## The PIM cache's render-path cost — and why it bites tests too
 
@@ -112,64 +115,99 @@ workaround in place; the trap is real, not hypothetical, so don't drop
 either without re-deriving why `search_rank` lives as a separate
 `@staticmethod`.
 
-## `_search_pim_id`: one `like` on `number`, and three unchecked edges
+## `_search_pim_id_result`: one `like` on `number`, and why an empty answer has to say *why*
 
-`_search_pim_id` (`utils.py:158`) resolves `pim_id` with a single
-`Where(attribute='number', type='like', value=product.sku)` queried straight
-against `EntityList(name='Product', select=['id'])` — a direct `Product`
-search, one round-trip. No `ContributorProduct` step, no `masterRecordId`, no
-`priceManagerId` fallback.
+`_search_pim_id_result(product) -> tuple[str | None, str]` (`utils.py:177`) is
+the resolver; `_search_pim_id` (`utils.py:244`) is a thin id-only wrapper kept
+for `_resolve_pim_id`, which has nothing to decide on a miss. One round-trip:
+`Where(attribute='number', type='like', value=product.sku)` against
+`EntityList(name='Product', select=['id'])` — a direct `Product` search, no
+`ContributorProduct` step, no `masterRecordId`, no `priceManagerId` fallback.
 
-The docstrings on `_search_pim_id`, `_fetch_pim_product` and
-`get_pim_data_for_product` claimed that `ContributorProduct`/`masterRecordId`/
-priceManagerId path until it was corrected as a docs-only fix. It was once
-true: `86f3289` collapsed a two-element `searches` list (priceManagerId, then
-sku) to one and dropped its `if product.sku` guard, and `48c31f8` swapped the
-entity from `ContributorProduct`/`masterRecordId` to `Product`/`id`. Neither
-touched the prose, so the docstring outlived its code by two commits; it was
-reported as having been read as the real lookup path during #164's triage
-(not visible in that issue's body or comments — grepped). The vestigial
-one-element loop went with the docstring fix. (`_fetch_pim_product`'s
-companion point — a `pim_id` is a `Product` id, not a `ContributorProduct` id
-— is still true and is why one `pim_id` legitimately spans several
-`MainProduct`s; `sync_pim_relations:300` says so and is accurate.)
+The outcome is one of five (`utils.py:166-170`): `_SEARCH_FOUND`,
+`_SEARCH_ABSENT`, `_SEARCH_AMBIGUOUS`, `_SEARCH_ERROR`, `_SEARCH_NO_SKU`.
+**Only `_SEARCH_ABSENT` means PIM was asked and answered "no such product."**
+That distinction is load-bearing rather than tidy, because
+`push_missing_pim_products` (`utils.py:631`) *writes to PIM* — it creates a
+`PriceManagerProduct` — so anything else reaching it creates a duplicate
+record for a product that may already be there. `create_pim_links`
+(`utils.py:649`) and `reindex_pim_ids_batch` (`utils.py:721`) branch on the
+outcome, not on `pim_id is None`. A new caller that writes on a miss must do
+the same.
 
-Three things the search does not check. All are current behaviour, all are
-undocumented outside the docstring, and none has been fixed:
+**The three edges this closed.** Until then the search returned the first
+non-empty id with no count check; a no-sku product was not skipped but sent an
+*unconstrained* `like` (`Where.get()` omits the `value` key entirely when it is
+None, `pim_api/__init__.py:24-25`); and an API error fell through to the same
+`cache.set(no_match_key, True, ...)` as a genuine miss. The last one was the
+severe one, and not for the reason it looks: a PIM outage mid-scan did not just
+suppress retries for 4h, it fed every unlinked row it touched to
+`push_missing_pim_products`. Do not restore the older, tidier claim that a
+no-sku product "can never resolve" — that was an assumption the query-string
+construction contradicted.
 
-- **First match wins.** The loop returns the first non-empty id in the
-  response with no count or ambiguity check, so a `like` that matches several
-  Products links to whichever PIM returns first.
-- **`sku` is nullable** (`models.py:50-53`) — but a no-sku product is *not*
-  skipped. `Where.value` is `Optional[str]` and `Where.get()` omits the
-  `value` key from the query string entirely when it is None
-  (`pim_api/__init__.py:24-25`), so the request still goes out as an
-  unconstrained `like` on `number`. What PIM returns for a valueless filter
-  is not knowable from this repo — but if it returns anything, first-match-wins
-  above will link the product to an arbitrary `Product`. Do not repeat the
-  older, tidier claim that a no-sku product "can never resolve": that is an
-  assumption, and the query-string construction contradicts it.
-- **A PIM error is cached as a definitive miss.** The `try/except` sits
-  *inside* what used to be the loop, and `except` only calls
-  `_record_pim_error` — no `return`, no re-raise — so control falls through to
-  `cache.set(no_match_key, True, _PIM_NO_MATCH_TTL)` on a transient network or
-  API error exactly as on a genuine "not in PIM". An outage during a scan
-  writes a 4h no-match flag for every product it touched, and the early return
-  at the top then skips those rows with no network call until it expires.
-  Only `get_pim_data_for_product`'s 404-recovery path clears the flag early
-  (`cache.delete(f"pim_no_match:{product.pk}")`) — nothing else does.
+**How each is handled now**: several matches log a warning and link nothing
+(`_SEARCH_AMBIGUOUS`); no sku returns before any request (`_SEARCH_NO_SKU`,
+restoring the guard `86f3289` dropped — not the `priceManagerId` search it
+dropped alongside); a failed request returns `_SEARCH_ERROR`.
 
-The last two are why a `MainProduct` gets stuck with `pim_id = NULL`, and the
-first is why a non-NULL `pim_id` is not proof of a *correct* link — relevant
-to #164, where 156 359 products carry a `pim_id` but only 465 have categories.
+**One cache key, deliberately.** `pim_no_match:{pk}` holds the outcome string
+rather than a bare flag, so `get_pim_data_for_product`'s single `cache.delete`
+on the 404-recovery path stays correct and there is no second key to leave
+stale. TTLs differ by reason: `_PIM_SEARCH_ERROR_TTL` = 5 min for an error,
+`_PIM_NO_MATCH_TTL` = 4h for a confirmed absence or an ambiguous match, those
+being conditions of the data rather than of the network (`utils.py:159-160`).
+A legacy bare `True` matches no outcome, so it is dropped and re-searched
+instead of guessed at (`utils.py:205-210`).
 
-**Stale UI copy this produces, not yet fixed:**
+**Both scans raise `PimSearchError` (`utils.py:173`)** when a search went
+unanswered — *after* their writes, so committed progress survives. It is the
+only durable signal there is: `maybe_notify_pim_error` is DEBUG-gated
+(`utils.py:45`) and prod runs under `settings.prod`, so `_PIM_LAST_ERROR_KEY`
+is written and read by nobody there; `TaskRunHistory` (from
+`execute_locked_task`'s `except`, `core/task_runner.py:112-132`) is what
+records it. The return must stay a 2-tuple — `_normalize_updated_count`
+(`core/task_runner.py:14-21`) sums every numeric element, so a third "failed"
+element would silently inflate `updated_count`. Ambiguity does not raise.
+Consequence: `manage.py run_task` in sync mode calls the task function directly
+(`management/commands/run_task.py:81`), so its no-argument form now stops at
+the failing task instead of continuing down the loop.
+
+**The cost of that correctness, in `create_pim_links` only.** Its window is
+`filter(pim_id__isnull=True)[:1000]` under `Meta.ordering = ['id']` — the same
+lowest-1000 unlinked rows every run — and it used to drain because every
+product left the unlinked set: linked, or pushed to PIM and given the id
+`_push_pim_products` wrote back. An unsearchable product now does neither, so
+it would hold a slot and a `time.sleep(delay)` at the head of the window
+forever. No-sku rows are excluded from the queryset itself
+(`utils.py:650-663`); drop that exclusion if a search that works without an sku
+is ever added back. `_SEARCH_AMBIGUOUS` rows have no such containment by
+design — an ambiguous match is a data problem someone has to settle in PIM.
+
+**How it got this way.** `86f3289` collapsed a two-element `searches` list
+(priceManagerId, then sku) to one and dropped its `if product.sku` guard;
+`48c31f8` swapped the entity from `ContributorProduct`/`masterRecordId` to
+`Product`/`id`. Neither touched the prose, so three docstrings outlived their
+code by two commits and were reported as having been read as the real lookup
+path during #164's triage (not visible in that issue's body or comments —
+grepped). The docs-only fix (#172) corrected the prose and documented the three
+edges; this work closed them.
+
+**Testing.** `site` is bound into `utils`'s own namespace (`utils.py:16`), so
+tests patch `main_product_manager.utils.site`, **not** `pim_client.site`.
+`SearchPimIdOutcomeTests` and `PimScanPushGuardTests` (`tests.py:531`, `:657`)
+are the pattern, both under `@override_settings(CACHES=LOCMEM_CACHE)` — the
+outcome cache has to be visible to in-process assertions rather than the
+worker container's shared Redis.
+
+**Stale UI copy this produces, still not fixed:**
 `templates/mainproduct/partials/detail.html:78` tells the user, in Russian,
 "Проверьте соответствие priceManagerId/названия" — but the lookup matches
 `number`/sku only; neither `priceManagerId` nor the product name participates.
-Correct copy needs to name `sku`/`number` and cover the no-sku case. After the
-docstring fix this line is the last surviving `priceManagerId` reference in the
-repo outside `pim_api` itself (grepped, not assumed).
+Correct copy needs to name `sku`/`number` and cover the no-sku case, which is
+now an explicit early return rather than a stray unconstrained query. This line
+is the last surviving `priceManagerId` reference in the repo outside `pim_api`
+itself (grepped, not assumed).
 
 ## The 11 Celery tasks, and one that isn't
 

--- a/price_manager/main_product_manager/tests.py
+++ b/price_manager/main_product_manager/tests.py
@@ -252,3 +252,284 @@ class QueuePimPopulationDispatchTests(TestCase):
                 _queue_pim_population('pim-2')
 
             delay.assert_called_once_with('pim-2')
+
+
+from . import utils as mp_utils
+from .utils import (
+    PimSearchError,
+    _PIM_NO_MATCH_TTL,
+    _PIM_SEARCH_ERROR_TTL,
+    _SEARCH_ABSENT,
+    _SEARCH_AMBIGUOUS,
+    _SEARCH_ERROR,
+    _SEARCH_FOUND,
+    _SEARCH_NO_SKU,
+    _search_pim_id_result,
+    create_pim_links,
+    reindex_pim_ids_batch,
+)
+
+
+def _pim_list(*ids):
+    return {'list': [{'id': pim_id} for pim_id in ids]}
+
+
+class _PimSearchTestCase(TestCase):
+    """Shared fixture for the pim_id search: a supplier plus MainProduct factory.
+
+    _search_pim_id_result caches under pim_no_match:{pk}, so every test here
+    needs the locmem cache rather than the worker container's shared Redis.
+    """
+
+    def setUp(self):
+        cache.clear()
+        self.currency = Currency.objects.get_or_create(name='KZT', value=1)[0]
+        self.supplier = Supplier.objects.create(
+            name='PIM search supplier',
+            currency=self.currency,
+            price_update_rate='',
+            stock_update_rate='',
+            delivery_days_available=1,
+            delivery_days_navailable=2,
+        )
+
+    def product(self, sku='SKU-1', **kwargs):
+        return MainProduct.objects.create(
+            supplier=self.supplier,
+            article=kwargs.pop('article', f'ART-{sku}'),
+            name=kwargs.pop('name', f'Product {sku}'),
+            sku=sku,
+            **kwargs,
+        )
+
+
+@override_settings(CACHES=LOCMEM_CACHE)
+class SearchPimIdOutcomeTests(_PimSearchTestCase):
+    """An empty result from _search_pim_id_result has to say *why* it is empty.
+
+    Only _SEARCH_ABSENT means PIM answered; everything else is "unknown" and
+    must not reach push_missing_pim_products.
+    """
+
+    def test_single_match_returns_the_id(self):
+        product = self.product()
+
+        with patch.object(mp_utils, 'site') as site:
+            site.get.return_value = _pim_list('pim-42')
+            pim_id, outcome = _search_pim_id_result(product)
+
+        self.assertEqual((pim_id, outcome), ('pim-42', _SEARCH_FOUND))
+        self.assertIsNone(cache.get(f'pim_no_match:{product.pk}'))
+
+    def test_empty_result_is_a_confirmed_absence(self):
+        product = self.product()
+
+        with patch.object(mp_utils, 'site') as site:
+            site.get.return_value = _pim_list()
+            pim_id, outcome = _search_pim_id_result(product)
+
+        self.assertIsNone(pim_id)
+        self.assertEqual(outcome, _SEARCH_ABSENT)
+        self.assertEqual(cache.get(f'pim_no_match:{product.pk}'), _SEARCH_ABSENT)
+
+    def test_pim_error_is_not_recorded_as_a_confirmed_absence(self):
+        product = self.product()
+
+        with patch.object(mp_utils, 'site') as site:
+            site.get.side_effect = RuntimeError('PIM down')
+            pim_id, outcome = _search_pim_id_result(product)
+
+        self.assertIsNone(pim_id)
+        self.assertEqual(outcome, _SEARCH_ERROR)
+        self.assertEqual(cache.get(f'pim_no_match:{product.pk}'), _SEARCH_ERROR)
+
+    def test_error_backoff_is_far_shorter_than_the_no_match_ttl(self):
+        # The whole point of defect 1: a PIM outage must cost minutes of
+        # suppressed retries, not the 4 hours a genuine absence gets.
+        product = self.product()
+        self.assertLess(_PIM_SEARCH_ERROR_TTL, _PIM_NO_MATCH_TTL)
+
+        with patch.object(mp_utils, 'site') as site, patch.object(mp_utils, 'cache') as cache_mock:
+            cache_mock.get.return_value = None
+            site.get.side_effect = RuntimeError('PIM down')
+            _search_pim_id_result(product)
+
+        # _record_pim_error writes _PIM_LAST_ERROR_KEY through the same cache,
+        # so assert on this call rather than on the only call.
+        cache_mock.set.assert_any_call(
+            f'pim_no_match:{product.pk}', _SEARCH_ERROR, _PIM_SEARCH_ERROR_TTL
+        )
+
+        with patch.object(mp_utils, 'site') as site, patch.object(mp_utils, 'cache') as cache_mock:
+            cache_mock.get.return_value = None
+            site.get.return_value = _pim_list()
+            _search_pim_id_result(product)
+
+        cache_mock.set.assert_called_once_with(
+            f'pim_no_match:{product.pk}', _SEARCH_ABSENT, _PIM_NO_MATCH_TTL
+        )
+
+    def test_cached_error_does_not_become_an_absence_on_the_next_call(self):
+        product = self.product()
+        cache.set(f'pim_no_match:{product.pk}', _SEARCH_ERROR, _PIM_SEARCH_ERROR_TTL)
+
+        with patch.object(mp_utils, 'site') as site:
+            pim_id, outcome = _search_pim_id_result(product)
+
+        site.get.assert_not_called()
+        self.assertIsNone(pim_id)
+        self.assertEqual(outcome, _SEARCH_ERROR)
+
+    def test_cached_absence_is_still_an_absence_on_the_next_call(self):
+        # The complement of the test above: caching the outcome must not cost
+        # the scans their one legitimate reason to push a product to PIM.
+        product = self.product()
+        cache.set(f'pim_no_match:{product.pk}', _SEARCH_ABSENT, _PIM_NO_MATCH_TTL)
+
+        with patch.object(mp_utils, 'site') as site:
+            pim_id, outcome = _search_pim_id_result(product)
+
+        site.get.assert_not_called()
+        self.assertIsNone(pim_id)
+        self.assertEqual(outcome, _SEARCH_ABSENT)
+
+    def test_a_bare_true_from_an_older_revision_triggers_a_fresh_search(self):
+        product = self.product()
+        cache.set(f'pim_no_match:{product.pk}', True, _PIM_NO_MATCH_TTL)
+
+        with patch.object(mp_utils, 'site') as site:
+            site.get.return_value = _pim_list('pim-7')
+            pim_id, outcome = _search_pim_id_result(product)
+
+        self.assertEqual((pim_id, outcome), ('pim-7', _SEARCH_FOUND))
+
+    def test_ambiguous_like_links_nothing(self):
+        # `like` on number: an sku that is a prefix of other product numbers
+        # matches several. Returning the first would link an arbitrary one.
+        product = self.product(sku='AB-1')
+
+        with patch.object(mp_utils, 'site') as site:
+            site.get.return_value = _pim_list('pim-1', 'pim-2')
+            pim_id, outcome = _search_pim_id_result(product)
+
+        self.assertIsNone(pim_id)
+        self.assertEqual(outcome, _SEARCH_AMBIGUOUS)
+        self.assertEqual(cache.get(f'pim_no_match:{product.pk}'), _SEARCH_AMBIGUOUS)
+
+    def test_product_without_sku_is_never_searched(self):
+        # Where.get() omits the value key when it is None, so the request would
+        # go out as an unconstrained `like` on number and match everything.
+        product = self.product(sku=None, article='NO-SKU')
+
+        with patch.object(mp_utils, 'site') as site:
+            pim_id, outcome = _search_pim_id_result(product)
+
+        site.get.assert_not_called()
+        self.assertIsNone(pim_id)
+        self.assertEqual(outcome, _SEARCH_NO_SKU)
+
+
+@override_settings(CACHES=LOCMEM_CACHE)
+class PimScanPushGuardTests(_PimSearchTestCase):
+    """The scans may only push products PIM actually confirmed it doesn't have.
+
+    push_missing_pim_products creates a new PriceManagerProduct, so pushing on
+    an unanswered search duplicates a product that may already be in PIM.
+    """
+
+    def _site_by_sku(self, responses):
+        """site.get double: maps the `number` filter value to a response/exception."""
+        def get(entity):
+            answer = responses[entity.where[0].value]
+            if isinstance(answer, Exception):
+                raise answer
+            return answer
+        return get
+
+    def test_create_pim_links_pushes_the_absence_but_not_the_failed_search(self):
+        absent = self.product(sku='ABSENT')
+        errored = self.product(sku='ERRORED')
+
+        with patch.object(mp_utils, 'site') as site, \
+                patch.object(mp_utils, 'push_missing_pim_products', return_value=0) as push:
+            site.get.side_effect = self._site_by_sku({
+                'ABSENT': _pim_list(),
+                'ERRORED': RuntimeError('PIM down'),
+            })
+            with self.assertRaises(PimSearchError):
+                create_pim_links(delay=0)
+
+        pushed = [p.pk for call in push.call_args_list for p in call.args[0]]
+        self.assertEqual(pushed, [absent.pk])
+        self.assertNotIn(errored.pk, pushed)
+
+    def test_create_pim_links_keeps_the_links_it_resolved_before_raising(self):
+        linked = self.product(sku='LINKED')
+        errored = self.product(sku='ERRORED')
+
+        with patch.object(mp_utils, 'site') as site, \
+                patch.object(mp_utils, 'push_missing_pim_products', return_value=0):
+            site.get.side_effect = self._site_by_sku({
+                'LINKED': _pim_list('pim-99'),
+                'ERRORED': RuntimeError('PIM down'),
+            })
+            with self.assertRaises(PimSearchError):
+                create_pim_links(delay=0)
+
+        linked.refresh_from_db()
+        errored.refresh_from_db()
+        self.assertEqual(linked.pim_id, 'pim-99')
+        self.assertIsNone(errored.pim_id)
+
+    def test_create_pim_links_succeeds_when_every_search_was_answered(self):
+        self.product(sku='LINKED')
+        self.product(sku='ABSENT')
+
+        with patch.object(mp_utils, 'site') as site, \
+                patch.object(mp_utils, 'push_missing_pim_products', return_value=1) as push:
+            site.get.side_effect = self._site_by_sku({
+                'LINKED': _pim_list('pim-1'),
+                'ABSENT': _pim_list(),
+            })
+            linked, created = create_pim_links(delay=0)
+
+        self.assertEqual((linked, created), (1, 1))
+        self.assertEqual(len(push.call_args_list[-1].args[0]), 1)
+
+    def test_create_pim_links_skips_products_with_no_sku_entirely(self):
+        # They cannot be searched and must not be pushed (the PIM record would
+        # carry number=''), so they must not consume a slot in the 1000-row
+        # window either.
+        searchable = self.product(sku='SEARCHABLE')
+        self.product(sku=None, article='NO-SKU')
+
+        with patch.object(mp_utils, 'site') as site, \
+                patch.object(mp_utils, 'push_missing_pim_products', return_value=0) as push:
+            site.get.side_effect = self._site_by_sku({'SEARCHABLE': _pim_list('pim-5')})
+            linked, created = create_pim_links(delay=0)
+
+        searchable.refresh_from_db()
+        self.assertEqual((linked, created), (1, 0))
+        self.assertEqual(searchable.pim_id, 'pim-5')
+        self.assertEqual(push.call_args.args[0], [])
+
+    def test_reindex_batch_raises_and_leaves_the_errored_product_alone(self):
+        linked = self.product(sku='LINKED', pim_id='pim-old')
+        errored = self.product(sku='ERRORED', pim_id='pim-keep')
+        unlinked = self.product(sku='ERRORED-NEW')
+
+        with patch.object(mp_utils, 'site') as site, \
+                patch.object(mp_utils, 'push_missing_pim_products', return_value=0) as push:
+            site.get.side_effect = self._site_by_sku({
+                'LINKED': _pim_list('pim-new'),
+                'ERRORED': RuntimeError('PIM down'),
+                'ERRORED-NEW': RuntimeError('PIM down'),
+            })
+            with self.assertRaises(PimSearchError):
+                reindex_pim_ids_batch([linked.pk, errored.pk, unlinked.pk], delay=0)
+
+        linked.refresh_from_db()
+        errored.refresh_from_db()
+        self.assertEqual(linked.pim_id, 'pim-new')
+        self.assertEqual(errored.pim_id, 'pim-keep')
+        self.assertEqual(push.call_args.args[0], [])

--- a/price_manager/main_product_manager/tests.py
+++ b/price_manager/main_product_manager/tests.py
@@ -476,3 +476,284 @@ class GetFileUrlTests(TestCase):
             site.get.side_effect = RuntimeError('PIM down')
 
             self.assertIsNone(get_file_url('file-1'))
+
+
+from . import utils as mp_utils
+from .utils import (
+    PimSearchError,
+    _PIM_NO_MATCH_TTL,
+    _PIM_SEARCH_ERROR_TTL,
+    _SEARCH_ABSENT,
+    _SEARCH_AMBIGUOUS,
+    _SEARCH_ERROR,
+    _SEARCH_FOUND,
+    _SEARCH_NO_SKU,
+    _search_pim_id_result,
+    create_pim_links,
+    reindex_pim_ids_batch,
+)
+
+
+def _pim_list(*ids):
+    return {'list': [{'id': pim_id} for pim_id in ids]}
+
+
+class _PimSearchTestCase(TestCase):
+    """Shared fixture for the pim_id search: a supplier plus MainProduct factory.
+
+    _search_pim_id_result caches under pim_no_match:{pk}, so every test here
+    needs the locmem cache rather than the worker container's shared Redis.
+    """
+
+    def setUp(self):
+        cache.clear()
+        self.currency = Currency.objects.get_or_create(name='KZT', value=1)[0]
+        self.supplier = Supplier.objects.create(
+            name='PIM search supplier',
+            currency=self.currency,
+            price_update_rate='',
+            stock_update_rate='',
+            delivery_days_available=1,
+            delivery_days_navailable=2,
+        )
+
+    def product(self, sku='SKU-1', **kwargs):
+        return MainProduct.objects.create(
+            supplier=self.supplier,
+            article=kwargs.pop('article', f'ART-{sku}'),
+            name=kwargs.pop('name', f'Product {sku}'),
+            sku=sku,
+            **kwargs,
+        )
+
+
+@override_settings(CACHES=LOCMEM_CACHE)
+class SearchPimIdOutcomeTests(_PimSearchTestCase):
+    """An empty result from _search_pim_id_result has to say *why* it is empty.
+
+    Only _SEARCH_ABSENT means PIM answered; everything else is "unknown" and
+    must not reach push_missing_pim_products.
+    """
+
+    def test_single_match_returns_the_id(self):
+        product = self.product()
+
+        with patch.object(mp_utils, 'site') as site:
+            site.get.return_value = _pim_list('pim-42')
+            pim_id, outcome = _search_pim_id_result(product)
+
+        self.assertEqual((pim_id, outcome), ('pim-42', _SEARCH_FOUND))
+        self.assertIsNone(cache.get(f'pim_no_match:{product.pk}'))
+
+    def test_empty_result_is_a_confirmed_absence(self):
+        product = self.product()
+
+        with patch.object(mp_utils, 'site') as site:
+            site.get.return_value = _pim_list()
+            pim_id, outcome = _search_pim_id_result(product)
+
+        self.assertIsNone(pim_id)
+        self.assertEqual(outcome, _SEARCH_ABSENT)
+        self.assertEqual(cache.get(f'pim_no_match:{product.pk}'), _SEARCH_ABSENT)
+
+    def test_pim_error_is_not_recorded_as_a_confirmed_absence(self):
+        product = self.product()
+
+        with patch.object(mp_utils, 'site') as site:
+            site.get.side_effect = RuntimeError('PIM down')
+            pim_id, outcome = _search_pim_id_result(product)
+
+        self.assertIsNone(pim_id)
+        self.assertEqual(outcome, _SEARCH_ERROR)
+        self.assertEqual(cache.get(f'pim_no_match:{product.pk}'), _SEARCH_ERROR)
+
+    def test_error_backoff_is_far_shorter_than_the_no_match_ttl(self):
+        # The whole point of defect 1: a PIM outage must cost minutes of
+        # suppressed retries, not the 4 hours a genuine absence gets.
+        product = self.product()
+        self.assertLess(_PIM_SEARCH_ERROR_TTL, _PIM_NO_MATCH_TTL)
+
+        with patch.object(mp_utils, 'site') as site, patch.object(mp_utils, 'cache') as cache_mock:
+            cache_mock.get.return_value = None
+            site.get.side_effect = RuntimeError('PIM down')
+            _search_pim_id_result(product)
+
+        # _record_pim_error writes _PIM_LAST_ERROR_KEY through the same cache,
+        # so assert on this call rather than on the only call.
+        cache_mock.set.assert_any_call(
+            f'pim_no_match:{product.pk}', _SEARCH_ERROR, _PIM_SEARCH_ERROR_TTL
+        )
+
+        with patch.object(mp_utils, 'site') as site, patch.object(mp_utils, 'cache') as cache_mock:
+            cache_mock.get.return_value = None
+            site.get.return_value = _pim_list()
+            _search_pim_id_result(product)
+
+        cache_mock.set.assert_called_once_with(
+            f'pim_no_match:{product.pk}', _SEARCH_ABSENT, _PIM_NO_MATCH_TTL
+        )
+
+    def test_cached_error_does_not_become_an_absence_on_the_next_call(self):
+        product = self.product()
+        cache.set(f'pim_no_match:{product.pk}', _SEARCH_ERROR, _PIM_SEARCH_ERROR_TTL)
+
+        with patch.object(mp_utils, 'site') as site:
+            pim_id, outcome = _search_pim_id_result(product)
+
+        site.get.assert_not_called()
+        self.assertIsNone(pim_id)
+        self.assertEqual(outcome, _SEARCH_ERROR)
+
+    def test_cached_absence_is_still_an_absence_on_the_next_call(self):
+        # The complement of the test above: caching the outcome must not cost
+        # the scans their one legitimate reason to push a product to PIM.
+        product = self.product()
+        cache.set(f'pim_no_match:{product.pk}', _SEARCH_ABSENT, _PIM_NO_MATCH_TTL)
+
+        with patch.object(mp_utils, 'site') as site:
+            pim_id, outcome = _search_pim_id_result(product)
+
+        site.get.assert_not_called()
+        self.assertIsNone(pim_id)
+        self.assertEqual(outcome, _SEARCH_ABSENT)
+
+    def test_a_bare_true_from_an_older_revision_triggers_a_fresh_search(self):
+        product = self.product()
+        cache.set(f'pim_no_match:{product.pk}', True, _PIM_NO_MATCH_TTL)
+
+        with patch.object(mp_utils, 'site') as site:
+            site.get.return_value = _pim_list('pim-7')
+            pim_id, outcome = _search_pim_id_result(product)
+
+        self.assertEqual((pim_id, outcome), ('pim-7', _SEARCH_FOUND))
+
+    def test_ambiguous_like_links_nothing(self):
+        # `like` on number: an sku that is a prefix of other product numbers
+        # matches several. Returning the first would link an arbitrary one.
+        product = self.product(sku='AB-1')
+
+        with patch.object(mp_utils, 'site') as site:
+            site.get.return_value = _pim_list('pim-1', 'pim-2')
+            pim_id, outcome = _search_pim_id_result(product)
+
+        self.assertIsNone(pim_id)
+        self.assertEqual(outcome, _SEARCH_AMBIGUOUS)
+        self.assertEqual(cache.get(f'pim_no_match:{product.pk}'), _SEARCH_AMBIGUOUS)
+
+    def test_product_without_sku_is_never_searched(self):
+        # Where.get() omits the value key when it is None, so the request would
+        # go out as an unconstrained `like` on number and match everything.
+        product = self.product(sku=None, article='NO-SKU')
+
+        with patch.object(mp_utils, 'site') as site:
+            pim_id, outcome = _search_pim_id_result(product)
+
+        site.get.assert_not_called()
+        self.assertIsNone(pim_id)
+        self.assertEqual(outcome, _SEARCH_NO_SKU)
+
+
+@override_settings(CACHES=LOCMEM_CACHE)
+class PimScanPushGuardTests(_PimSearchTestCase):
+    """The scans may only push products PIM actually confirmed it doesn't have.
+
+    push_missing_pim_products creates a new PriceManagerProduct, so pushing on
+    an unanswered search duplicates a product that may already be in PIM.
+    """
+
+    def _site_by_sku(self, responses):
+        """site.get double: maps the `number` filter value to a response/exception."""
+        def get(entity):
+            answer = responses[entity.where[0].value]
+            if isinstance(answer, Exception):
+                raise answer
+            return answer
+        return get
+
+    def test_create_pim_links_pushes_the_absence_but_not_the_failed_search(self):
+        absent = self.product(sku='ABSENT')
+        errored = self.product(sku='ERRORED')
+
+        with patch.object(mp_utils, 'site') as site, \
+                patch.object(mp_utils, 'push_missing_pim_products', return_value=0) as push:
+            site.get.side_effect = self._site_by_sku({
+                'ABSENT': _pim_list(),
+                'ERRORED': RuntimeError('PIM down'),
+            })
+            with self.assertRaises(PimSearchError):
+                create_pim_links(delay=0)
+
+        pushed = [p.pk for call in push.call_args_list for p in call.args[0]]
+        self.assertEqual(pushed, [absent.pk])
+        self.assertNotIn(errored.pk, pushed)
+
+    def test_create_pim_links_keeps_the_links_it_resolved_before_raising(self):
+        linked = self.product(sku='LINKED')
+        errored = self.product(sku='ERRORED')
+
+        with patch.object(mp_utils, 'site') as site, \
+                patch.object(mp_utils, 'push_missing_pim_products', return_value=0):
+            site.get.side_effect = self._site_by_sku({
+                'LINKED': _pim_list('pim-99'),
+                'ERRORED': RuntimeError('PIM down'),
+            })
+            with self.assertRaises(PimSearchError):
+                create_pim_links(delay=0)
+
+        linked.refresh_from_db()
+        errored.refresh_from_db()
+        self.assertEqual(linked.pim_id, 'pim-99')
+        self.assertIsNone(errored.pim_id)
+
+    def test_create_pim_links_succeeds_when_every_search_was_answered(self):
+        self.product(sku='LINKED')
+        self.product(sku='ABSENT')
+
+        with patch.object(mp_utils, 'site') as site, \
+                patch.object(mp_utils, 'push_missing_pim_products', return_value=1) as push:
+            site.get.side_effect = self._site_by_sku({
+                'LINKED': _pim_list('pim-1'),
+                'ABSENT': _pim_list(),
+            })
+            linked, created = create_pim_links(delay=0)
+
+        self.assertEqual((linked, created), (1, 1))
+        self.assertEqual(len(push.call_args_list[-1].args[0]), 1)
+
+    def test_create_pim_links_skips_products_with_no_sku_entirely(self):
+        # They cannot be searched and must not be pushed (the PIM record would
+        # carry number=''), so they must not consume a slot in the 1000-row
+        # window either.
+        searchable = self.product(sku='SEARCHABLE')
+        self.product(sku=None, article='NO-SKU')
+
+        with patch.object(mp_utils, 'site') as site, \
+                patch.object(mp_utils, 'push_missing_pim_products', return_value=0) as push:
+            site.get.side_effect = self._site_by_sku({'SEARCHABLE': _pim_list('pim-5')})
+            linked, created = create_pim_links(delay=0)
+
+        searchable.refresh_from_db()
+        self.assertEqual((linked, created), (1, 0))
+        self.assertEqual(searchable.pim_id, 'pim-5')
+        self.assertEqual(push.call_args.args[0], [])
+
+    def test_reindex_batch_raises_and_leaves_the_errored_product_alone(self):
+        linked = self.product(sku='LINKED', pim_id='pim-old')
+        errored = self.product(sku='ERRORED', pim_id='pim-keep')
+        unlinked = self.product(sku='ERRORED-NEW')
+
+        with patch.object(mp_utils, 'site') as site, \
+                patch.object(mp_utils, 'push_missing_pim_products', return_value=0) as push:
+            site.get.side_effect = self._site_by_sku({
+                'LINKED': _pim_list('pim-new'),
+                'ERRORED': RuntimeError('PIM down'),
+                'ERRORED-NEW': RuntimeError('PIM down'),
+            })
+            with self.assertRaises(PimSearchError):
+                reindex_pim_ids_batch([linked.pk, errored.pk, unlinked.pk], delay=0)
+
+        linked.refresh_from_db()
+        errored.refresh_from_db()
+        self.assertEqual(linked.pim_id, 'pim-new')
+        self.assertEqual(errored.pim_id, 'pim-keep')
+        self.assertEqual(push.call_args.args[0], [])

--- a/price_manager/main_product_manager/utils.py
+++ b/price_manager/main_product_manager/utils.py
@@ -69,9 +69,9 @@ def _fetch_pim_product(pim_id: str) -> tuple[dict | None, bool]:
     """GET a PIM `Product` by id straight from the API (no cache).
 
     pim_id is a PIM `Product` id — either one already stored on the MainProduct,
-    or one _search_pim_id found by matching sku against `Product.number`. It is
-    not a `ContributorProduct` id, which is why a single pim_id legitimately
-    spans several MainProducts (see sync_pim_relations).
+    or one _search_pim_id_result found by matching sku against `Product.number`.
+    It is not a `ContributorProduct` id, which is why a single pim_id
+    legitimately spans several MainProducts (see sync_pim_relations).
 
     Returns (data, not_found) — not_found is True only on an explicit 404,
     so callers can tell "PIM deleted/renumbered this id" apart from a
@@ -209,38 +209,8 @@ def _search_pim_id_result(product) -> tuple[str | None, str]:
         # drop it and search again rather than guess which one it meant.
         cache.delete(cache_key)
 
-def _search_pim_id(product) -> str | None:
-    """Resolve a MainProduct's pim_id by matching its sku against PIM `Product.number`.
-
-    One request: a `like` search on `Product.number` for `product.sku`, taking
-    the first id in the response. The `Product` is queried directly — there is
-    no `ContributorProduct` lookup and no `masterRecordId` hop, and
-    `priceManagerId` is not consulted.
-
-    Three things the code does not check, all of them current behaviour:
-
-    - **First match wins.** `like` can match several Products; nothing counts
-      or disambiguates them, so an sku that is a prefix of others links to
-      whichever PIM happens to return first.
-    - **`sku` is nullable** (`models.py:50-53`), and `Where` omits `value` from
-      the query string entirely when it is None (`pim_api/__init__.py:24-25`).
-      A product with no sku is therefore not skipped — it sends an
-      *unconstrained* `like` filter on `number`. What PIM returns for that is
-      not knowable from this repo.
-    - **An API error is indistinguishable from a miss.** The `except` records
-      the error and falls through to the no-match cache below, so a PIM outage
-      suppresses retries for _PIM_NO_MATCH_TTL exactly as a genuine miss does.
-      A scan interrupted by an outage resumes by skipping the rows the outage
-      hit, without a network call, until the flag expires.
-
-    Throttled by that no-match cache (_PIM_NO_MATCH_TTL) so unmatched products
-    are only retried periodically instead of on every lookup/task run; only
-    get_pim_data_for_product's 404-recovery path clears the flag early.
-    Does not persist the result — callers decide how/when to save it.
-    """
-    no_match_key = f"pim_no_match:{product.pk}"
-    if cache.get(no_match_key):
-        return None
+    if not product.sku:
+        return None, _SEARCH_NO_SKU
 
     t0 = time.monotonic()
     try:
@@ -251,13 +221,28 @@ def _search_pim_id(product) -> str | None:
                 where=[Where(attribute='number', type='like', value=product.sku)],
             )
         )
-        for item in result.get('list', []):
-            product_id = item.get('id')
-            if product_id:
-                return product_id
-        # No match is normal — don't treat as error, just set no-match cache below
     except Exception as exc:
         _record_pim_error("_search_pim_id", exc, int((time.monotonic() - t0) * 1000))
+        cache.set(cache_key, _SEARCH_ERROR, _PIM_SEARCH_ERROR_TTL)
+        return None, _SEARCH_ERROR
+
+    pim_ids = [item.get('id') for item in result.get('list', []) if item.get('id')]
+    if len(pim_ids) == 1:
+        return pim_ids[0], _SEARCH_FOUND
+    if pim_ids:
+        logger.warning(
+            "PIM number=%s matched %s products (MainProduct pk=%s) — linking none",
+            product.sku, len(pim_ids), product.pk,
+        )
+        cache.set(cache_key, _SEARCH_AMBIGUOUS, _PIM_NO_MATCH_TTL)
+        return None, _SEARCH_AMBIGUOUS
+
+    cache.set(cache_key, _SEARCH_ABSENT, _PIM_NO_MATCH_TTL)
+    return None, _SEARCH_ABSENT
+
+
+def _search_pim_id(product) -> str | None:
+    """The resolved id alone, for callers with nothing to decide on a miss.
 
     Anything that *writes* on a miss must call _search_pim_id_result and check
     the outcome instead — see push_missing_pim_products.
@@ -280,8 +265,8 @@ def get_pim_data_for_product(product, refresh: bool = False) -> dict | None:
     If the stored pim_id 404s _PIM_404_THRESHOLD times in a row (deleted/
     renumbered in PIM), get_pim_data clears it from the DB — detected here via
     refresh_from_db — and it's re-resolved by sku before retrying once. The
-    no-match cache is dropped first; without that, _search_pim_id's 4h throttle
-    would short-circuit the re-resolve. This is the only place that clears it.
+    no-match cache is dropped first; without that, the cached outcome would
+    short-circuit the re-resolve. This is the only place that clears it.
     """
     if not product.pim_id:
         _resolve_pim_id(product)

--- a/price_manager/main_product_manager/utils.py
+++ b/price_manager/main_product_manager/utils.py
@@ -1,3 +1,4 @@
+import logging
 import time
 
 import httpx
@@ -18,6 +19,8 @@ from .columns import AVAILABLE_COLUMN_MAP, DEFAULT_VISIBLE_COLUMNS
 from supplier_product_manager.models import SupplierProduct
 from supplier_manager.models import Category, Manufacturer
 from core.task_runner import dispatch_after_commit
+
+logger = logging.getLogger(__name__)
 
 CACHE_TTL = 60 * 60 * 24 * 30  # 30 дней
 PIM_CACHE_TTL = 60 * 60 * 24  # 24 часа
@@ -65,8 +68,8 @@ def maybe_notify_pim_error(user) -> None:
 def _fetch_pim_product(pim_id: str) -> tuple[dict | None, bool]:
     """Fetch a verified PIM `Product` (master record) by id straight from the API (no cache).
 
-    pim_id is the id of the verified/merged PIM `Product`, not a `ContributorProduct` —
-    see _search_pim_id for how it's resolved via ContributorProduct.masterRecordId.
+    pim_id is the id of the verified/merged PIM `Product`, not a `ContributorProduct`
+    — see _search_pim_id_result for how it's resolved from MainProduct.sku.
 
     Returns (data, not_found) — not_found is True only on an explicit 404,
     so callers can tell "PIM deleted/renumbered this id" apart from a
@@ -152,44 +155,95 @@ def get_pim_data(pim_id: str | None, refresh: bool = False) -> dict | None:
 
 
 _PIM_NO_MATCH_TTL = 60 * 60 * 4  # 4 hours — avoid hammering PIM for unlinked products
+_PIM_SEARCH_ERROR_TTL = 60 * 5  # 5 minutes — backoff after a search PIM never answered
 _PIM_POPULATE_QUEUED_TTL = 60 * 10  # throttle for the cache-miss population trigger
+
+# Outcomes of one _search_pim_id_result() call. The middle three double as the
+# values cached under pim_no_match:{pk}, so the cached shortcut still tells the
+# caller *why* the previous search came back empty.
+_SEARCH_FOUND = "found"
+_SEARCH_ABSENT = "absent"
+_SEARCH_AMBIGUOUS = "ambiguous"
+_SEARCH_ERROR = "error"
+_SEARCH_NO_SKU = "no_sku"
+
+
+class PimSearchError(RuntimeError):
+    """A catalog scan ended with PIM searches that never got an answer."""
+
+
+def _search_pim_id_result(product) -> tuple[str | None, str]:
+    """Resolve a MainProduct's pim_id in PIM — returns (pim_id, outcome).
+
+    The search is one `like` on the PIM `Product` attribute `number`, matched
+    against `product.sku`. `outcome` is one of the _SEARCH_* constants, and
+    callers must not collapse it back to "found or not": only _SEARCH_ABSENT
+    means PIM was reached and answered that it holds no such product. The other
+    three misses all mean "unknown", and treating one of them as an absence is
+    what makes push_missing_pim_products create a second PIM record for a
+    product that may already be in there:
+
+    - _SEARCH_ERROR — the request failed, so nothing was learned.
+    - _SEARCH_AMBIGUOUS — `like` matched several products, so no single one is
+      *the* match. Returning the first (as this used to) links the product to
+      whichever one PIM happened to list first.
+    - _SEARCH_NO_SKU — no sku to search by, so PIM is never asked. Where.get()
+      drops the value key when it is None (pim_api/__init__.py:24-25), so the
+      request would otherwise go out as an unconstrained `like` on `number`.
+
+    Misses are throttled through one cache key, pim_no_match:{pk}, holding the
+    outcome that wrote it: a confirmed absence and an ambiguous match are
+    conditions of the data and hold for _PIM_NO_MATCH_TTL, while an error holds
+    only for _PIM_SEARCH_ERROR_TTL — a PIM outage costs minutes of suppressed
+    retries, not hours. Does not persist the id — callers decide how/when to
+    save it.
+    """
+    cache_key = f"pim_no_match:{product.pk}"
+    cached = cache.get(cache_key)
+    if isinstance(cached, str):
+        return None, cached
+    if cached is not None:
+        # A bare True written by an older revision: it recorded no outcome, so
+        # drop it and search again rather than guess which one it meant.
+        cache.delete(cache_key)
+
+    if not product.sku:
+        return None, _SEARCH_NO_SKU
+
+    t0 = time.monotonic()
+    try:
+        result = site.get(EntityList(
+            name='Product',
+            select=['id'],
+            where=[Where(attribute='number', type='like', value=product.sku)],
+        ))
+    except Exception as exc:
+        _record_pim_error("_search_pim_id", exc, int((time.monotonic() - t0) * 1000))
+        cache.set(cache_key, _SEARCH_ERROR, _PIM_SEARCH_ERROR_TTL)
+        return None, _SEARCH_ERROR
+
+    pim_ids = [item.get('id') for item in result.get('list', []) if item.get('id')]
+    if len(pim_ids) == 1:
+        return pim_ids[0], _SEARCH_FOUND
+    if pim_ids:
+        logger.warning(
+            "PIM number=%s matched %s products (MainProduct pk=%s) — linking none",
+            product.sku, len(pim_ids), product.pk,
+        )
+        cache.set(cache_key, _SEARCH_AMBIGUOUS, _PIM_NO_MATCH_TTL)
+        return None, _SEARCH_AMBIGUOUS
+
+    cache.set(cache_key, _SEARCH_ABSENT, _PIM_NO_MATCH_TTL)
+    return None, _SEARCH_ABSENT
 
 
 def _search_pim_id(product) -> str | None:
-    """Resolve a MainProduct's pim_id: the verified PIM `Product` (master record) id.
+    """The resolved id alone, for callers with nothing to decide on a miss.
 
-    A product isn't directly linked to a `Product` — it's found by searching
-    `ContributorProduct` (by priceManagerId, then by sku/number) and reading its
-    `masterRecordId`, which points at the merged/verified `Product`. A
-    ContributorProduct without a masterRecordId yet (not verified in PIM) counts
-    as no match.
-
-    Throttled by a no-match cache (_PIM_NO_MATCH_TTL) so unmatched products
-    are only retried periodically instead of on every lookup/task run.
-    Does not persist the result — callers decide how/when to save it.
+    Anything that *writes* on a miss must call _search_pim_id_result and check
+    the outcome instead — see push_missing_pim_products.
     """
-    no_match_key = f"pim_no_match:{product.pk}"
-    if cache.get(no_match_key):
-        return None
-
-    searches = [Where(attribute='number', type='like', value=product.sku)]
-
-    for where in searches:
-        t0 = time.monotonic()
-        try:
-            result = site.get(
-                EntityList(name='Product', select=['id'], where=[where])
-            )
-            for item in result.get('list', []):
-                product_id = item.get('id')
-                if product_id:
-                    return product_id
-            # No match is normal — don't treat as error, just set no-match cache below
-        except Exception as exc:
-            _record_pim_error("_search_pim_id", exc, int((time.monotonic() - t0) * 1000))
-
-    cache.set(no_match_key, True, _PIM_NO_MATCH_TTL)
-    return None
+    return _search_pim_id_result(product)[0]
 
 
 def _resolve_pim_id(product) -> str | None:
@@ -206,8 +260,7 @@ def get_pim_data_for_product(product, refresh: bool = False) -> dict | None:
 
     If the stored pim_id 404s _PIM_404_THRESHOLD times in a row (deleted/
     renumbered in PIM), get_pim_data clears it from the DB — detected here via
-    refresh_from_db — and it's re-resolved by priceManagerId/sku before
-    retrying once.
+    refresh_from_db — and it's re-resolved from sku before retrying once.
     """
     if not product.pim_id:
         _resolve_pim_id(product)
@@ -515,10 +568,12 @@ def push_supplier_products_to_pim(supplier_products, batch_size: int = 1000, del
 def push_missing_pim_products(products, batch_size: int = 1000, delay: float = 0.5) -> int:
     """Bulk-create MainProducts with no PIM match as PriceManagerProduct records.
 
-    Callers must pass only products already confirmed absent from PIM
-    (pim_id is None and _search_pim_id just found nothing) — this doesn't
-    re-check, so a transient search miss on an already-linked product won't
-    silently create a duplicate PIM record for it.
+    Callers must pass only products already confirmed absent from PIM —
+    pim_id is None and _search_pim_id_result just came back _SEARCH_ABSENT.
+    This doesn't re-check, so every other empty outcome (a failed request, an
+    ambiguous `like`, a product with no sku to search by) must be filtered out
+    by the caller: PIM cannot confirm an absence it was never asked about, and
+    pushing on one creates a duplicate record for a product already in there.
     """
     return _push_pim_products(
         list(products),
@@ -529,29 +584,57 @@ def push_missing_pim_products(products, batch_size: int = 1000, delay: float = 0
 
 
 def create_pim_links(delay: float = 0.5, batch_size: int = 1000) -> tuple[int, int]:
-    products = list(MainProduct.objects.filter(pim_id__isnull=True)[:1000])
+    # The window is the first 1000 unlinked products in pk order (Meta.ordering
+    # = ['id']), so it is the same rows every run until they leave the unlinked
+    # set. A product with no sku never can: _search_pim_id_result returns
+    # _SEARCH_NO_SKU without asking PIM, and it must not be pushed either
+    # (_pim_product_payload would create a PIM record with number=''). Excluded
+    # here so it doesn't hold a slot — and a delay — against products the scan
+    # can still resolve. Drop the exclusion if a search that works without an
+    # sku is ever added back.
+    products = list(
+        MainProduct.objects
+        .filter(pim_id__isnull=True)
+        .exclude(sku__isnull=True)
+        .exclude(sku='')[:1000]
+    )
     result = []
     missing = []
     created = 0
+    unanswered = 0
     for product in products:
-        pim_id = _search_pim_id(product)
+        pim_id, outcome = _search_pim_id_result(product)
         if pim_id:
             product.pim_id = pim_id
             result.append(product)
-        else:
+        elif outcome == _SEARCH_ABSENT:
+            # Only a confirmed absence may be pushed as a new PIM record; an
+            # error or an ambiguous match leaves the product for a later run.
             missing.append(product)
             if len(missing) >= batch_size:
                 created += push_missing_pim_products(missing, batch_size=batch_size, delay=delay)
                 missing = []
+        elif outcome == _SEARCH_ERROR:
+            unanswered += 1
         time.sleep(delay)
     # Runs with no transaction held (create_pim_links_task passes atomic=False),
     # so each write below commits on its own rather than idling a transaction
     # open across the PIM calls above. Safe to resume after a partial run: this
     # only ever fills pim_id__isnull=True, so committed rows are simply skipped
-    # next time.
+    # next time, and a row skipped over a PIM error is retried once its
+    # _PIM_SEARCH_ERROR_TTL backoff expires.
     if result:
         MainProduct.objects.bulk_update(result, fields=['pim_id'])
     created += push_missing_pim_products(missing, batch_size=batch_size, delay=delay)
+    if unanswered:
+        # Raised after the writes, so the progress above stays committed. The
+        # run is recorded as an error instead of a success over a dead PIM:
+        # TaskRunHistory is the only durable signal, maybe_notify_pim_error
+        # being DEBUG-gated and prod running under settings.prod.
+        raise PimSearchError(
+            f'PIM не ответил на поиск по {unanswered} из {len(products)} товаров: '
+            f'связано {len(result)}, создано в PIM {created}'
+        )
     return len(result), created
 
 
@@ -588,23 +671,35 @@ def reindex_pim_ids_batch(pks: list[int], delay: float = 0.5, batch_size: int = 
     products = MainProduct.objects.filter(pk__in=pks).order_by('pk')
     result = []
     missing = []
+    unanswered = 0
     for product in products:
-        pim_id = _search_pim_id(product)
+        pim_id, outcome = _search_pim_id_result(product)
         if pim_id:
             if pim_id != product.pim_id:
                 product.pim_id = pim_id
                 result.append(product)
-        elif product.pim_id is None:
+        elif outcome == _SEARCH_ABSENT and product.pim_id is None:
+            # As in create_pim_links: only a confirmed absence gets pushed.
             missing.append(product)
+        elif outcome == _SEARCH_ERROR:
+            unanswered += 1
         time.sleep(delay)
     # Runs with no transaction held (reindex_pim_ids_batch_task passes
     # atomic=False), so each write below commits on its own rather than idling
     # a transaction open across the PIM calls above. Safe to resume after a
-    # partial run: re-searching is idempotent and only a changed pim_id is
-    # written back.
+    # partial run: re-searching is idempotent, only a changed pim_id is written
+    # back, and a row skipped over a PIM error is retried once its
+    # _PIM_SEARCH_ERROR_TTL backoff expires.
     if result:
         MainProduct.objects.bulk_update(result, fields=['pim_id'])
     created = push_missing_pim_products(missing, batch_size=batch_size, delay=delay)
+    if unanswered:
+        # See create_pim_links: raised after the writes so committed progress
+        # survives, and the batch is recorded as an error, not a success.
+        raise PimSearchError(
+            f'PIM не ответил на поиск по {unanswered} из {len(pks)} товаров партии: '
+            f'связано {len(result)}, создано в PIM {created}'
+        )
     return len(result), created
 
 


### PR DESCRIPTION
Относится к #164 — не закрывает его, но убирает одну из причин, по которой `pim_id` у товара может быть неверным.

**Продолжение #172.** Тот PR был docs-only: он привёл в соответствие с кодом три докстринга и заодно задокументировал три края, которые код не проверяет. Здесь эти три края закрываются.

## Что было

`_search_pim_id` возвращал `None` для двух разных состояний: PIM ответил «такого товара нет» и PIM не ответил вообще. `except` записывал ошибку и проваливался в тот же `cache.set(no_match_key, True, _PIM_NO_MATCH_TTL)`, что и честный промах.

Про 4 часа подавленных повторов — это мягкая половина. Ранний `return` в начале функции потом пропускал ровно эти строки без единого сетевого вызова, пока флаг не истечёт, — то есть комментарии «safe to resume after a partial run» у обоих `atomic=False` проходов обещали то, чего не было.

**Жёсткая половина — это запись.** Оба прохода отдают свои промахи в `push_missing_pim_products`, чей собственный докстринг требует товаров «already confirmed absent from PIM», — а она **создаёт в PIM новый `PriceManagerProduct`**. У `create_pim_links` построчной проверки не было вовсе, у `reindex_pim_ids_batch` была `product.pim_id is None` — она спасает уже связанные строки, но не несвязанные. Значит, недоступность PIM посреди прохода не просто останавливала работу: она заводила дубль в PIM на каждый несвязанный товар, которого проход коснулся.

Второй дефект в той же функции: поиск — один `like` по `number`, а цикл возвращал первый непустой `id` без проверки количества. Артикул, являющийся префиксом чужих номеров, связывался с тем `Product`, который PIM вернул первым. Для #164 это существенно: непустой `pim_id` сам по себе никогда не был доказательством *правильной* связи.

И `sku` nullable (`models.py:50-53`), а `Where.get()` при `value=None` вообще выбрасывает ключ `value` из запроса (`pim_api/__init__.py:24-25`) — товар без артикула не пропускался, он уходил в PIM **фильтром без ограничения** по `number`. Вместе с «побеждает первый» это могло связать его с произвольным `Product`. Коммит `86f3289` убрал этот guard заодно с поиском по `priceManagerId`; возвращён только guard.

## Что стало

Починка — это третье состояние, а не просто «не кешировать при ошибке»: возврат `None` без кеша всё равно не даёт проходам отличить отсутствие от аварии, и запись дубля остаётся.

`_search_pim_id_result(product) -> (pim_id, outcome)` повторяет форму `(data, not_found)` у `_fetch_pim_product` из того же файла. В PIM можно отдать только `_SEARCH_ABSENT`; `_SEARCH_ERROR`, `_SEARCH_AMBIGUOUS` и `_SEARCH_NO_SKU` все означают «неизвестно». `_search_pim_id` остался тонкой обёрткой для `_resolve_pim_id`, которому на промахе решать нечего.

Ключ кеша по-прежнему **один**, `pim_no_match:{pk}`, но хранит теперь сам outcome, а не `True`. Это сделано намеренно: единственный `cache.delete` в `get_pim_data_for_product` на пути восстановления после 404 остаётся корректным, и нет второго ключа, который можно оставить протухшим. Ошибка живёт `_PIM_SEARCH_ERROR_TTL` (5 минут) вместо 4 часов; неоднозначное совпадение сохраняет 4 часа — это свойство данных, а не сети. Голый `True` от прошлой ревизии не угадывается, а сбрасывается и переискивается.

Оба прохода теперь бросают `PimSearchError`, если какой-то поиск остался без ответа, — **после** `bulk_update` и `push`, так что зафиксированный прогресс переживает исключение. Другого варианта нет: `maybe_notify_pim_error` закрыт условием `DEBUG` (`utils.py:45`), а прод работает под `settings.prod`, поэтому `_PIM_LAST_ERROR_KEY` в проде пишется и не читается никем. `TaskRunHistory` — единственный долговечный сигнал. Возврат остаётся 2-tuple намеренно: `_normalize_updated_count` суммирует все числовые элементы кортежа, так что третий элемент со счётчиком ошибок молча раздул бы `updated_count`. Счётчики ушли в текст исключения. Неоднозначность не роняет прогон — она пишет `logger.warning` с pk и артикулом.

## Что ревьюеру стоит знать

- **Окно `create_pim_links` нуждалось в подстраховке из-за самой починки.** Оно берёт `filter(pim_id__isnull=True)[:1000]` при `Meta.ordering = ['id']` — те же 1000 несвязанных строк каждый запуск — и раньше вычерпывалось, потому что товар уходил из несвязанных в любом случае: либо связался, либо был запушен в PIM и получил `pim_id` обратно. Товар без артикула теперь не делает ни того, ни другого, то есть занимал бы слот и `time.sleep(delay)` в голове окна вечно. Такие строки исключены из самого queryset. У неоднозначных подстраховки нет сознательно: это проблема данных, которую кто-то должен разрешить в PIM, и до дна окна там далеко — по снимку из #164 несвязанных товаров всего 122.
- **Побочный эффект:** `manage.py run_task` в синхронном режиме теперь пробрасывает это исключение, и его форма без аргументов останавливается на упавшей задаче, а не идёт по циклу дальше.
- **Докстринги согласованы с #172, а не переписаны поверх него.** #172 описал `_search_pim_id` по факту тогдашнего кода; здесь код изменился, поэтому докстринг заменён на контракт outcome. Формулировки #172 у `_fetch_pim_product` и `get_pim_data_for_product` сохранены, поправлены только две фразы по факту: резолвер теперь `_search_pim_id_result`, а «4-часовой троттл» в описании 404-восстановления стал «закешированный outcome» — он больше не всегда четырёхчасовой.
- **Не проверено:** что PIM делает с `like` без wildcard — точное совпадение или неявное `%…%`. `PIM_HOST` здесь заглушка. На безопасность починки это не влияет (худший случай — связей *меньше*, но не неверных, а `reindex_pim_ids_batch` при неоднозначности сохраняет существующий `pim_id`), но задаёт границу того, насколько проверка на неоднозначность может сократить связывание из #164.
- **Стало неверным одно утверждение в файле знаний, которое пришло из #172:** секция «three unchecked edges» описывала эти края как текущее поведение. Переписана. Сохранены археология (`86f3289`, `48c31f8`), предупреждение не возвращать версию «товар без sku никогда не свяжется» и не исправленный до сих пор пункт про UI-копию (`detail.html:78` — по-прежнему единственная ссылка на `priceManagerId` вне `pim_api`, проверено grep'ом). Оговорка в секции `atomic=False` про «resume cleanly» тоже переписана: то, о чём она предупреждала, теперь почи́нено.

## Про историю коммитов

Веток три коммита, и средний из них — чужой merge `main` в эту ветку (`fb44a04`), разрешённый неудачно: `utils.py` перестал компилироваться (голова `_search_pim_id_result` обрывалась, следом целиком вставлялся `_search_pim_id` из main, хвост докстринга оставался снаружи литерала), а из `tests.py` и файла знаний пропали правки ветки. CI падал не на тесте, а на импорте — `SyntaxError: invalid character '—' (U+2014)` ещё на шаге «Check for uncommitted migrations». Конфликты там были ожидаемы: обе стороны правили одни и те же докстринги. Неверна была развязка.

`d57c113` доводит слияние: реализация ветки восстановлена целиком, всё, что принёс main (#172 и #173), сохранено. Слияние не переделывалось, force-push не делался.

## Тесты

14 новых — этот путь не был покрыт ничем: PIM-тесты приложения либо патчат уровень view, либо обходят PIM стороной. Патчить нужно `main_product_manager.utils.site`, **не** `pim_client.site`: `site` привязан к собственному пространству имён `utils` (`utils.py:16`).

Ключевой — `test_create_pim_links_pushes_the_absence_but_not_the_failed_search`: упавший поиск не должен доходить до `push_missing_pim_products`. Его дополнение закреплено тоже (закешированный `_SEARCH_ABSENT` дойти обязан) — именно оно ломается, если кто-то позже свернёт outcome обратно в голый флаг.

Локально после доводки: `main_product_manager` + `core` + `blogapp` — 99 тестов, OK; `makemigrations --check --dry-run` — No changes detected. CI на `d57c113` зелёный.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
