### PR TITLE
fix(main_product_manager): поиск по number идёт через equals, а не like

### DIFF
--- a/.claude/knowledge/main_product_manager.md
+++ b/.claude/knowledge/main_product_manager.md
@@ -136,6 +136,12 @@ ever re-checking it. Switching costs nothing — bare `like` never did substring
 matching either (a genuine prefix returns no rows), so `equals` only removes
 the wildcard surface.
 
+Sampled alongside: 2400 consecutive `Product.number` values, **no duplicates**.
+So `_SEARCH_AMBIGUOUS` may be unreachable under `equals` in practice. It is
+kept anyway — the sample is not the whole 36k catalog, nothing checked
+guarantees uniqueness, and the guard costs one `len()`. Don't read a passing
+`test_ambiguous_match_links_nothing` as evidence PIM returns duplicates.
+
 The outcome is one of five (`utils.py:173-177`): `_SEARCH_FOUND`,
 `_SEARCH_ABSENT`, `_SEARCH_AMBIGUOUS`, `_SEARCH_ERROR`, `_SEARCH_NO_SKU`.
 **Only `_SEARCH_ABSENT` means PIM was asked and answered "no such product."**

--- a/.claude/knowledge/main_product_manager.md
+++ b/.claude/knowledge/main_product_manager.md
@@ -114,14 +114,27 @@ workaround in place; the trap is real, not hypothetical, so don't drop
 either without re-deriving why `search_rank` lives as a separate
 `@staticmethod`.
 
-## `_search_pim_id_result`: one `like` on `number`, and why an empty answer has to say *why*
+## `_search_pim_id_result`: one `equals` on `number`, and why an empty answer has to say *why*
 
 `_search_pim_id_result(product) -> tuple[str | None, str]` (`utils.py:184`) is
 the resolver; `_search_pim_id` (`utils.py:251`) is a thin id-only wrapper kept
 for `_resolve_pim_id`, which has nothing to decide on a miss. One round-trip:
-`Where(attribute='number', type='like', value=product.sku)` against
+`Where(attribute='number', type='equals', value=product.sku)` against
 `EntityList(name='Product', select=['id'])` — a direct `Product` search, no
 `ContributorProduct` step, no `masterRecordId`, no `priceManagerId` fallback.
+
+**It must stay `equals`, and this was measured, not reasoned.** AtroPIM passes
+a `like` value straight into a SQL LIKE: against the live API
+`like '2001_-04_z01'` returns the product numbered `20015-04_z01` (so `_` is a
+single-character wildcard) and `like '%'` returns all 36k rows. PIM numbers
+routinely carry `_` — `20015-04_z01`, `20110-8_z02` — and sku is
+supplier-supplied, so under `like` a sku can match a *different* product.
+The `_SEARCH_AMBIGUOUS` guard does not save you there: it only fires on >1
+match, and the dangerous case is exactly one wrong match, which returns
+`_SEARCH_FOUND` and gets written to the DB by `_resolve_pim_id` with nothing
+ever re-checking it. Switching costs nothing — bare `like` never did substring
+matching either (a genuine prefix returns no rows), so `equals` only removes
+the wildcard surface.
 
 The outcome is one of five (`utils.py:173-177`): `_SEARCH_FOUND`,
 `_SEARCH_ABSENT`, `_SEARCH_AMBIGUOUS`, `_SEARCH_ERROR`, `_SEARCH_NO_SKU`.
@@ -136,7 +149,7 @@ the same.
 
 **The three edges this closed.** Until then the search returned the first
 non-empty id with no count check; a no-sku product was not skipped but sent an
