### PR TITLE
fix(main_product_manager): прореживание логов удаляло новые строки, не старые

### DIFF
--- a/.claude/knowledge/main_product_manager.md
+++ b/.claude/knowledge/main_product_manager.md
@@ -49,15 +49,14 @@ early return, so a cold cache blocks the request on a PIM HTTP round-trip.
 the queueing.
 
 `prefetch_pim_data` (`utils.py:322`) loops products one at a time, and
-`MainProductTableView.get_context_data` (`views.py:186`) then calls
-`get_file_url` again per entry (`views.py:198`): up to **2N** PIM calls per
-cold page (the main page paginates 5 categories at a time, `views.py:89`,
-each firing its own `hx-trigger="load"` fetch, `tables_bycat.html:53,82`).
-**But calls dedupe by `pim_id`/file id, not by row** — `get_pim_data` caches
-on `pim_product:{pim_id}` (`:136`), `get_file_url` on `pim_file:{file_id}`
-(`:344`) — so real cost is bounded by distinct `pim_id`s on the page.
-`MainProductTable._pim` still reads `pim_map` by `record.pk`
-(`tables.py:230-231`).
+`MainProductTableView.get_context_data` (`views.py:186`) calls `get_file_url`
+again per entry (`views.py:198`). **Calls dedupe by `pim_id`/file id, not by
+row** — `get_pim_data` caches on `pim_product:{pim_id}` (`:136`),
+`get_file_url` on `pim_file:{file_id}` (`:344`) — so real cost per cold page
+is bounded by distinct `pim_id`s on the page, not row count (the main page
+paginates 5 categories at a time, `views.py:89`, each firing its own
+`hx-trigger="load"` fetch, `tables_bycat.html:53,82`). `MainProductTable._pim`
+still reads `pim_map` by `record.pk` (`tables.py:230-231`).
 
 **Rendering this table in a test makes live PIM HTTP calls unless patched.**
 Tests run under `settings.prod` with the placeholder `PIM_TOKEN`/`PIM_HOST`,
@@ -123,13 +122,43 @@ sane limit. Fan-out: `reindex_pim_ids_task` chunks pks via
 `iter_pim_id_pk_batches()` (`utils.py:558`) and queues one
 `reindex_pim_ids_batch_task` per chunk to run in parallel; `task_name` is
 uniquified per chunk (`tasks.py:190`) or they'd all contend on one Redis lock.
-`sync_main_products_task` (`tasks.py:143`) is a 12th function but not a task
-itself — no `@shared_task`, just `chain(...)`-ing the 11 into one
-`apply_async()` workflow (`tasks.py:144`); each link still goes through
-`execute_locked_task` on its own. Easy to confuse: `create_pim_links` only
+`sync_main_products_task` (`tasks.py:138`) is a 12th function but not a task
+itself — no `@shared_task`, just a `chain()` of six of the eleven
+(`rebuild_categories_task` → `recalculate_vectors_missing_task` →
+`update_prices_task` → `update_stocks_task` → `delete_outdated_logs_task` →
+`notify_sync_main_products_task`, `tasks.py:139-146`) run via
+`apply_async()` (`:147`); each link still goes through `execute_locked_task`
+on its own, and log pruning lands as the second-to-last step of every sync,
+not just off the beat schedule. Easy to confuse: `create_pim_links` only
 fills `pim_id__isnull=True`, while `reindex_pim_ids` re-searches PIM for
 **every** product (writing only the ones whose value changed), so
 `skip_non_empty=True` is what narrows it back to unlinked ones.
