### PR TITLE
docs: права на media/ в worktree ломают 16 тестов supplier_product_manager

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,24 @@ survive between tool calls. Serializing stays the safe default; isolate when you
 genuinely need two stacks at once, and read "Which stack you are talking to" in
 `run-price-manager` first.
 
+`media/` is gitignored on the same principle, and that one costs more because it
+looks like a regression. A fresh worktree gets its own empty `media/`, and it
+does not inherit the main checkout's mode — inside the container it is 0755
+where the shared tree's is 0777, and the worker runs as uid 1011. Every
+`supplier_product_manager` test that creates a `SupplierFile` then dies with
+`PermissionError: [Errno 13] ... '/app/media/setting_<pk>'`: 16 errors in an
+otherwise-green suite, belonging to neither the branch nor the code under test.
+Once per worktree:
+
+```bash
+docker compose run --rm --no-deps --user root -T celery_worker sh -c 'mkdir -p /app/media && chmod -R 777 /app/media'
+```
+
+`chmod` from Git Bash on the host does not change the mode the container sees —
+that only works from inside a container. And it has to be `run --no-deps` (so it
+does not start the shared `db`/`redis`), not `exec`: `exec` attaches to the
+running container, whose `/app` is whichever tree last ran `up`.
+
 ## Direction of travel — read this before adding code
 
 There are two product catalogs in the tree. **They are not peers, and the newer one is not the future.**


### PR DESCRIPTION
## Что изменилось

18 строк в `CLAUDE.md`, в раздел **«Running more than one agent»** — сразу после абзаца про gitignore-нутый `.env`, где уже живут ловушки worktree/контейнеров.

## Зачем

Полный прогон тестов из git worktree даёт 16 ошибок в `supplier_product_manager.tests` (`BasicLoadTests`, `GetSpsCacheTests`, `SupplierFileSelectionTests`), все вида:

```
PermissionError: [Errno 13] Permission denied: '/app/media/setting_<pk>'
```

Причина: `media/` в `.gitignore` (`.gitignore:9`), поэтому свежий worktree получает свой пустой каталог и не наследует режим основного чекаута — в контейнере 0755 против 0777, а воркер работает под uid 1011 (`user: "1011:1011"`, `docker-compose.yml:39,77`). Это чистый шум, который выглядит как настоящая регрессия: 16 ошибок в зелёном прогоне, не относящихся ни к ветке, ни к тестируемому коду.

Разовая команда на worktree:

```bash
docker compose run --rm --no-deps --user root -T celery_worker sh -c 'mkdir -p /app/media && chmod -R 777 /app/media'
```

## На что посмотреть ревьюеру

**Команда шире исходной, проверенной вручную.** Проверена была `chmod -R 777 /app/media` без обёртки. В документацию попал вариант с `mkdir -p`, потому что свежий worktree может вообще не иметь `price_manager/media` — в этом случае голый `chmod` завершится с ненулевым кодом. В прогоне, где ловушка была найдена, каталог уже существовал (ошибка была на создании подкаталога `setting_<pk>` внутри него). Обёртка `sh -c` нужна потому, что compose `run` передаёт argv в контейнер без шелла, и голый `&&` съел бы хостовый шелл. Расширенный вариант **не** проверялся запуском — CLAUDE.md требует спрашивать перед поднятием стека.

**`run --no-deps`, а не `exec`.** `exec` цепляется к уже запущенному контейнеру, чей `/app` — это то дерево, которое последним делало `up`; то есть chmod ушёл бы не в тот worktree. `--no-deps` не даёт поднять общие `db`/`redis`.

**Почему не в `.claude/knowledge/supplier_product_manager.md`.** Правило границ в самом CLAUDE.md резервирует файлы знаний под app-local механику. Здесь же инфраструктура worktree/контейнеров, которая просто всплывает в `supplier_product_manager` — это единственное приложение, чьи тесты пишут в `MEDIA_ROOT`. Симптом и починка держатся вместе в том разделе, который читают при отладке worktree.

**Механизм на хосте описан эмпирически.** Первая редакция объясняла no-op хостового `chmod` через «NTFS не несёт mode bits», что противоречит соседнему утверждению про 0755 vs 0777 — если биты не проходят через mount, контейнер не увидел бы два разных режима. В тексте осталось только наблюдаемое: `chmod` с хоста не меняет режим, который видит контейнер.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