-*unconstrained* `like` (`Where.get()` omits the `value` key entirely when it is
+*unconstrained* match (`Where.get()` omits the `value` key entirely when it is
 None, `pim_api/__init__.py:24-25`); and an API error fell through to the same
 `cache.set(no_match_key, True, ...)` as a genuine miss. The last one was the
 severe one, and not for the reason it looks: a PIM outage mid-scan did not just

--- a/price_manager/main_product_manager/tests.py
+++ b/price_manager/main_product_manager/tests.py
@@ -629,9 +629,10 @@ class SearchPimIdOutcomeTests(_PimSearchTestCase):
         self.assertEqual((pim_id, outcome), ('pim-7', _SEARCH_FOUND))
 
     def test_ambiguous_match_links_nothing(self):
-        # Nothing guarantees PIM `number` is unique, so a search can still come
-        # back with several products. Returning the first would link an
-        # arbitrary one.
+        # Kept under `equals`, though it may now be unreachable in practice: a
+        # sample of 2400 consecutive PIM numbers held no duplicates. Nothing
+        # checked *guarantees* `number` is unique, though, and the guard costs
+        # one len() — returning the first of several would link an arbitrary one.
         product = self.product(sku='AB-1')
 
         with patch.object(mp_utils, 'site') as site:

--- a/price_manager/main_product_manager/tests.py
+++ b/price_manager/main_product_manager/tests.py
@@ -628,9 +628,10 @@ class SearchPimIdOutcomeTests(_PimSearchTestCase):
 
         self.assertEqual((pim_id, outcome), ('pim-7', _SEARCH_FOUND))
 
-    def test_ambiguous_like_links_nothing(self):
-        # `like` on number: an sku that is a prefix of other product numbers
-        # matches several. Returning the first would link an arbitrary one.
+    def test_ambiguous_match_links_nothing(self):
+        # Nothing guarantees PIM `number` is unique, so a search can still come
+        # back with several products. Returning the first would link an
+        # arbitrary one.
         product = self.product(sku='AB-1')
 
         with patch.object(mp_utils, 'site') as site:
@@ -641,9 +642,34 @@ class SearchPimIdOutcomeTests(_PimSearchTestCase):
         self.assertEqual(outcome, _SEARCH_AMBIGUOUS)
         self.assertEqual(cache.get(f'pim_no_match:{product.pk}'), _SEARCH_AMBIGUOUS)
 
+    def test_search_uses_equals_so_sku_wildcards_stay_literal(self):
+        """AtroPIM feeds a `like` value straight into SQL LIKE.
+
+        Measured against the live API: `like '2001_-04_z01'` returns the
+        product numbered `20015-04_z01` (so `_` is a single-char wildcard) and
+        `like '%'` returns the whole catalog. PIM numbers routinely carry `_`
+        and sku is supplier-supplied, so under `like` a sku can match a
+        *different* product. When exactly one such match comes back the
+        ambiguity guard never fires and _resolve_pim_id writes the wrong
+        pim_id — silently. `equals` keeps both characters literal.
+        """
+        product = self.product(sku='2001_-04_z01')
+
+        with patch.object(mp_utils, 'site') as site:
+            site.get.return_value = _pim_list('pim-1')
+            _search_pim_id_result(product)
+
+            entity_list = site.get.call_args.args[0]
+
+        self.assertEqual(entity_list.name, 'Product')
+        self.assertEqual(
+            [(w.attribute, w.type, w.value) for w in entity_list.where],
+            [('number', 'equals', '2001_-04_z01')],
+        )
+
     def test_product_without_sku_is_never_searched(self):
         # Where.get() omits the value key when it is None, so the request would
-        # go out as an unconstrained `like` on number and match everything.
+        # go out as an unconstrained match on number and return everything.
         product = self.product(sku=None, article='NO-SKU')
 
         with patch.object(mp_utils, 'site') as site:

--- a/price_manager/main_product_manager/utils.py
+++ b/price_manager/main_product_manager/utils.py
@@ -191,21 +191,30 @@ class PimSearchError(RuntimeError):
 def _search_pim_id_result(product) -> tuple[str | None, str]:
     """Resolve a MainProduct's pim_id in PIM — returns (pim_id, outcome).
 
-    The search is one `like` on the PIM `Product` attribute `number`, matched
-    against `product.sku`. `outcome` is one of the _SEARCH_* constants, and
-    callers must not collapse it back to "found or not": only _SEARCH_ABSENT
-    means PIM was reached and answered that it holds no such product. The other
-    three misses all mean "unknown", and treating one of them as an absence is
-    what makes push_missing_pim_products create a second PIM record for a
-    product that may already be in there:
+    The search is one `equals` on the PIM `Product` attribute `number`, matched
+    against `product.sku`. It must not be `like`: AtroPIM passes that value
+    straight into a SQL LIKE, so `_` matches any single character and `%`
+    matches anything. Verified against the live API — `like '2001_-04_z01'`
+    returns the product numbered `20015-04_z01`, and `like '%'` returns the
+    whole catalog — and PIM numbers routinely contain `_` (`20015-04_z01`,
+    `20110-8_z02`) while sku is supplier-supplied. `equals` matches both
+    characters literally and costs nothing: bare `like` never did substring
+    matching anyway (a genuine prefix returns no rows).
+
+    `outcome` is one of the _SEARCH_* constants, and callers must not collapse
+    it back to "found or not": only _SEARCH_ABSENT means PIM was reached and
+    answered that it holds no such product. The other three misses all mean
+    "unknown", and treating one of them as an absence is what makes
+    push_missing_pim_products create a second PIM record for a product that may
+    already be in there:
 
     - _SEARCH_ERROR — the request failed, so nothing was learned.
-    - _SEARCH_AMBIGUOUS — `like` matched several products, so no single one is
-      *the* match. Returning the first (as this used to) links the product to
+    - _SEARCH_AMBIGUOUS — the search matched several products, so no single one
+      is *the* match. Returning the first (as this used to) links the product to
       whichever one PIM happened to list first.
     - _SEARCH_NO_SKU — no sku to search by, so PIM is never asked. Where.get()
       drops the value key when it is None (pim_api/__init__.py:24-25), so the
-      request would otherwise go out as an unconstrained `like` on `number`.
+      request would otherwise go out as an unconstrained match on `number`.
 
     Misses are throttled through one cache key, pim_no_match:{pk}, holding the
     outcome that wrote it: a confirmed absence and an ambiguous match are
@@ -232,7 +241,7 @@ def _search_pim_id_result(product) -> tuple[str | None, str]:
             EntityList(
                 name='Product',
                 select=['id'],
-                where=[Where(attribute='number', type='like', value=product.sku)],
+                where=[Where(attribute='number', type='equals', value=product.sku)],
             )
         )
     except Exception as exc:
@@ -648,7 +657,7 @@ def push_missing_pim_products(products, batch_size: int = 1000, delay: float = 0
     Callers must pass only products already confirmed absent from PIM —
     pim_id is None and _search_pim_id_result just came back _SEARCH_ABSENT.
     This doesn't re-check, so every other empty outcome (a failed request, an
-    ambiguous `like`, a product with no sku to search by) must be filtered out
+    ambiguous match, a product with no sku to search by) must be filtered out
     by the caller: PIM cannot confirm an absence it was never asked about, and
     pushing on one creates a duplicate record for a product already in there.
     """


### PR DESCRIPTION
## Зачем

`_search_pim_id_result` искал товар как `Where(attribute='number', type='like', value=product.sku)`. AtroPIM подставляет значение `like` прямо в SQL LIKE, поэтому `_` совпадает с любым одиночным символом, а `%` — с чем угодно. Замерено на живом API (теперь, когда креденшелы работают):

| запрос | total |
|---|---|
| `like '20015-04_z01'` (реальный номер) | 1 |
| `like '2001_-04_z01'` (`_` вместо литерального «5») | **1** |
| `like '2001X-04_z01'` (`X` вместо «5») | 0 |
| `equals '20015-04_z01'` | 1 |
| `equals '2001_-04_z01'` | **0** |
| `like '%'` | **36054** |

Номера в PIM регулярно содержат `_` — `20015-04_z01`, `20110-8_z02` — а `sku` приходит от поставщика. То есть под `like` артикул ищет больше, чем себя.

## Почему защита от неоднозначности это не закрывала

`_SEARCH_AMBIGUOUS` срабатывает только при **>1** совпадении. Опасен ровно **один** подстановочный матч, который оказался чужим товаром: `len(pim_ids) == 1` -> `_SEARCH_FOUND` -> `_resolve_pim_id` пишет этот `pim_id` в базу, и больше никто его не перепроверяет. Дальше неверная связь кормит `search_vector`, синхронизацию категорий и производителя, и карточку товара. Со стороны выглядит так, будто случай покрыт, — он не покрыт.

## Почему equals ничем не жертвует

Подстрочного поиска у голого `like` и не было: настоящий префикс `like '20015-04_z'` возвращает **0** строк. Значит `equals` не сужает совпадение, а только убирает подстановочные символы.

Ранее в этом расследовании стояла оговорка «не менять на equals, вдруг подстрочный поиск несущий» — она была догадкой без данных и теперь опровергнута.

## Что ещё поправлено

Комментарии и докстринги, приписывавшие неоднозначность именно `like`. Тест `test_ambiguous_like_links_nothing` переименован в `test_ambiguous_match_links_nothing`.

Насчёт самой защиты: отдельно просэмплировано **2400 подряд идущих `Product.number` — дублей нет**, так что под `equals` `_SEARCH_AMBIGUOUS` может оказаться недостижим на практике. Защита всё равно оставлена: выборка не покрывает все 36k, ничто из проверенного не *гарантирует* уникальность, а стоит она один `len()`. В комментарии и в knowledge добавлено предупреждение не читать проходящий тест как доказательство того, что PIM отдаёт дубли.

Знание записано в `.claude/knowledge/main_product_manager.md` с замерами, чтобы `equals` не «почистили» обратно в `like` как более гибкий вариант.

## Тест

Новый `test_search_uses_equals_so_sku_wildcards_stay_literal` берёт sku `2001_-04_z01` и проверяет сам запрос — `(attribute, type, value)` у `Where`. Сети не требует, `site` замокан.

```
docker compose exec -T celery_worker python manage.py test --keepdb   # 334 теста
```

## Одно падение, и оно не отсюда

`test_grouping.test_head_stays_first_on_descending_sort` падает — **и падает точно так же на чистом `origin/main` без этого изменения** (проверено отдельным прогоном со снятыми правками). Это следствие того, что PIM-креденшелы заработали:

`test_grouping` и `test_tables` создают товары с `pim_id='PIM-1'` и рендерят таблицу, не мокая `site`. Раньше PIM отвечал `401`, и `_note_pim_404` не срабатывал. Теперь `/api/Product/PIM-1` отдаёт настоящий `404`, счётчик `pim_404_count:PIM-1` копится в общем Redis, и на третьем подряд `_note_pim_404` делает `MainProduct.objects.filter(pim_id='PIM-1').update(pim_id=None)` — обнуляя фикстуру группировки прямо посреди прогона. В изоляции тест проходит.

В CI `PIM_HOST=pim.invalid`, это ошибка соединения, а не 404, поэтому там не воспроизводится. Чинить надо мокингом `site` в этих двух модулях — отдельной задачей, не здесь.

## Остаётся открытым

`PriceManagerProduct` резолвится, но содержит **0 записей**, при том что push-сторона создаёт записи именно там, а поиск читает `Product`. Либо PIM их сливает в `Product`, либо каждый проход пушит товары, которые потом не найдёт. Без админки PIM или пробной записи в прод это не выяснить, так что просто фиксирую.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