+
+## The beat schedule silently drops one task, and `lock_ttl` isn't a rate limiter
+
+`price_manager/price_manager/settings/celery.py:38-45`'s `CELERY_BEAT_SCHEDULE`
+dict has two entries under the identical key `'update-logs'` — the later one
+wins, so `main_product_manager.update_logs` is never scheduled, and the
+surviving entry gives `delete_outdated_logs` a bare `schedule: 60` where
+every sibling uses `*_MINUTES * 60`. Flagged, not fixed here —
+deliberately, since it's currently latent: `docker-compose.yml`'s
+`celery_worker` runs `celery -A price_manager worker -l info` with no `-B`,
+so `CELERY_BEAT_SCHEDULE` is never consulted anywhere in this repo's compose
+stack.
+
+**Check before re-fixing:** a fix already exists, unmerged, on
+`claude/zealous-jemison-a8c03e` (commit `e6a8440`) — a distinct
+`'delete-outdated-logs'` key plus two regression tests in `core/tests.py`.
+One reads the source with `ast` rather than `settings.CELERY_BEAT_SCHEDULE`,
+because by import time the duplicate is already gone: the dict just has one
+fewer entry and every surviving key is unique, so the loss is invisible at
+runtime. The other asserts every schedule entry names a registered Celery
+task, catching a misspelled name — the second way a task goes quietly idle.
+
+Don't assume `execute_locked_task`'s `lock_ttl` throttles a task's
+*frequency* either — see [[core]]: `core/task_runner.py:133-134` deletes the
+lock key in a `finally` right after each run, so it's only a crash-recovery
+ceiling, not a rate limit.
 
 ## Price fields and three columns that only look like fields
 
@@ -139,6 +168,19 @@ non-null ones. `kaspi_price` added by
 `migrations/0009_mainproduct_kaspi_price.py`. `product_price_manager` writes
 these — see [[product_price_manager]]. `MainProductLog` (`models.py:182`) is
 the price/stock history row.
+
+**Three writers feed `MainProductLog`, and the dominant one is not the
+name-obvious one.** `utils.update_logs()` (`utils.py:611`) reads like the
+writer, but [[product_price_manager]]'s `PriceManager.apply(logs=True)`
+(`product_price_manager/models.py:302-308`) and `PriceTag.get_mp()`
+(`:426-434`) also insert rows, reached via module-level `update_prices()`
+(`:455`) — which has its own beat entry and is a step in the
+`sync_main_products_task` chain above. `get_mp()` is reached unconditionally
+every run: `update_prices()`'s `get_updated_mps()` helper calls it for every
+`PriceTag` with `p_manager__isnull=True` (three separate calls, `:488,493,498`
+— manual/orphan tags, as opposed to the `PriceManager.apply()` path for
+rule-driven ones). Any change to `MainProductLog` has to account for all
+three call sites, not just the one named after the model.
 
 `supplier_product_price`, `supplier_product_rrp` and
 `supplier_product_discount_price` look like ordinary columns —
@@ -153,6 +195,64 @@ shows `—` for them (`test_grouping.py:237-251`). `kaspi_price` is a genuine
 field but an orphan in the picker: offered at `columns.py:33`, absent from
 `MainProductTable.Meta.fields` (`tables.py:100-127`) — selecting it does
 nothing.
+
+## `MainProductLog` pruning: the slice-direction trap (fixed) and its testing traps
+
+`MainProductLog.Meta.ordering = ['-update_time']` (`models.py:208`), and it
+has no secondary key. **General lesson: on this model a bare slice inherits
+that DESC order** — `[:n]` means newest-`n`, `[n:]` means
+everything-but-the-newest-`n`. `delete_outdated_logs_task` used to prune with
+`MainProductLog.objects.all()[:100000]`, which resolves to
+`ORDER BY update_time DESC LIMIT 100000` — it deleted the **newest** 100k rows
+and kept the oldest, inverting the task's purpose. Caught by printing
+`str(qs.query)`, not by reading the code. The runner is now
+`utils.delete_outdated_logs(keep=100_000)` (`utils.py:648`), which spells the
+order out — `order_by('-update_time', '-id')[keep:]` (`utils.py:663`), an
+*offset* slice — retention-cap semantics: keep the newest `keep`, delete the
+tail. Writing `order_by` explicitly, rather than trusting `Meta.ordering`, is
+the convention here now.
+
+**Why a retention cap, not "delete the oldest 100k".** The obvious-looking
+alternative, `order_by('update_time')[:100000]`, is wrong here: the guard
+threshold and the slice bound are the same number, so a table sitting at
+100,001 rows would collapse to a single surviving row, deleting logs written
+seconds earlier. That threshold-equals-bound shape is itself the evidence a
+retention cap was intended, not an oldest-purge.
+
+**A user-facing reader confirms which end matters.** `MainProductLogList`
+(`views.py:321`), routed `<int:pk>/logs` (`urls.py:23`,
+`mainproductlog-list`), renders one product's full history via
+`MainProductLogTable` (`tables.py:313-326`, `paginate=False`) — pruning
+direction is also this page's data, not just table housekeeping.
+
+**Testing trap — backdating `auto_now_add`.** `update_time` is
+`auto_now_add=True`, not nullable, with no `default=`. Both `Model.save()`
+and `QuerySet.bulk_create()` re-stamp it to `timezone.now()` on insert —
+confirmed by the model's own writers, not by reading Django internals:
+`utils.update_logs()` (`utils.py:642-643`) and `PriceManager.apply()`
+(`product_price_manager/models.py:306-307`) both `bulk_create()`
+`MainProductLog` rows without ever setting `update_time`, into a `NOT NULL`
+column with no column default — an insert that would fail if `bulk_create()`
+skipped the re-stamp. So `create(update_time=...)` and
+`bulk_create([MainProductLog(update_time=...)])` both silently discard an
+explicit value the same way; only `QuerySet.update()` doesn't re-stamp
+(`auto_now_add` fires only on insert). Backdate via
+`MainProductLog.objects.filter(pk=...).update(update_time=stamp)`. No other
+backdating helper exists in the repo, and `freezegun` isn't in
+`requirements.txt` (both grepped). Pattern: `tests.py::DeleteOutdatedLogsTests`
+(`tests.py:264-333`).
+
+**Testing trap — a shared `update_time` makes the tie-break untested by
+default.** `Meta.ordering` has no secondary key, so if two rows share an
+`update_time`, which is "newest" is undefined without `-id`.
+`test_ties_on_update_time_are_broken_deterministically` (`tests.py:318-333`)
+manufactures exactly that — five rows via `.create()`, then one
+`.filter(pk__in=...).update(update_time=stamp)` forcing an identical
+timestamp — and asserts the highest `id` (most recently inserted) survives a
+`keep=3` prune. Verified empirically: dropping `'-id'` from
+`delete_outdated_logs`'s `order_by` makes this test fail. A test backdating
+rows individually must give each a distinct `update_time`, or it collapses
+into this same tie by accident.
 
 ## `pim_id`: indexed since #155, but the index doesn't make grouping cheap
 
@@ -180,16 +280,14 @@ per category plus one for `categories__isnull=True` (the `else` branch at
 index can't serve this sort at all: `grp_key` is
 `Coalesce(NullIf(pim_id, ''), Cast('id', TextField()))` (`grouping.py:50-64`)
 — an expression, not the indexed column — so Postgres sorts every row in the
-bucket regardless. On a restored production snapshot: 156,016 of 156,481
-`MainProduct`s have no category, the largest real category holds 67 rows,
-and all 1,323 duplicated-`pim_id` groups sit in the uncategorised bucket
-(aggregates/counts only, per prod-snapshot rule 3). The window pass costs
-~+6ms on a ~67-row category table versus ~70ms -> ~3s on the ~156k-row
-uncategorised one (merge sort spilling ~107MB to disk); trimming to bare-id
-columns still floors ~1.6s — the partition sort over the whole bucket, not
-the `pim_id` lookup, is what's expensive. **Benchmark grouping changes
-against the uncategorised bucket** — it is effectively the whole catalog,
-and a category table always looks fast.
+bucket regardless. On a restored production snapshot (aggregates only, per
+prod-snapshot rule 3): 156,016 of 156,481 `MainProduct`s have no category,
+and all 1,323 duplicated-`pim_id` groups sit in that uncategorised bucket —
+the window pass costs single-digit milliseconds on a small category table
+but seconds on the ~156k-row uncategorised one, a merge sort spilling
+~107MB to disk (`work_mem`, not CPU, is the bottleneck). **Benchmark
+grouping changes against the uncategorised bucket** — it is effectively the
+whole catalog, and a category table always looks fast.
 
 ## `render_<column>` is silently skipped when the cell value is empty
 
@@ -229,7 +327,7 @@ copies.** `render_stock_msg` (`tables.py:166-186`) now branches on
 guards it — this file's old claim that no renderer had test coverage is
 stale, corrected here. `Supplier.get_delivery_days_for_stock`
 (`supplier_manager/models.py:109-122`) also branches on `stock is None`
-explicitly, though it still returns the same value as the zero case — now a
+explicitly, though it still returns the same value as the zero case — a
 documented, deliberate default, not a silent conflation. Unfixed:
 `core/templates/shopping_tab/includes/stock_badge.html:2,4` still tests
 truthy `product.stock` — see [[core]]; named here, not owned here.

--- a/price_manager/main_product_manager/tasks.py
+++ b/price_manager/main_product_manager/tasks.py
@@ -6,8 +6,8 @@ from django.contrib.auth import get_user_model
 from supplier_manager.models import Category
 from product_price_manager.models import update_prices
 
-from .utils import recalculate_search_vectors, update_logs, update_stocks, create_pim_links, iter_pim_id_pk_batches, reindex_pim_ids_batch, get_pim_data, sync_pim_relations
-from .models import MainProduct, MainProductLog
+from .utils import delete_outdated_logs, recalculate_search_vectors, update_logs, update_stocks, create_pim_links, iter_pim_id_pk_batches, reindex_pim_ids_batch, get_pim_data, sync_pim_relations
+from .models import MainProduct
 
 
 def _build_step_result(payload: dict | None) -> dict:
@@ -82,15 +82,10 @@ def update_logs_task() -> dict:
 
 @shared_task(name="main_product_manager.delete_outdated_logs")
 def delete_outdated_logs_task(stats: dict | None = None) -> dict:
-    def delete_logs():
-        if MainProductLog.objects.count() > 100000:
-            return MainProductLog.objects.filter(id__in=MainProductLog.objects.all()[:100000].values_list('id', flat=True)).delete()[0]
-        return 0
-
     payload  = execute_locked_task(
         task_name="main_product_manager.delete_outdated_logs",
         lock_ttl=60 * 20,
-        runner=delete_logs,
+        runner=delete_outdated_logs,
     )
     return _append_step(stats, "delete_outdated_logs", payload)
 

--- a/price_manager/main_product_manager/tests.py
+++ b/price_manager/main_product_manager/tests.py
@@ -252,3 +252,82 @@ class QueuePimPopulationDispatchTests(TestCase):
                 _queue_pim_population('pim-2')
 
             delay.assert_called_once_with('pim-2')
+
+
+from datetime import timedelta
+
+from django.utils import timezone
+
+from .utils import delete_outdated_logs
+
+
+class DeleteOutdatedLogsTests(TestCase):
+    """delete_outdated_logs must keep the newest `keep` rows and drop the rest.
+
+    MainProductLog.Meta.ordering is ['-update_time'], so a bare `.all()[:keep]`
+    resolves to ORDER BY update_time DESC LIMIT keep — the *newest* rows. The
+    prune used exactly that and deleted the newest logs while keeping the
+    oldest. These tests pin the retention direction, so the fix cannot be
+    undone by dropping the explicit order_by and leaning on Meta.ordering.
+    """
+
+    def setUp(self):
+        self.currency = Currency.objects.get_or_create(name='KZT', value=1)[0]
+        self.supplier = Supplier.objects.create(
+            name='Log prune supplier',
+            currency=self.currency,
+            price_update_rate='',
+            stock_update_rate='',
+            delivery_days_available=1,
+            delivery_days_navailable=2,
+        )
+        self.mp = MainProduct.objects.create(
+            supplier=self.supplier,
+            article='LP-1',
+            name='Log prune product',
+        )
+
+    def _log_at(self, days_ago: int) -> MainProductLog:
+        """Create a log row stamped `days_ago` days in the past.
+
+        update_time is auto_now_add, so it is ignored by create() and has to be
+        overwritten afterwards with .update(), which bypasses save()/pre_save.
+        """
+        log = MainProductLog.objects.create(main_product=self.mp, stock=days_ago)
+        stamp = timezone.now() - timedelta(days=days_ago)
+        MainProductLog.objects.filter(pk=log.pk).update(update_time=stamp)
+        return log
+
+    def test_prunes_the_oldest_rows_and_keeps_the_newest(self):
+        # days_ago 0 is the newest row, 4 the oldest.
+        logs = {days_ago: self._log_at(days_ago) for days_ago in range(5)}
+
+        deleted = delete_outdated_logs(keep=3)
+
+        self.assertEqual(deleted, 2)
+        survivors = set(MainProductLog.objects.values_list('pk', flat=True))
+        self.assertEqual(survivors, {logs[0].pk, logs[1].pk, logs[2].pk})
+
+    def test_does_nothing_while_under_the_cap(self):
+        for days_ago in range(3):
+            self._log_at(days_ago)
+
+        self.assertEqual(delete_outdated_logs(keep=3), 0)
+        self.assertEqual(MainProductLog.objects.count(), 3)
+
+    def test_ties_on_update_time_are_broken_deterministically(self):
+        """A bulk_create batch shares one update_time, so ties are the norm.
+
+        Meta.ordering has no secondary key, so without an explicit tiebreaker
+        the cut between kept and deleted rows falls arbitrarily inside the
+        tied batch. Highest id — the most recently inserted — must win.
+        """
+        logs = [MainProductLog.objects.create(main_product=self.mp, stock=n) for n in range(5)]
+        stamp = timezone.now() - timedelta(days=1)
+        MainProductLog.objects.filter(pk__in=[log.pk for log in logs]).update(update_time=stamp)
+
+        deleted = delete_outdated_logs(keep=3)
+
+        self.assertEqual(deleted, 2)
+        newest_ids = {log.pk for log in sorted(logs, key=lambda log: log.pk)[-3:]}
+        self.assertEqual(set(MainProductLog.objects.values_list('pk', flat=True)), newest_ids)

--- a/price_manager/main_product_manager/utils.py
+++ b/price_manager/main_product_manager/utils.py
@@ -643,3 +643,25 @@ def update_logs():
   mpls = MainProductLog.objects.bulk_create(mpls)
   updated_logs += len(mpls)
   return updated_logs
+
+
+def delete_outdated_logs(keep: int = 100_000) -> int:
+    """Trim the log table down to its newest `keep` rows, returning how many went.
+
+    The order_by is explicit on purpose. MainProductLog.Meta.ordering is
+    ['-update_time'], so a bare `.all()[keep:]` would happen to work here —
+    but relying on Meta.ordering is what produced the original bug, where
+    `.all()[:keep]` resolved to ORDER BY update_time DESC LIMIT keep and
+    deleted the newest rows while keeping the oldest.
+
+    '-id' is a tiebreaker, not decoration: update_logs and PriceManager.apply
+    bulk_create whole batches at one wall-clock instant, so update_time ties
+    are routine and Meta.ordering has no secondary key. Without it the cut
+    between kept and deleted rows falls arbitrarily inside a tied batch.
+    """
+    if MainProductLog.objects.count() > keep:
+        outdated = MainProductLog.objects.order_by('-update_time', '-id')[keep:]
+        return MainProductLog.objects.filter(
+            id__in=outdated.values_list('id', flat=True)
+        ).delete()[0]
+    return 0


### PR DESCRIPTION
## Что было не так

`delete_outdated_logs_task` прореживал `MainProductLog` так:

```python
MainProductLog.objects.filter(
    id__in=MainProductLog.objects.all()[:100000].values_list('id', flat=True)
).delete()
```

`MainProductLog.Meta.ordering = ['-update_time']` (`models.py:208`), поэтому срез разворачивается в:

```sql
ORDER BY "...update_time" DESC LIMIT 100000
```

То есть задача с именем `delete_outdated_logs` удаляла **самые свежие** 100k строк и оставляла самые старые.

Находка пришла из чтения кода (агент `main-product-keeper`, при работе над `update_stocks`) и была непроверенной. Проверено перед правкой печатью `str(qs.query)` — SQL выше настоящий, а не предполагаемый. Отдельно написан падающий тест: он падал с `AssertionError: 3 != 2`, то есть именно потому, что удалялись новые строки.

## Почему «оставить новые», а не «удалить старые»

Очевидная правка — `order_by('update_time')` на внутреннем queryset — исправляет направление, но оставляет более неприятную проблему: **порог в условии и граница срезки — одно и то же число**. На таблице из 100 001 строки такая версия удалит 100 000 и оставит одну, то есть задача «удаления устаревших логов» снесёт логи, записанные секунды назад.

Поэтому семантика здесь — предел хранения: `order_by('-update_time', '-id')[keep:]`, срезка со смещением. Таблица держится на стабильном пределе `keep`. Совпадение порога и границы — само по себе довод в пользу этой трактовки: баг похож на переставленное двоеточие, а не на забытый `order_by`.

Ставки поднимает то, что у этой истории есть читатель в интерфейсе: `MainProductLogList` (`views.py:321`, маршрут `<int:pk>/logs`) отдаёт страницу истории цен и остатков товара, причём `MainProductLogTable` выставляет `paginate=False`.

## Что изменилось

| Файл | Изменение |
|---|---|
| `utils.py` | новая `delete_outdated_logs(keep=100_000)` — сама правка |
| `tasks.py` | замыкание убрано, задача ссылается на раннер; снят неиспользуемый импорт `MainProductLog` |
| `tests.py` | `DeleteOutdatedLogsTests` — 3 теста |
| `.claude/knowledge/main_product_manager.md` | запись находок (отдельный коммит) |

Раннер переехал из замыкания в `utils.py`, к остальным раннерам (`update_stocks`, `update_logs`) — замыкание было единственным исключением. **Это не косметика, а условие тестируемости:** с захардкоженными `100000` и в условии, и в срезке никакая небольшая фикстура порог не перешагнёт. `keep` протянут в оба места — если протянуть только в срезку, тест с `keep=3` молча ничего не сделает и пройдёт.

## На что посмотреть ревьюеру

**`'-id'` — не украшение.** `update_logs` и `PriceManager.apply` пишут через `bulk_create`, то есть целый пакет строк получает один и тот же `update_time`, а вторичного ключа в `Meta.ordering` нет. Без тайбрейкера граница между сохранёнными и удалёнными строками падает внутрь пакета произвольно. Проверено: если убрать `'-id'`, тест `test_ties_on_update_time_are_broken_deterministically` падает.

**Подзапрос с `OFFSET` без `LIMIT`.** `id__in=<qs[keep:]>` даёт внутри подзапроса `OFFSET n` без `LIMIT`. PostgreSQL это принимает, Django не возражает (запрет «filter after slice» касается только `filter`/`exclude`). SQL распечатан и проверен.

**Первый запуск на проде будет большим.** Старый код оставлял именно *старые* строки, поэтому содержимое таблицы сейчас смещено в прошлое: первый запуск после правки удалит всё за пределами новых 100k одной транзакцией (`execute_locked_task` оборачивает раннер в `transaction.atomic()`). Поведение корректное, но объём разовой операции стоит знать заранее.

## Проверка

```
docker compose exec -T celery_worker python manage.py test main_product_manager --keepdb
Ran 55 tests — OK
```

Прогонялось в изолированном стеке (`PROJECT_NAME=pm_epicgates`, порты 8010/5442/6389): запущенные контейнеры монтировали основной чекаут, а не этот worktree, так что прогон в них проверял бы чужой код.

## Рядом, но не здесь

`CELERY_BEAT_SCHEDULE` содержит **две записи под одним ключом** `'update-logs'` (`settings/celery.py:38-45`): позднейшая молча затирает первую, поэтому `update_logs` — задача, которая эти строки *пишет* — вообще не попадает в расписание, а выжившая запись даёт `delete_outdated_logs` голый `schedule: 60` там, где все соседи считают `*_MINUTES * 60`.

Сюда это не вошло намеренно, и **править это не нужно** — исправление уже есть на ветке `claude/zealous-jemison-a8c03e` (коммит `e6a8440`), пока не влитой. Пересечений с этим PR нет: та ветка трогает только `core/tests.py` и `settings/celery.py`. Указатель на неё добавлен в файл знаний, чтобы следующий читатель не переделывал работу заново.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
