### PR TITLE
refactor(main_product_manager): MainProduct.pim_id → FK на product.Product

### DIFF
--- a/.claude/knowledge/main_product_manager.md
+++ b/.claude/knowledge/main_product_manager.md
@@ -1,16 +1,23 @@
 # main_product_manager
 
-`MainProduct` — the canonical product record. Owns the PIM integration.
+`MainProduct` — the canonical product record. Owns the PIM integration. Its
+link to PIM is `MainProduct.product`, a nullable FK to `product.Product`
+(see [[product]]) — replacing `MainProduct`'s own CharField `pim_id` as of
+the `MainProduct.product` FK conversion. `SupplierProduct.pim_id` is a
+**separate, still-live CharField** (`utils.py:685,688`), untouched by this —
+don't go looking for a FK there. The sections below are line-numbered
+against the tree as of that conversion (worktree `mainproduct-product-fk`),
+so re-check line numbers after it merges and drifts further.
 
 ## `.save()` deliberately doesn't rebuild the search vector
 
-`MainProduct.save()` (`models.py:178`) is a bare `super().save()` — don't
-"fix" that by adding a rebuild call. `_build_searchvector()` makes a PIM
-network call per row (CLAUDE.md's cross-app-dependencies note); adding it to
-`save()` would turn every save in the codebase into an HTTP request. Trace
-whether a loop over `MainProduct` reaches `rebuild_search_vector()`
-(`models.py:172`) regardless of how cheap the queryset looked — that's one
-round-trip per row.
+`MainProduct.save()` (`models.py:180`) is a bare `super().save()` — don't
+"fix" that by adding a rebuild call. `_build_searchvector()` (`models.py:151`)
+makes a PIM network call per row (CLAUDE.md's cross-app-dependencies note);
+adding it to `save()` would turn every save in the codebase into an HTTP
+request. Trace whether a loop over `MainProduct` reaches
+`rebuild_search_vector()` (`models.py:174`) regardless of how cheap the
+queryset looked — that's one round-trip per row.
 
 ## PIM scans run with `atomic=False` — moving the write is not enough
 
@@ -32,24 +39,93 @@ for minutes, not hours (see the section below) — and a run that hit one is
 recorded as an error instead of a success, so "it resumed" is checkable rather
 than assumed.
 
+## `MainProduct.product` — the FK that replaced `pim_id`, and its traps
+
+**`group_key()` (`grouping.py:50-79`) must not be `Coalesce` over `Concat`.**
+It partitions the main page so several `MainProduct`s sharing one PIM
+`product.Product` collapse into one head row. The first draft wrote it as
+`Coalesce(Concat(Value('pim-'), Cast('product_id', TextField())),
+Concat(Value('mp-'), Cast('id', TextField())))` and it silently broke:
+Postgres `CONCAT()` treats NULL as the empty string (unlike `||`), so
+`Concat('pim-', NULL)` returns `'pim-'`, not NULL — `Coalesce` never reaches
+its second branch, and **every unlinked product collapses into one fake
+group keyed `'pim-'`**, exactly what the key exists to prevent. The fix is
+`Case/When(product__isnull=True, then=Concat('mp-', id))`, `default=Concat('pim-',
+product_id)` — an explicit branch, not a NULL-swallowing fallback.
+
+**Both branches must carry their prefix**, for a second, independent reason:
+`product_id` and `MainProduct.id` are separate integer sequences. Without
+`'pim-'`/`'mp-'`, an unlinked row with `id = N` silently joins the group of
+whatever is linked to a `Product` with `id = N`. The old string `pim_id` was
+immune purely because it never looked like a small integer — this hazard is
+new with the FK and has no precedent in the file. Guarded by two tests in
+`test_grouping.py`: `test_unlinked_products_never_group` (`:190-204`) pins
+the NULL-swallowing case, `test_unlinked_product_does_not_join_group_with_matching_product_id`
+(`:206-225`) pins an explicit `Product.id` collision against an unlinked
+`MainProduct.pk`.
+
+**`recalculate_search_vectors` absorbs the FK hop — don't push
+`select_related('product')` out to its callers.** `_build_searchvector()`
+used to read `self.pim_id` off the row for free; it now calls `_pim_id_of()`
+(`utils.py:28-40`), a module function (deliberately not a `MainProduct`
+property — a property named `pim_id` would keep working in templates and
+silently break in `.filter()`/annotations, where the lookup is
+`product__pim_id`), which crosses the FK. The fix already lives in the one
+place that needed it: `recalculate_search_vectors` (`utils.py:549-559`) adds
+`.select_related('supplier', 'manufacturer', 'product')` itself (`:554`), so
+its three callers — `main_product_manager/tasks.py`,
+`supplier_product_manager/tasks.py:277`, `supplier_product_manager/functions.py`,
+plus `main_product_manager/views.py:421-422` (which only passes
+`select_related('supplier', 'manufacturer')`) — stay correct without change.
+Don't add `select_related('product')` at those call sites (redundant) and
+don't remove it from `recalculate_search_vectors` (N+1 per already-linked
+row). `create_pim_links` (`utils.py:765-819`) is the deliberate exemption,
+commented in place at `:774-777`: it only ever *writes* the link, never reads
+it via `_pim_id_of`, so it skips `select_related('product')` on purpose.
+
+**`_push_pim_products` stores the wrong PIM entity's id — known, preserved on
+purpose, open decision with the user.** `_push_pim_products`
+(`utils.py:625-681`) creates PIM `PriceManagerProduct` records via
+`upsertAsync` and persists the id PIM returns through a caller-supplied
+`link_fn` — split out because the two callers store the link differently:
+`_link_supplier_products` (`utils.py:684-692`) still writes
+`SupplierProduct.pim_id`, a plain CharField; `_link_main_products`
+(`utils.py:695-717`) writes the FK. Every *read* path (`get_pim_data`,
+`_search_pim_id_result`) addresses the PIM **`Product`** entity, but
+`PriceManagerProduct.id` is not a `Product` id — `PriceManagerProduct.productId`
+is. Under the old CharField this mismatch sat inert as a string that never
+resolved. **Under the FK it now materialises a placeholder `product.Product`
+row per push** — `_link_main_products` calls `_pim_product_row(pim_id)`
+(`utils.py:43-62`, `get_or_create` on `product.Product.pim_id`) with the
+unresolvable id, so [[product]] gains a real row keyed by a
+`PriceManagerProduct` id instead of a `Product` id. Preserved deliberately,
+per the comment at `utils.py:698-706` — the existing "already pushed, don't
+re-push" suppression depends on the FK being set to *something* — and
+flagged there as an open decision with the user, **not as correct
+behaviour**: don't "clean this up" unilaterally. `PimProductWidget`
+(`resources.py:258-280`) does the same `get_or_create` for the Excel-import
+path (`MainProductPimImportResource`, `resources.py:286-296`), for the
+legitimate reason: PIM exports can carry ids the local mirror doesn't have
+yet.
+
 ## The PIM cache's render-path cost — and why it bites tests too
 
-`get_pim_data` (`utils.py:138`) is synchronous on a cache miss or when
-`refresh=True` — `_fetch_pim_product(...)` (`utils.py:146`) runs in-line, no
-early return, so a cold cache blocks the request on a PIM HTTP round-trip.
-`get_file_url` (`utils.py:436`) has the same shape on a miss (`:446-453`),
-minus the queueing.
+`get_pim_data` (`utils.py:185-210`) is synchronous on a cache miss or when
+`refresh=True` — `_fetch_pim_product` (def `utils.py:115`, called at `:193`)
+runs in-line, no early return, so a cold cache blocks the request on a PIM
+HTTP round-trip. `get_file_url` (`utils.py:502-529`) has the same shape on a
+miss (`:511-519`), minus the queueing.
 
-`prefetch_pim_data` (`utils.py:388`) loops products one at a time, and
+`prefetch_pim_data` (`utils.py:453-469`) loops products one at a time, and
 `MainProductTableView.get_context_data` (`views.py:214`) then calls
 `get_file_url` again per entry (`views.py:226`): up to **2N** PIM calls per
-cold page (the main page paginates 5 categories at a time, `views.py:89`,
+cold page (the main page paginates 5 categories at a time, `views.py:89-90`,
 each firing its own `hx-trigger="load"` fetch, `tables_bycat.html:53,82`).
 **But calls dedupe by `pim_id`/file id, not by row** — `get_pim_data` caches
-on `pim_product:{pim_id}` (`:136`), `get_file_url` on `pim_file:{file_id}`
-(`:378`) — so real cost is bounded by distinct `pim_id`s on the page.
+on `pim_product:{pim_id}` (`:188`), `get_file_url` on `pim_file:{file_id}`
+(`:510`) — so real cost is bounded by distinct `pim_id`s on the page.
 `MainProductTable._pim` still reads `pim_map` by `record.pk`
-(`tables.py:230-231`).
+(`tables.py:231-232`).
 
 **Rendering this table in a test makes live PIM HTTP calls unless
 patched — and "live" can mean production.** `docker-compose.yml`'s
@@ -58,51 +134,28 @@ the repo-root `.env` (gitignored, absent from a fresh worktree per CLAUDE.md's
 "Running more than one agent") holds **real** PIM credentials, so a compose
 invocation that loads it — `--env-file <repo>/.env` included — runs the
 suite against the live production PIM, and an unpatched test then makes real
-calls to it. Working recipe — **in the shared base's `setUp`, never a class
-decorator** (`test_grouping.py:72-82`): patch
-`main_product_manager.views.prefetch_pim_data`, `.maybe_notify_pim_error` and
-`main_product_manager.utils.site`. As a *class* decorator `@patch` wraps only
-the `test_` methods visible when it is applied, and a shared base has none of
-its own — so the decorators that used to sit on `GroupingTestCase` protected
-nobody, and five of its seven subclasses called the live PIM. `setUp` runs per
-test method for every subclass, so the stub cannot be forgotten. Measured
-before the fix: **42 live `GET /api/Product/PIM-1` in one full suite**, and
-those real 404s tripped `_note_pim_404` (`utils.py:123-133`) at
-`_PIM_404_THRESHOLD` = 3 — `update(pim_id=None)` over the grouping fixtures
-mid-run, which is why `test_head_stays_first_on_descending_sort` failed in a
-full run and passed in isolation.
-
-Creating `MainProduct`s is safe — `save()` doesn't reach PIM — but that is
-narrower than it reads, and two paths out of `supplier_product_manager`'s own
-tests do reach it: `copy_supplier_products_to_main_task` →
-`recalculate_search_vectors` → `_build_searchvector` → `get_pim_data` (GET),
-and the import, `load_setting` → `push_supplier_products_to_pim`
-(`supplier_product_manager/functions.py:505`) → `_upsert_async`, which
-**POSTs test fixtures to the live PIM**. Both are stubbed from
-`BasicLoadTests.setUp` and `CopySupplierProductsToMainTaskTests.setUp`
-(`supplier_product_manager/tests.py:48-57`, `:685`) by patching
-`main_product_manager.utils.site` — the client, not the function under test;
-`_push_pim_products` (`utils.py:587`) and `_fetch_pim_product` both swallow
-the resulting exception and carry on, so nothing the tests assert changes.
-
-A test needing a populated `search_vector` should set it directly with
-`SearchVector` over local fields (`test_grouping.py:112-117`) instead of
-calling `rebuild_search_vector()`. `get_file_url` has its own direct-mock
-recipe instead (`GetFileUrlTests`, `tests.py:356`, patches
-`main_product_manager.utils.site`).
+calls to it. Working recipe: `GroupingTestCase.PIM_PATCHES`
+(`test_grouping.py:73-77`, applied in `setUp` at `:79-86`) patches
+`main_product_manager.views.prefetch_pim_data`, `.maybe_notify_pim_error`,
+and `main_product_manager.utils.site` with `_PimUnreachable()`
+(`test_grouping.py:45-58`) — a class that raises on any attribute access
+rather than a `MagicMock`, because a "working" mock would cache a fabricated
+PIM response and queue a real background task against it. Creating
+`MainProduct`s is safe — `save()` doesn't reach PIM — but a test needing a
+populated `search_vector` should set it directly with `SearchVector` over
+local fields (`test_grouping.py:122`, inside the `make_product` factory,
+`:103-123`) instead of calling `rebuild_search_vector()`. `get_file_url` has
+its own direct-mock recipe instead (`GetFileUrlTests`, `tests.py:357`,
+patches `main_product_manager.utils.site`).
 
 ## `get_file_url`'s PIM File payload — the precedence bug is fixed (#160/PR #169)
 
-`get_file_url` (`utils.py:436`) now loops over `(f'{size}ThumbnailUrl',
+`get_file_url` (`utils.py:502-529`) loops over `(f'{size}ThumbnailUrl',
 *_PIM_FILE_URL_KEYS)`, `_PIM_FILE_URL_KEYS = ('url', 'downloadUrl')`
-(`utils.py:406`), normalizing each candidate through `_absolute_pim_url`
-(`utils.py:409-433`). Old bug: the return was
-`"https://" + data.get(f'{size}ThumbnailUrl') or data.get('url') or
-data.get('downloadUrl')` — `+` binds tighter than `or`, so a missing
-`{size}ThumbnailUrl` raised an uncaught `TypeError` before either fallback
-ran, and the fallbacks were dead code besides.
-`views.py:226` and `render_pim_photo` (`tables.py:233-244`) now get a clean
-`None`/URL instead of a 500 on a missing thumbnail.
+(`utils.py:472`), normalizing each candidate through `_absolute_pim_url`
+(`utils.py:475-499`). `views.py:226` and `render_pim_photo`
+(`tables.py:234-245`) get a clean `None`/URL rather than raising on a missing
+thumbnail.
 
 **The lasting fact is the payload shape**, sampled read-only against the
 live PIM — both the `File` list endpoint and the single-record endpoint
@@ -120,13 +173,12 @@ live PIM — both the `File` list endpoint and the single-record endpoint
 
 So `size` currently selects a key that never exists —
 `'small'|'medium'|'large'` has **no observable effect today** — and
-`downloadUrl`, full-size
-rather than a thumbnail, is what every caller actually renders. Matters for
-the «PIM • Фото» column (`tables.py:47`, `render_pim_photo`): sized as a
-thumbnail, renders full-size. **`downloadUrl` also needs a PIM session** —
-an unauthenticated GET of the built URL returns `401`, so a browser without
-a PIM login still renders a broken image, just not a 500 anymore. Not filed
-as an issue yet.
+`downloadUrl`, full-size rather than a thumbnail, is what every caller
+actually renders. Matters for the «PIM • Фото» column (`tables.py:47`,
+`render_pim_photo`): sized as a thumbnail, renders full-size. **`downloadUrl`
+also needs a PIM session** — an unauthenticated GET of the built URL returns
+`401`, so a browser without a PIM login still renders a broken image, just
+not a 500 anymore. Not filed as an issue yet.
 
 ## `MainProductFilter` — `.order_by()` bleeding into `GROUP BY`
 
@@ -140,12 +192,13 @@ either without re-deriving why `search_rank` lives as a separate
 
 ## `_search_pim_id_result`: one `equals` on `number`, and why an empty answer has to say *why*
 
-`_search_pim_id_result(product) -> tuple[str | None, str]` (`utils.py:184`) is
-the resolver; `_search_pim_id` (`utils.py:251`) is a thin id-only wrapper kept
-for `_resolve_pim_id`, which has nothing to decide on a miss. One round-trip:
-`Where(attribute='number', type='equals', value=product.sku)` against
-`EntityList(name='Product', select=['id'])` — a direct `Product` search, no
-`ContributorProduct` step, no `masterRecordId`, no `priceManagerId` fallback.
+`_search_pim_id_result(product) -> tuple[str | None, str]` (`utils.py:231`)
+is the resolver; `_search_pim_id` (`utils.py:307`) is a thin id-only wrapper
+kept for `_resolve_pim_id` (`utils.py:316`), which has nothing to decide on a
+miss. One round-trip: `Where(attribute='number', type='equals',
+value=product.sku)` (`utils.py:280-286`) against `EntityList(name='Product',
+select=['id'])` — a direct `Product` search, no `ContributorProduct` step, no
+`masterRecordId`, no `priceManagerId` fallback.
 
 **It must stay `equals`, and this was measured, not reasoned.** AtroPIM passes
 a `like` value straight into a SQL LIKE: against the live API
@@ -155,10 +208,10 @@ routinely carry `_` — `20015-04_z01`, `20110-8_z02` — and sku is
 supplier-supplied, so under `like` a sku can match a *different* product.
 The `_SEARCH_AMBIGUOUS` guard does not save you there: it only fires on >1
 match, and the dangerous case is exactly one wrong match, which returns
-`_SEARCH_FOUND` and gets written to the DB by `_resolve_pim_id` with nothing
-ever re-checking it. Switching costs nothing — bare `like` never did substring
-matching either (a genuine prefix returns no rows), so `equals` only removes
-the wildcard surface.
+`_SEARCH_FOUND` and gets written to the DB with nothing ever re-checking it.
+Switching costs nothing — bare `like` never did substring matching either (a
+genuine prefix returns no rows), so `equals` only removes the wildcard
+surface.
 
 Sampled alongside: 2400 consecutive `Product.number` values, **no duplicates**.
 So `_SEARCH_AMBIGUOUS` may be unreachable under `equals` in practice. It is
@@ -166,104 +219,91 @@ kept anyway — the sample is not the whole 36k catalog, nothing checked
 guarantees uniqueness, and the guard costs one `len()`. Don't read a passing
 `test_ambiguous_match_links_nothing` as evidence PIM returns duplicates.
 
-The outcome is one of five (`utils.py:173-177`): `_SEARCH_FOUND`,
+The outcome is one of five (`utils.py:220-224`): `_SEARCH_FOUND`,
 `_SEARCH_ABSENT`, `_SEARCH_AMBIGUOUS`, `_SEARCH_ERROR`, `_SEARCH_NO_SKU`.
 **Only `_SEARCH_ABSENT` means PIM was asked and answered "no such product."**
 That distinction is load-bearing rather than tidy, because
-`push_missing_pim_products` (`utils.py:638`) *writes to PIM* — it creates a
+`push_missing_pim_products` (`utils.py:746-762`) *writes to PIM* — it creates a
 `PriceManagerProduct` — so anything else reaching it creates a duplicate
 record for a product that may already be there. `create_pim_links`
-(`utils.py:656`) and `reindex_pim_ids_batch` (`utils.py:728`) branch on the
-outcome, not on `pim_id is None`. A new caller that writes on a miss must do
-the same.
-
-**The three edges this closed.** Until then the search returned the first
-non-empty id with no count check; a no-sku product was not skipped but sent an
-*unconstrained* match (`Where.get()` omits the `value` key entirely when it is
-None, `pim_api/__init__.py:24-25`); and an API error fell through to the same
-`cache.set(no_match_key, True, ...)` as a genuine miss. The last one was the
-severe one, and not for the reason it looks: a PIM outage mid-scan did not just
-suppress retries for 4h, it fed every unlinked row it touched to
-`push_missing_pim_products`. Do not restore the older, tidier claim that a
-no-sku product "can never resolve" — that was an assumption the query-string
-construction contradicted.
+(`utils.py:765-819`) and `reindex_pim_ids_batch` (`utils.py:845-892`) branch on
+the outcome, not on `product_id is None`. A new caller that writes on a miss
+must do the same. (Earlier revisions returned the first non-empty id with no
+count check, sent no-sku products as an unconstrained match, and conflated a
+PIM error with a genuine miss under one cache flag — all three closed here;
+`Where.get()` still omits the `value` key entirely when it is `None`,
+`pim_api/__init__.py:24-25`, which is why `_SEARCH_NO_SKU` returns before any
+request rather than relying on that.)
 
 **How each is handled now**: several matches log a warning and link nothing
-(`_SEARCH_AMBIGUOUS`); no sku returns before any request (`_SEARCH_NO_SKU`,
-restoring the guard `86f3289` dropped — not the `priceManagerId` search it
-dropped alongside); a failed request returns `_SEARCH_ERROR`.
+(`_SEARCH_AMBIGUOUS`); no sku returns before any request (`_SEARCH_NO_SKU`);
+a failed request returns `_SEARCH_ERROR`.
 
 **One cache key, deliberately.** `pim_no_match:{pk}` holds the outcome string
 rather than a bare flag, so `get_pim_data_for_product`'s single `cache.delete`
-on the 404-recovery path stays correct and there is no second key to leave
-stale. TTLs differ by reason: `_PIM_SEARCH_ERROR_TTL` = 5 min for an error,
-`_PIM_NO_MATCH_TTL` = 4h for a confirmed absence or an ambiguous match, those
-being conditions of the data rather than of the network (`utils.py:166-167`).
-A legacy bare `True` matches no outcome, so it is dropped and re-searched
-instead of guessed at (`utils.py:212-217`).
+(`utils.py:355`) on the 404-recovery path stays correct and there is no
+second key to leave stale. TTLs differ by reason: `_PIM_SEARCH_ERROR_TTL` = 5
+min for an error, `_PIM_NO_MATCH_TTL` = 4h for a confirmed absence or an
+ambiguous match, those being conditions of the data rather than of the
+network (`utils.py:213-214`). A legacy bare `True` matches no outcome, so it
+is dropped and re-searched instead of guessed at (`utils.py:270-273`).
 
-**Both scans raise `PimSearchError` (`utils.py:180`)** when a search went
-unanswered — *after* their writes, so committed progress survives. It is the
-only durable signal there is: `maybe_notify_pim_error` is DEBUG-gated
-(`utils.py:45`) and prod runs under `settings.prod`, so `_PIM_LAST_ERROR_KEY`
-is written and read by nobody there; `TaskRunHistory` (from
-`execute_locked_task`'s `except`, `core/task_runner.py:112-132`) is what
-records it. The return must stay a 2-tuple — `_normalize_updated_count`
-(`core/task_runner.py:14-21`) sums every numeric element, so a third "failed"
-element would silently inflate `updated_count`. Ambiguity does not raise.
-Consequence: `manage.py run_task` in sync mode calls the task function directly
+**Both scans raise `PimSearchError` (`utils.py:227-228`)** when a search went
+unanswered — *after* their writes, so committed progress survives. `TaskRunHistory`
+(from `execute_locked_task`'s `except`, `core/task_runner.py:112-132`) is what
+records it. **`maybe_notify_pim_error` (`utils.py:82-112`) now fires in prod
+too** — earlier it was gated on `settings.DEBUG`, which inverted the intent
+(DEBUG defaults false, so production, the one environment where a PIM outage
+costs something, got no signal at all); it's per-user and throttled
+(`_PIM_NOTIF_THROTTLE_TTL`, 30 min) instead, so `TaskRunHistory` is no longer
+the *only* durable signal, just the unconditional one. The return must stay a
+2-tuple — `_normalize_updated_count` (`core/task_runner.py:14-21`) sums every
+numeric element, so a third "failed" element would silently inflate
+`updated_count`. Ambiguity does not raise. Consequence:
+`manage.py run_task` in sync mode calls the task function directly
 (`management/commands/run_task.py:81`), so its no-argument form now stops at
 the failing task instead of continuing down the loop.
 
 **The cost of that correctness, in `create_pim_links` only.** Its window is
-`filter(pim_id__isnull=True)[:1000]` under `Meta.ordering = ['id']` — the same
-lowest-1000 unlinked rows every run — and it used to drain because every
-product left the unlinked set: linked, or pushed to PIM and given the id
-`_push_pim_products` wrote back. An unsearchable product now does neither, so
-it would hold a slot and a `time.sleep(delay)` at the head of the window
-forever. No-sku rows are excluded from the queryset itself
-(`utils.py:657-670`); drop that exclusion if a search that works without an sku
-is ever added back. `_SEARCH_AMBIGUOUS` rows have no such containment by
-design — an ambiguous match is a data problem someone has to settle in PIM.
-
-**How it got this way.** `86f3289` collapsed a two-element `searches` list
-(priceManagerId, then sku) to one and dropped its `if product.sku` guard;
-`48c31f8` swapped the entity from `ContributorProduct`/`masterRecordId` to
-`Product`/`id`. Neither touched the prose, so three docstrings outlived their
-code by two commits and were reported as having been read as the real lookup
-path during #164's triage (not visible in that issue's body or comments —
-grepped). The docs-only fix (#172) corrected the prose and documented the three
-edges; this work closed them.
+`filter(product__isnull=True).exclude(sku__isnull=True).exclude(sku='')[:1000]`
+(`utils.py:778-782`) under `Meta.ordering = ['id']` — the same lowest-1000
+unlinked rows every run — and it used to drain because every product left the
+unlinked set: linked, or pushed to PIM and given the id `_push_pim_products`
+wrote back. An unsearchable product now does neither, so it would hold a slot
+and a `time.sleep(delay)` at the head of the window forever. No-sku rows are
+excluded from the queryset itself; drop that exclusion if a search that works
+without an sku is ever added back. `_SEARCH_AMBIGUOUS` rows have no such
+containment by design — an ambiguous match is a data problem someone has to
+settle in PIM.
 
 **Testing.** `site` is bound into `utils`'s own namespace (`utils.py:16`), so
 tests patch `main_product_manager.utils.site`, **not** `pim_client.site`.
-`SearchPimIdOutcomeTests` and `PimScanPushGuardTests` (`tests.py:532`, `:658`)
+`SearchPimIdOutcomeTests` and `PimScanPushGuardTests` (`tests.py:537`, `:690`)
 are the pattern, both under `@override_settings(CACHES=LOCMEM_CACHE)` — the
 outcome cache has to be visible to in-process assertions rather than the
 worker container's shared Redis.
 
-**Stale UI copy this produces, still not fixed:**
-`templates/mainproduct/partials/detail.html:78` tells the user, in Russian,
-"Проверьте соответствие priceManagerId/названия" — but the lookup matches
-`number`/sku only; neither `priceManagerId` nor the product name participates.
-Correct copy needs to name `sku`/`number` and cover the no-sku case, which is
-now an explicit early return rather than a stray unconstrained query. This line
-is the last surviving `priceManagerId` reference in the repo outside `pim_api`
-itself (grepped, not assumed).
+**Stale UI copy — fixed.** `templates/mainproduct/partials/detail.html:78`
+used to tell the user "Проверьте соответствие priceManagerId/названия" while
+the lookup actually matched `number`/sku and neither `priceManagerId` nor the
+name participated. It now reads "Поиск идёт по артикулу товара — проверьте,
+совпадает ли он с полем «number» в PIM, или привяжите вручную" — matches the
+real lookup, and `priceManagerId` no longer appears anywhere in the repo
+(grepped).
 
 ## The 11 Celery tasks, and one that isn't
 
-`sync_main_products_task` (`tasks.py:143`) has no `@shared_task` — it's a
+`sync_main_products_task` (`tasks.py:138`) has no `@shared_task` — it's a
 plain function that `chain(...)`s the other 11 into one `apply_async()`
 workflow; each link still goes through `execute_locked_task` on its own.
 `reindex_pim_ids_task`'s fan-out uniquifies `task_name` per chunk
-(`tasks.py:190`, `f"...:{pks[0]}-{pks[-1]}"`) — without it every batch would
+(`tasks.py:185`, `f"...:{pks[0]}-{pks[-1]}"`) — without it every batch would
 contend on the same Redis lock.
 
 ## Three columns that look like fields but aren't
 
 **Three writers feed `MainProductLog`, and the dominant one is not the
-name-obvious one.** `utils.update_logs()` (`utils.py:776`) reads like the
+name-obvious one.** `utils.update_logs()` (`utils.py:895`) reads like the
 writer, but [[product_price_manager]]'s `PriceManager.apply(logs=True)`
 (`product_price_manager/models.py:302-308`) and `PriceTag.get_mp()`
 (`:426-434`) also insert rows, reached via module-level `update_prices()`
@@ -279,35 +319,41 @@ three call sites, not just the one named after the model.
 `supplier_product_discount_price` are `tables.Column`s (`tables.py:39-41`)
 offered in `AVAILABLE_COLUMN_GROUPS` (`columns.py:36-38`), but they're not
 `MainProduct` fields — `MainProductTableView.get_table_data`
-(`views.py:146-154`) builds each as a correlated `Subquery` on
+(`views.py:146-160`) builds each as a correlated `Subquery` on
 `SupplierProduct`, ordered `-updated_at`. That's ordering a singleton, since
 `SupplierProduct.main_product` is `unique=True`
 (`supplier_product_manager/models.py:24-30`). `kaspi_price`, by contrast, is
 a genuine field but an orphan in the column picker: offered at
 `columns.py:33`, absent from `MainProductTable.Meta.fields`
-(`tables.py:100-127`) — selecting it does nothing.
+(`tables.py:100-128`) — selecting it does nothing.
 
-## `pim_id` is indexed, but the index doesn't make grouping cheap
+## The `product` FK is indexed automatically, but the index doesn't make grouping cheap
 
-`models.py:46-49` gives `pim_id` a plain `db_index=True` (added with #155),
-distinct from the `GinIndex` on `search_vector`. It isn't `unique` — several
-`MainProduct`s from different suppliers legitimately share one `pim_id`
-(`sync_pim_relations`'s docstring, `utils.py:362-367`), which is exactly
-what `grouping.py` collapses into one head row.
+`models.py:46-51` gives `MainProduct.product` a plain nullable
+`ForeignKey('product.Product', ...)`, not `unique` — several `MainProduct`s
+from different suppliers legitimately share one linked `Product`
+(`sync_pim_relations`'s docstring, `utils.py:426-432`), which is exactly what
+`grouping.py` collapses into one head row. Django gives an FK column its own
+btree index automatically, same as the old `pim_id` CharField's explicit
+`db_index=True` did — that part didn't change with the conversion.
 
 **The index removes a lookup cost, not the grouping cost.**
-`MainProductTableView.get_table_data` (`views.py:145-185`) computes
-`Window(partition_by=[F('grp_key')])` (`grouping.py:105-155`) per
-category/uncategorised bucket, and `grp_key` is
-`Coalesce(NullIf(pim_id, ''), Cast('id', TextField()))` (`grouping.py:50-64`)
-— an expression, not the indexed column, so Postgres sorts every row in the
-bucket regardless. On a restored production snapshot: 156,016 of 156,481
-`MainProduct`s have no category, so the uncategorised bucket is effectively
-the whole catalog while the largest real category holds 67 rows — the
-window pass costs ~+6ms there versus ~70ms→~3s on the uncategorised one
-(merge sort spilling ~107MB to disk; aggregates/counts only, per
-prod-snapshot rule 3). **Benchmark grouping changes against the
-uncategorised bucket** — a category table always looks fast.
+`MainProductTableView.get_table_data` (`views.py:146-213`) computes
+`Window(...)` per-partition inside `annotate_groups`
+(`grouping.py:120-171`), and `grp_key` is still an *expression* —
+`Case/When` over `Concat(..., Cast('product_id'/'id', TextField()))`
+(`grouping.py:72-79`) — not the indexed column itself, so Postgres sorts
+every row in the bucket regardless of the FK's index. On a restored
+production snapshot: 156,016 of 156,481 `MainProduct`s have no category, so
+the uncategorised bucket is effectively the whole catalog while the largest
+real category holds 67 rows — the window pass costs ~+6ms there versus
+~70ms→~3s on the uncategorised one (merge sort spilling ~107MB to disk;
+aggregates/counts only, per prod-snapshot rule 3). **Benchmark grouping
+changes against the uncategorised bucket** — a category table always looks
+fast. Consistent with this: `GroupHeadRecord.__init__` (`grouping.py:237-244`)
+deliberately exposes `product_id` (the local FK's target pk) rather than
+resolving and exposing `pim_id`, precisely to avoid adding a `product.Product`
+join to that hot path.
 
 ## `render_<column>` is silently skipped when the cell value is empty
 
@@ -317,25 +363,25 @@ eight `pim_*` columns (`:47-54`). Without it, django-tables2 skips the
 renderer and returns the column's `default` whenever the value is `None`/`""`
 — a `render_foo` added without `empty_values=()` works for populated rows and
 silently renders the table-wide `—` for empty ones, reading like a data
-problem, not a wiring one. `GroupHeadRecord` (`grouping.py:207-244`) relies
-on the inverse on purpose: `__getattr__` (`:238-241`) returns `None` for any
+problem, not a wiring one. `GroupHeadRecord` (`grouping.py:222-263`) relies
+on the inverse on purpose: `__getattr__` (`:257-260`) returns `None` for any
 unset attribute, so an unhandled column falls through to `—` for free — only
 the three branching renderers needed an `is_group_head` branch when #155
 added the header row.
 
 ## `update_stocks` and `render_stock_msg` — NULL vs `0`, three copies of the check
 
-`update_stocks`'s docstring (`utils.py:494-513`) covers why the candidate
+`update_stocks`'s docstring (`utils.py:562-582`) covers why the candidate
 filter tests `stock__isnull` separately rather than coalescing both sides —
 that bug silently skipped never-synced products forever.
-`UpdateStocksNullSafeTests` (`tests.py:51`) guards it; each of its tests
+`UpdateStocksNullSafeTests` (`tests.py:52`) guards it; each of its tests
 creates a single `MainProduct`, so none of them exercise batching — see the
 next section.
 
 The render-path version of the same NULL is fixed in two of three places.
-`render_stock_msg` (`tables.py:166-186`) branches on `record.stock is None`
+`render_stock_msg` (`tables.py:167-187`) branches on `record.stock is None`
 before zero/nonzero and returns `NO_STOCK_DATA`; `StockSelectionTests`
-(`test_grouping.py:318-397`) guards it. `Supplier.get_delivery_days_for_stock`
+(`test_grouping.py:351`) guards it. `Supplier.get_delivery_days_for_stock`
 (`supplier_manager/models.py:109-122`) also branches on `stock is None`
 explicitly, though it still returns the zero-case value — a deliberate
 default, not a silent conflation. Unfixed:
@@ -351,29 +397,29 @@ control it updated 0 of 5 products in `UpdateStocksBatchingTests`, not merely
 the tail. `MainProduct.pk` is a `BigAutoField` whose sequence is never reset,
 so live pks sit far above `count()` in any real or test DB, and a single
 deleted row (`count() < max(pk)`) is enough to trigger the same gap in
-production. `update_stocks` (`utils.py:522-528`) instead snapshots
+production. `update_stocks` (`utils.py:591-599`) instead snapshots
 `pks = list(MainProduct.objects.order_by('pk').values_list('pk', flat=True))`
 once, then `chunk = pks[i:i+batch_size]` bounds the query with
 `pk__gte=chunk[0], pk__lte=chunk[-1]` — equivalent to `pk__in=chunk` (chunk is
 a contiguous slice of every existing pk in order, so nothing sits strictly
 between its ends) without shipping a `batch_size`-long IN list. Same
-gap-safe idiom as `iter_pim_id_pk_batches` (`utils.py:711-725`), which feeds
-`reindex_pim_ids_batch`'s `pk__in=pks` (`utils.py:741`).
+gap-safe idiom as `iter_pim_id_pk_batches` (`utils.py:828-842`), which feeds
+`reindex_pim_ids_batch`'s `pk__in=pks` (`utils.py:858`).
 
-`timezone.now()` (`utils.py:515`) is read once, above the loop — read
+`timezone.now()` (`utils.py:584`) is read once, above the loop — read
 per-iteration it produces one distinct `stock_updated_at` per chunk instead
 of one per run; guarded by
 `UpdateStocksBatchingTests.test_one_run_stamps_one_timestamp`
-(`tests.py:202`).
+(`tests.py:203`).
 
-`UpdateStocksBatchingTests` (`tests.py:136-227`) is what actually exercises
+`UpdateStocksBatchingTests` (`tests.py:137-252`) is what actually exercises
 multi-batch behaviour: `batch_size=2` over 5 products with distinct stocks
 (so a chunk-scoping slip shows in the logs, not just the counts), a
 deleted-row pk gap not dropping the tail, the timestamp guard above, and
-`logs=False` (`tests.py:213`) — the one branch the loop adds statements to
+`logs=False` (`tests.py:214`) — the one branch the loop adds statements to
 without bounding a log list, and which no caller reaches.
 
 `batch_size` had no caller until this fix — `update_stocks_task`
-(`main_product_manager/tasks.py:66-72`, `product_price_manager/tasks.py:18-23`)
+(`main_product_manager/tasks.py:65-72`, `product_price_manager/tasks.py:18-23`)
 both call `runner=update_stocks` bare, and `run_task.py`'s `--batch-size`
 flag only reaches `create_pim_links`/`reindex_pim_ids` (`run_task.py:67`).

--- a/price_manager/main_product_manager/grouping.py
+++ b/price_manager/main_product_manager/grouping.py
@@ -61,10 +61,20 @@ def group_key():
     дают одинаковый ключ — непривязанный товар молча уезжает в чужую группу.
     Старая версия жила без префикса только потому, что pim_id — строка, не
     похожая на маленькое целое.
+
+    Case/When, а не Coalesce поверх Concat: postgres-овый CONCAT() считает
+    NULL пустой строкой (в отличие от оператора ||), поэтому
+    Concat('pim-', NULL) даёт 'pim-', а не NULL — Coalesce никогда не
+    доходил бы до второй ветки, и ВСЕ непривязанные товары склеивались бы в
+    одну группу с ключом 'pim-'. Ровно та фальшивая группа, от которой этот
+    ключ и должен защищать.
     """
-    return Coalesce(
-        Concat(Value('pim-'), Cast('product_id', TextField()), output_field=TextField()),
-        Concat(Value('mp-'), Cast('id', TextField()), output_field=TextField()),
+    return Case(
+        When(
+            product__isnull=True,
+            then=Concat(Value('mp-'), Cast('id', TextField()), output_field=TextField()),
+        ),
+        default=Concat(Value('pim-'), Cast('product_id', TextField()), output_field=TextField()),
         output_field=TextField(),
     )
 

--- a/price_manager/main_product_manager/grouping.py
+++ b/price_manager/main_product_manager/grouping.py
@@ -1,6 +1,6 @@
-"""Схлопывание MainProduct с общим pim_id в строку-представитель на главной.
+"""Схлопывание MainProduct с общим товаром PIM в строку-представитель на главной.
 
-Несколько MainProduct законно делят один pim_id — это всегда записи разных
+Несколько MainProduct законно делят один product — это всегда записи разных
 поставщиков (см. docstring sync_pim_relations в utils.py). На главной такие
 записи показываются одной строкой-заголовком, а сами становятся скрытыми
 строками-членами под ней.
@@ -23,7 +23,7 @@ from django.db.models import (
     When,
     Window,
 )
-from django.db.models.functions import Cast, Coalesce, FirstValue, NullIf, RowNumber
+from django.db.models.functions import Cast, Coalesce, Concat, FirstValue, RowNumber
 
 # Ценовые колонки, участвующие в поколоночном сквозном выборе по price_priority.
 # Три колонки supplier_product_* сюда НЕ входят: это коррелированные Subquery из
@@ -48,18 +48,23 @@ NO_STOCK_DATA = 'Нет данных'
 
 
 def group_key():
-    """Ключ партиции.
+    """Ключ партиции — по FK на product.Product, а не по join к его pim_id.
 
-    В SQL все NULL в PARTITION BY равны друг другу, поэтому голый pim_id собрал
-    бы все непроиндексированные товары в одну фальшивую группу. Пустая строка
-    приезжает из CSV-импорта (MainProductPimImportResource кладёт колонку ID
-    голым fields.Field, без виджета и clean), так что её надо гасить наравне с
-    NULL. Одно выражение закрывает оба случая: такая строка попадает в партицию
-    из самой себя, grp_size = 1, заголовок не рисуется.
+    В SQL все NULL в PARTITION BY равны друг другу, поэтому голый product_id
+    собрал бы все непривязанные товары в одну фальшивую группу. Непривязанная
+    строка падает на собственный id и попадает в партицию из самой себя,
+    grp_size = 1, заголовок не рисуется. Случая пустой строки больше нет: FK
+    бывает только числом или NULL.
+
+    Обе ветки ОБЯЗАНЫ быть с префиксом. Это два разных пространства
+    целочисленных PK, и без префикса product_id = 42 и MainProduct.id = 42
+    дают одинаковый ключ — непривязанный товар молча уезжает в чужую группу.
+    Старая версия жила без префикса только потому, что pim_id — строка, не
+    похожая на маленькое целое.
     """
     return Coalesce(
-        NullIf(F('pim_id'), Value('')),
-        Cast('id', TextField()),
+        Concat(Value('pim-'), Cast('product_id', TextField()), output_field=TextField()),
+        Concat(Value('mp-'), Cast('id', TextField()), output_field=TextField()),
         output_field=TextField(),
     )
 
@@ -125,6 +130,11 @@ def annotate_groups(queryset, selected_columns, searching=False):
     seq_order = [F('rank').desc(), *_member_order('price')] if searching else _member_order('price')
 
     annotations = {
+        # Не оконная — просто join к product.Product: внутри партиции
+        # product_id постоянен, значит и pim_id тоже. Нужен только заголовку
+        # (GroupHeadRecord.__str__); FK-join «многие к одному» строк не
+        # дублирует, так что на оконные функции ниже он не влияет.
+        'grp_pim_id': F('product__pim_id'),
         'grp_size': Window(Count('id'), partition_by=[F('grp_key')]),
         'grp_seq': Window(RowNumber(), partition_by=[F('grp_key')], order_by=seq_order),
         'grp_min_id': Window(Min('id'), partition_by=[F('grp_key')]),
@@ -222,7 +232,7 @@ class GroupHeadRecord:
     def __init__(self, record, price_columns=GROUPED_PRICE_COLUMNS):
         self.pk = record.pk
         self.id = record.pk
-        self.pim_id = record.pim_id
+        self.pim_id = getattr(record, 'grp_pim_id', None)
         self.grp_key = record.grp_key
         self.grp_size = record.grp_size
         # Остаток и всё, что от него считается, — от победителя по stock_priority.

--- a/price_manager/main_product_manager/grouping.py
+++ b/price_manager/main_product_manager/grouping.py
@@ -130,11 +130,6 @@ def annotate_groups(queryset, selected_columns, searching=False):
     seq_order = [F('rank').desc(), *_member_order('price')] if searching else _member_order('price')
 
     annotations = {
-        # Не оконная — просто join к product.Product: внутри партиции
-        # product_id постоянен, значит и pim_id тоже. Нужен только заголовку
-        # (GroupHeadRecord.__str__); FK-join «многие к одному» строк не
-        # дублирует, так что на оконные функции ниже он не влияет.
-        'grp_pim_id': F('product__pim_id'),
         'grp_size': Window(Count('id'), partition_by=[F('grp_key')]),
         'grp_seq': Window(RowNumber(), partition_by=[F('grp_key')], order_by=seq_order),
         'grp_min_id': Window(Min('id'), partition_by=[F('grp_key')]),
@@ -232,7 +227,11 @@ class GroupHeadRecord:
     def __init__(self, record, price_columns=GROUPED_PRICE_COLUMNS):
         self.pk = record.pk
         self.id = record.pk
-        self.pim_id = getattr(record, 'grp_pim_id', None)
+        # Локальный id зеркала, а не pim_id из PIM: последний потребовал бы
+        # join к product.Product в каждом запросе главной (78 мс против 580 —
+        # см. комментарий в MainProductTableView.get_table_data) ради строки,
+        # которую ни один шаблон не рисует. __str__ — отладочный.
+        self.product_id = record.product_id
         self.grp_key = record.grp_key
         self.grp_size = record.grp_size
         # Остаток и всё, что от него считается, — от победителя по stock_priority.
@@ -251,4 +250,4 @@ class GroupHeadRecord:
         return None
 
     def __str__(self):
-        return f'Группа PIM {self.pim_id}'
+        return f'Группа PIM {self.product_id}'

--- a/price_manager/main_product_manager/management/commands/import_main_products_pim.py
+++ b/price_manager/main_product_manager/management/commands/import_main_products_pim.py
@@ -18,7 +18,7 @@ def _detect_format(file_name: str):
 
 class Command(BaseCommand):
     help = (
-        "Импортирует pim_id и категорию в MainProduct из PIM-выгрузки. "
+        "Импортирует привязку к товару PIM и категорию в MainProduct из PIM-выгрузки. "
         "Ожидаемые колонки: PriceManagerId, ID, Categories."
     )
 

--- a/price_manager/main_product_manager/migrations/0011_mainproduct_product_fk.py
+++ b/price_manager/main_product_manager/migrations/0011_mainproduct_product_fk.py
@@ -1,0 +1,99 @@
+"""MainProduct.pim_id (строка) → MainProduct.product (FK на product.Product).
+
+Зеркало PIM живёт в product.Product, и хранить рядом с ним ещё и голый id
+в main_product_manager означало две несвязанные копии одной связи.
+
+Засеять таблицу зеркала здесь всё-таки приходится: product.0005 создал по
+Product на каждый MainProduct.pim_id, который существовал НА ТОТ МОМЕНТ, а
+_resolve_pim_id / create_pim_links / reindex_pim_ids_batch и импорт из выгрузки
+писали pim_id и после него — для этих строк Product-а нет. Поэтому сначала
+дозаполняем зеркало, и только потом проставляем FK.
+"""
+
+from django.db import migrations, models
+from django.db.models import OuterRef, Subquery
+import django.db.models.deletion
+
+
+def link_products_to_pim_mirror(apps, schema_editor):
+    MainProduct = apps.get_model('main_product_manager', 'MainProduct')
+    Product = apps.get_model('product', 'Product')
+    max_length = Product._meta.get_field('pim_id').max_length
+
+    linkable = MainProduct.objects.exclude(pim_id__isnull=True).exclude(pim_id='')
+    pim_ids = set(linkable.order_by().values_list('pim_id', flat=True).distinct())
+
+    # MainProduct.pim_id — varchar без ограничения длины, product.Product.pim_id
+    # — max_length=64. Значение, которое никогда не влезало бы в зеркало,
+    # пропускаем: такие MainProduct останутся непривязанными (product_id = NULL
+    # им проставит тот же Subquery ниже, не найдя строки), а не уронят миграцию
+    # целиком на DataError посреди bulk_create.
+    too_long = sorted(p for p in pim_ids if len(p) > max_length)
+    if too_long:
+        print(
+            f'  0011: пропущено pim_id длиннее {max_length} символов: {len(too_long)} '
+            f'(например {too_long[0]!r}) — эти MainProduct останутся без привязки'
+        )
+
+    existing = set(Product.objects.order_by().values_list('pim_id', flat=True))
+    missing = [p for p in sorted(pim_ids) if len(p) <= max_length and p not in existing]
+    if missing:
+        # Заготовки: только pim_id, number/name = NULL — ровно та же форма, что
+        # кладёт product.0005 и product.services.pim_sync.sync_product_from_pim.
+        Product.objects.bulk_create(
+            [Product(pim_id=pim_id, number=None) for pim_id in missing],
+            batch_size=1000,
+        )
+        print(f'  0011: создано заготовок product.Product: {len(missing)}')
+
+    # Один коррелированный UPDATE, а не запрос на каждый pim_id: строк здесь
+    # порядка 156k. Для pim_id, которого нет в зеркале (слишком длинный),
+    # подзапрос вернёт NULL — товар просто остаётся непривязанным.
+    updated = linkable.update(
+        product_id=Subquery(
+            Product.objects.filter(pim_id=OuterRef('pim_id')).values('id')[:1]
+        )
+    )
+    print(f'  0011: привязано MainProduct: {updated}')
+
+
+def unlink_products_from_pim_mirror(apps, schema_editor):
+    """Обратный ход: вернуть строковый pim_id из связанного Product."""
+    MainProduct = apps.get_model('main_product_manager', 'MainProduct')
+    Product = apps.get_model('product', 'Product')
+    MainProduct.objects.filter(product__isnull=False).update(
+        pim_id=Subquery(
+            Product.objects.filter(id=OuterRef('product_id')).values('pim_id')[:1]
+        )
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('main_product_manager', '0010_alter_mainproduct_pim_id'),
+        ('product', '0006_alter_product_name'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='mainproduct',
+            name='product',
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name='main_products',
+                to='product.product',
+                verbose_name='Товар PIM',
+            ),
+        ),
+        migrations.RunPython(
+            link_products_to_pim_mirror,
+            unlink_products_from_pim_mirror,
+        ),
+        migrations.RemoveField(
+            model_name='mainproduct',
+            name='pim_id',
+        ),
+    ]

--- a/price_manager/main_product_manager/migrations/0011_mainproduct_product_fk.py
+++ b/price_manager/main_product_manager/migrations/0011_mainproduct_product_fk.py
@@ -49,16 +49,26 @@ def link_products_to_pim_mirror(apps, schema_editor):
     # Один коррелированный UPDATE, а не запрос на каждый pim_id: строк здесь
     # порядка 156k. Для pim_id, которого нет в зеркале (слишком длинный),
     # подзапрос вернёт NULL — товар просто остаётся непривязанным.
-    updated = linkable.update(
+    touched = linkable.update(
         product_id=Subquery(
             Product.objects.filter(pim_id=OuterRef('pim_id')).values('id')[:1]
         )
     )
-    print(f'  0011: привязано MainProduct: {updated}')
+    # Считаем именно связанные, а не то, что вернул update(): тот отдаёт число
+    # строк, попавших под фильтр, включая те, которым подзапрос проставил NULL.
+    linked = MainProduct.objects.filter(product__isnull=False).count()
+    print(f'  0011: привязано MainProduct: {linked} (из {touched} со заполненным pim_id)')
 
 
 def unlink_products_from_pim_mirror(apps, schema_editor):
-    """Обратный ход: вернуть строковый pim_id из связанного Product."""
+    """Обратный ход: вернуть строковый pim_id из связанного Product.
+
+    Восстанавливает всё, что вообще представимо в FK. Не восстанавливаются
+    два случая, которых в связи физически нет: пустая строка возвращается как
+    NULL (FK не различает '' и NULL), и pim_id длиннее 64 символов — их
+    прямой ход пропустил, связи для них не было. Оба и так не привязывались
+    ни к чему, так что на поведении приложения это не сказывается.
+    """
     MainProduct = apps.get_model('main_product_manager', 'MainProduct')
     Product = apps.get_model('product', 'Product')
     MainProduct.objects.filter(product__isnull=False).update(

--- a/price_manager/main_product_manager/models.py
+++ b/price_manager/main_product_manager/models.py
@@ -43,10 +43,12 @@ class MainProduct(models.Model):
         indexes = [
           GinIndex(fields=['search_vector']),
         ]
-    pim_id = models.CharField(verbose_name='Id для системы Pim',
+    product = models.ForeignKey('product.Product',
+                              verbose_name='Товар PIM',
+                              related_name='main_products',
+                              on_delete=models.SET_NULL,
                               null=True,
-                              blank=True,
-                              db_index=True)
+                              blank=True)
     sku = models.CharField(verbose_name='Артикул товара',
                          null=True,
                          blank=True,
@@ -148,10 +150,10 @@ class MainProduct(models.Model):
         ]
     def _build_searchvector(self) -> SearchVector:
         """Собираем строку для поиска без join-ов."""
-        from main_product_manager.utils import _resolve_pim_id, get_pim_data
-        if self.pim_id is None:
+        from main_product_manager.utils import _pim_id_of, _resolve_pim_id, get_pim_data
+        if self.product_id is None:
             _resolve_pim_id(self)
-        pim_product = get_pim_data(self.pim_id) or {}
+        pim_product = get_pim_data(_pim_id_of(self)) or {}
         # Значения, а не field references ("supplier__name") - bulk_update()/update()
         # не допускают joined-полей в выражении SET.
         supplier_name = self.supplier.name if self.supplier_id else ''

--- a/price_manager/main_product_manager/resources.py
+++ b/price_manager/main_product_manager/resources.py
@@ -3,6 +3,8 @@ from import_export import resources, fields
 from import_export.widgets import ForeignKeyWidget, ManyToManyWidget
 from difflib import get_close_matches
 from .models import *
+from .utils import _pim_product_row
+from product.models import Product as PimProduct
 from supplier_manager.models import ManufacturerDict, Discount
 
 class CategoryWidget(ManyToManyWidget):
@@ -253,17 +255,45 @@ class PimCategoryWidget(ManyToManyWidget):
         return ','.join(cat.pim_id for cat in value if cat.pim_id)
 
 
+class PimProductWidget(ForeignKeyWidget):
+    """Колонка ID выгрузки PIM (id товара в PIM) → FK MainProduct.product.
+
+    get_or_create, а не просто поиск, как у стокового ForeignKeyWidget:
+    выгрузка законно приносит id, которых в локальном зеркале ещё нет, а
+    product.Product.pim_id — NOT NULL и unique, так что заготовка с пустыми
+    number/name — единственное, что здесь можно создать. Дозаполнит её потом
+    product.services.pim_sync.sync_product_from_pim.
+
+    Пустое значение даёт None — то есть «снять привязку». Слишком длинный id
+    тоже даёт None (_pim_product_row его залогирует): раньше колонка лежала в
+    varchar без ограничения длины, а теперь упирается в max_length=64, и одна
+    кривая строка не должна ронять весь импорт.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(PimProduct, 'pim_id', *args, **kwargs)
+
+    def clean(self, value, row=None, *args, **kwargs):
+        pim_id = str(value).strip() if value is not None else ''
+        if not pim_id:
+            return None
+        return _pim_product_row(pim_id)
+
+    def render(self, value, obj=None, **kwargs):
+        return value.pim_id if value else ''
+
+
 class MainProductPimImportResource(resources.ModelResource):
     """Import MainProduct data exported from PIM.
 
     Expected columns:
       PriceManagerId  – MainProduct.id (used to locate the record)
-      ID              – PIM product ID  → MainProduct.pim_id
+      ID              – PIM product ID  → MainProduct.product (FK to product.Product)
       Categories      – JSON/CSV list of PIM category IDs; the first one found
                         in the 'Main tree' (Основной) is assigned as category
     """
     id = fields.Field(column_name='PriceManagerId', attribute='id')
-    pim_id = fields.Field(column_name='ID', attribute='pim_id')
+    product = fields.Field(column_name='ID', attribute='product', widget=PimProductWidget())
     category = fields.Field(
         column_name='Categories',
         attribute='categories',
@@ -273,7 +303,7 @@ class MainProductPimImportResource(resources.ModelResource):
     class Meta:
         model = MainProduct
         import_id_fields = ('id',)
-        fields = ('id', 'pim_id', 'category')
+        fields = ('id', 'product', 'category')
         skip_unchanged = True
         report_skipped = True
 

--- a/price_manager/main_product_manager/templates/mainproduct/partials/detail.html
+++ b/price_manager/main_product_manager/templates/mainproduct/partials/detail.html
@@ -64,16 +64,16 @@
         PIM
         {% if pim_data %}
           <span class="badge text-bg-success">Привязан</span>
-        {% elif mainproduct.pim_id %}
+        {% elif mainproduct.product %}
           <span class="badge text-bg-warning">Ошибка получения данных</span>
         {% else %}
           <span class="badge text-bg-secondary">Не найден в PIM</span>
         {% endif %}
       </h5>
       {% if not pim_data %}
-      <div class="alert {% if mainproduct.pim_id %}alert-warning{% else %}alert-secondary{% endif %} mb-0">
-        {% if mainproduct.pim_id %}
-          Не удалось получить данные из PIM (id: {{ mainproduct.pim_id }}). Возможно, временная ошибка соединения — попробуйте обновить страницу.
+      <div class="alert {% if mainproduct.product %}alert-warning{% else %}alert-secondary{% endif %} mb-0">
+        {% if mainproduct.product %}
+          Не удалось получить данные из PIM (id: {{ mainproduct.product.pim_id }}). Возможно, временная ошибка соединения — попробуйте обновить страницу.
         {% else %}
           Товар не найден в PIM. Поиск идёт по артикулу товара — проверьте, совпадает ли он с полем «number» в PIM, или привяжите вручную.
         {% endif %}

--- a/price_manager/main_product_manager/test_grouping.py
+++ b/price_manager/main_product_manager/test_grouping.py
@@ -15,7 +15,7 @@ PIM-запросы заглушены в GroupingTestCase.setUp, поэтому 
 /api/Product/PIM-1. Рабочие PIM-креды из корневого .env отвечают на
 несуществующий id честным 404 (раньше токен отвергался, и 401 за 404 не
 считался), а на третий такой ответ — _PIM_404_THRESHOLD — _note_pim_404
-выполняет MainProduct.objects.filter(pim_id='PIM-1').update(pim_id=None),
+выполняет MainProduct.objects.filter(product__pim_id='PIM-1').update(product=None),
 обнуляя фикстуры прямо посреди прогона. Счётчик 404 лежит в общем Redis и
 копится через все тесты, поэтому поодиночке тесты проходили, а на полном
 прогоне падал test_head_stays_first_on_descending_sort: схлопывать стало
@@ -30,6 +30,7 @@ from django.contrib.postgres.search import SearchVector
 from django.test import RequestFactory, TestCase, override_settings
 from django.urls import reverse
 
+from product.models import Product as PimProduct
 from supplier_manager.models import Category, Currency, Supplier
 
 from .columns import DEFAULT_VISIBLE_COLUMNS
@@ -100,6 +101,12 @@ class GroupingTestCase(TestCase):
         )
 
     def make_product(self, article, category=None, **kwargs):
+        # pim_id= оставлен как удобство фабрики: связь теперь FK на
+        # product.Product, но тесты группировки рассуждают именно в терминах
+        # «эти товары — один товар PIM». Пустой/None — товар без привязки.
+        pim_id = kwargs.pop('pim_id', None)
+        if pim_id:
+            kwargs['product'] = PimProduct.objects.get_or_create(pim_id=pim_id)[0]
         product = MainProduct.objects.create(
             article=article,
             name=kwargs.pop('name', f'Товар {article}'),
@@ -180,18 +187,44 @@ class GroupFormationTests(GroupingTestCase):
         self.assertEqual(self.head_rows(html), [])
         self.assertNotIn('mp-group-member', html)
 
-    def test_null_and_blank_pim_id_never_group(self):
-        """PARTITION BY по голому pim_id склеил бы их всех в одну фальшивую группу."""
+    def test_unlinked_products_never_group(self):
+        """PARTITION BY по голому product_id склеил бы их всех в одну фальшивую группу.
+
+        В SQL все NULL в PARTITION BY равны друг другу. Ветка пустой строки из
+        старого теста ушла вместе с колонкой: FK бывает только числом или NULL.
+        """
         supplier = self.make_supplier('A')
         self.make_product('N-1', self.category, pim_id=None, supplier=supplier)
         self.make_product('N-2', self.category, pim_id=None, supplier=supplier)
-        self.make_product('E-1', self.category, pim_id='', supplier=supplier)
-        self.make_product('E-2', self.category, pim_id='', supplier=supplier)
+        self.make_product('N-3', self.category, pim_id=None, supplier=supplier)
 
         html = self.fetch(self.category)
 
         self.assertEqual(self.head_rows(html), [])
         self.assertNotIn('mp-group-member', html)
+
+    def test_unlinked_product_does_not_join_group_with_matching_product_id(self):
+        """Ключ партиции мешает два независимых пространства целочисленных PK.
+
+        product_id и MainProduct.id считаются своими счётчиками, поэтому без
+        префикса в group_key() непривязанный товар с id = N молча уезжает в
+        группу товаров, привязанных к Product с id = N. Со строковым pim_id
+        этого не могло случиться — он не похож на маленькое целое, — а с FK
+        может, и только на проде, где номера успели разойтись.
+        """
+        supplier_a = self.make_supplier('A')
+        supplier_b = self.make_supplier('B')
+        unlinked = self.make_product('C-1', self.category, supplier=supplier_a)
+        # id задан явно: нужен Product ровно с номером непривязанного товара.
+        pim_product = PimProduct.objects.create(id=unlinked.pk, pim_id='PIM-COLLIDE')
+        self.make_product('A-1', self.category, supplier=supplier_a, product=pim_product)
+        self.make_product('A-2', self.category, supplier=supplier_b, product=pim_product)
+
+        html = self.fetch(self.category)
+
+        # Группа ровно одна и ровно из двух членов: C-1 в неё не затесался.
+        self.assertEqual(len(self.head_rows(html)), 1)
+        self.assertEqual(html.count('mp-group-member'), 2)
 
     def test_filter_breaking_a_pair_returns_it_to_a_flat_row(self):
         """Группа считается по отфильтрованному queryset, а не по всему каталогу."""

--- a/price_manager/main_product_manager/tests.py
+++ b/price_manager/main_product_manager/tests.py
@@ -44,6 +44,7 @@ class ManufacturerWidgetTests(TestCase):
 
 from supplier_manager.models import Currency, Supplier
 from supplier_product_manager.models import SupplierProduct
+from product.models import Product as PimProduct
 from .models import MainProduct, MainProductLog
 from .utils import update_stocks
 
@@ -519,6 +520,10 @@ class _PimSearchTestCase(TestCase):
         )
 
     def product(self, sku='SKU-1', **kwargs):
+        # pim_id= — удобство фабрики: связь теперь FK на product.Product.
+        pim_id = kwargs.pop('pim_id', None)
+        if pim_id:
+            kwargs['product'] = PimProduct.objects.get_or_create(pim_id=pim_id)[0]
         return MainProduct.objects.create(
             supplier=self.supplier,
             article=kwargs.pop('article', f'ART-{sku}'),
@@ -730,8 +735,8 @@ class PimScanPushGuardTests(_PimSearchTestCase):
 
         linked.refresh_from_db()
         errored.refresh_from_db()
-        self.assertEqual(linked.pim_id, 'pim-99')
-        self.assertIsNone(errored.pim_id)
+        self.assertEqual(linked.product.pim_id, 'pim-99')
+        self.assertIsNone(errored.product)
 
     def test_create_pim_links_succeeds_when_every_search_was_answered(self):
         self.product(sku='LINKED')
@@ -762,7 +767,7 @@ class PimScanPushGuardTests(_PimSearchTestCase):
 
         searchable.refresh_from_db()
         self.assertEqual((linked, created), (1, 0))
-        self.assertEqual(searchable.pim_id, 'pim-5')
+        self.assertEqual(searchable.product.pim_id, 'pim-5')
         self.assertEqual(push.call_args.args[0], [])
 
     def test_reindex_batch_raises_and_leaves_the_errored_product_alone(self):
@@ -782,8 +787,8 @@ class PimScanPushGuardTests(_PimSearchTestCase):
 
         linked.refresh_from_db()
         errored.refresh_from_db()
-        self.assertEqual(linked.pim_id, 'pim-new')
-        self.assertEqual(errored.pim_id, 'pim-keep')
+        self.assertEqual(linked.product.pim_id, 'pim-new')
+        self.assertEqual(errored.product.pim_id, 'pim-keep')
         self.assertEqual(push.call_args.args[0], [])
 
 

--- a/price_manager/main_product_manager/utils.py
+++ b/price_manager/main_product_manager/utils.py
@@ -12,6 +12,7 @@ from django.db.models.functions import Coalesce
 from pim_api import EntityList, Entity, Where, FileRecord, upsert_async as _upsert_async
 
 from .models import MainProduct, MainProductLog, MP_PRICES
+from product.models import Product as PimProduct
 from .pim_client import site
 from .columns import AVAILABLE_COLUMN_MAP, DEFAULT_VISIBLE_COLUMNS
 
@@ -20,6 +21,45 @@ from supplier_manager.models import Category, Manufacturer
 from core.task_runner import dispatch_after_commit
 
 logger = logging.getLogger(__name__)
+
+PIM_ID_MAX_LENGTH = PimProduct._meta.get_field('pim_id').max_length
+
+
+def _pim_id_of(product) -> str | None:
+    """PIM `Product` id a MainProduct is linked to, or None if it is unlinked.
+
+    MainProduct.product replaced the old pim_id string column, so every read of
+    "this product's PIM id" is now a hop across the FK. Deliberately a function
+    and not a MainProduct property: a property named pim_id would keep working
+    in templates and silently break in .filter()/annotations, where the lookup
+    has to be `product__pim_id`.
+
+    Callers iterating a queryset must select_related('product') — otherwise this
+    is one query per row.
+    """
+    return product.product.pim_id if product.product_id else None
+
+
+def _pim_product_row(pim_id: str) -> PimProduct | None:
+    """The local product.Product mirror row for a PIM Product id, bare-created if absent.
+
+    product.Product.pim_id is unique and NOT NULL, so a row with number/name
+    left null is the only thing that can be created before
+    product.services.pim_sync.sync_product_from_pim fills it in — the same
+    placeholder shape migration product.0005 seeded.
+
+    Returns None for an id that does not fit: MainProduct.pim_id was an
+    unbounded varchar while product.Product.pim_id is max_length=64, so an
+    over-long value has to be dropped rather than abort the caller's batch.
+    """
+    if len(pim_id) > PIM_ID_MAX_LENGTH:
+        logger.warning(
+            'PIM id %r is longer than %s chars — MainProduct left unlinked',
+            pim_id, PIM_ID_MAX_LENGTH,
+        )
+        return None
+    row, _ = PimProduct.objects.get_or_create(pim_id=pim_id)
+    return row
 
 CACHE_TTL = 60 * 60 * 24 * 30  # 30 дней
 PIM_CACHE_TTL = 60 * 60 * 24  # 24 часа
@@ -135,7 +175,7 @@ def _note_pim_404(pim_id: str) -> None:
         cache.set(count_key, count, _PIM_404_COUNT_TTL)
         return
     cache.delete(count_key)
-    MainProduct.objects.filter(pim_id=pim_id).update(pim_id=None)
+    MainProduct.objects.filter(product__pim_id=pim_id).update(product=None)
 
 
 def _note_pim_success(pim_id: str) -> None:
@@ -274,11 +314,19 @@ def _search_pim_id(product) -> str | None:
 
 
 def _resolve_pim_id(product) -> str | None:
-    """Look up pim_id in PIM and persist it on the product if found."""
+    """Look up pim_id in PIM and link the product to the matching Product row.
+
+    Returns the resolved id even though what gets persisted is the FK, because
+    callers only ever use it as "did this resolve?".
+    """
     pim_id = _search_pim_id(product)
-    if pim_id:
-        MainProduct.objects.filter(pk=product.pk).update(pim_id=pim_id)
-        product.pim_id = pim_id
+    if not pim_id:
+        return None
+    row = _pim_product_row(pim_id)
+    if row is None:
+        return None
+    MainProduct.objects.filter(pk=product.pk).update(product=row)
+    product.product = row
     return pim_id
 
 
@@ -291,22 +339,23 @@ def get_pim_data_for_product(product, refresh: bool = False) -> dict | None:
     no-match cache is dropped first; without that, the cached outcome would
     short-circuit the re-resolve. This is the only place that clears it.
     """
-    if not product.pim_id:
+    if not product.product_id:
         _resolve_pim_id(product)
-    if not product.pim_id:
+    pim_id = _pim_id_of(product)
+    if not pim_id:
         return None
-    data = get_pim_data(product.pim_id, refresh=refresh)
+    data = get_pim_data(pim_id, refresh=refresh)
     if data is not None:
         return data
 
-    product.refresh_from_db(fields=['pim_id'])
-    if product.pim_id:
+    product.refresh_from_db(fields=['product'])
+    if product.product_id:
         return None  # still linked — transient error or under the 404 threshold
 
     cache.delete(f"pim_no_match:{product.pk}")
     if not _resolve_pim_id(product):
         return None
-    return get_pim_data(product.pim_id, refresh=refresh)
+    return get_pim_data(_pim_id_of(product), refresh=refresh)
 
 
 def _resolve_manufacturer(data: dict) -> Manufacturer | None:
@@ -381,13 +430,13 @@ def sync_pim_relations(pim_id: str, data: dict) -> int:
     since it points at a single PIM `Product` matched by number/sku rather than
     at anything per-supplier — so this updates all of them in one go.
     """
-    products = list(MainProduct.objects.filter(pim_id=pim_id))
+    products = list(MainProduct.objects.filter(product__pim_id=pim_id))
     if not products:
         return 0
 
     manufacturer = _resolve_manufacturer(data)
     if manufacturer:
-        MainProduct.objects.filter(pim_id=pim_id).update(manufacturer=manufacturer)
+        MainProduct.objects.filter(product__pim_id=pim_id).update(manufacturer=manufacturer)
 
     category_ids = data.get('categoriesIds') or []
     categories = [c for c in (_ensure_pim_category(cid) for cid in category_ids) if c]
@@ -411,9 +460,10 @@ def prefetch_pim_data(products) -> dict:
     """
     result = {}
     for product in products:
-        if not product.pim_id:
+        pim_id = _pim_id_of(product)
+        if not pim_id:
             continue
-        data = get_pim_data(product.pim_id)
+        data = get_pim_data(pim_id)
         if data:
             result[product.pk] = data
     return result
@@ -569,9 +619,14 @@ def _pim_product_payload(name: str, description: str | None, number: str | None)
     return {'name': name, 'description': description or '', 'number': number or ''}
 
 
-def _push_pim_products(objects: list, payload_fn, batch_size: int = 1000, delay: float = 0.5) -> int:
+def _push_pim_products(objects: list, payload_fn, link_fn, batch_size: int = 1000, delay: float = 0.5) -> int:
     """Bulk-create `objects` as PriceManagerProduct records in PIM via
-    upsertAsync, persisting the ids PIM returns onto obj.pim_id.
+    upsertAsync, persisting the ids PIM returns through `link_fn`.
+
+    `link_fn` takes the chunk's [(obj, pim_id), ...] and returns how many it
+    actually persisted. It is a per-caller hook because the two callers no
+    longer store the link the same way: SupplierProduct still has its own
+    pim_id CharField, while MainProduct now carries a FK to product.Product.
 
     Split into chunks of `batch_size` so a large `objects` list doesn't go out
     as one oversized upsertAsync payload/job, with `delay` seconds between
@@ -612,18 +667,51 @@ def _push_pim_products(objects: list, payload_fn, batch_size: int = 1000, delay:
             )
             continue
 
-        updated = []
+        linked = []
         for obj, result in zip(chunk, results):
             if result.get('status') == 'Failed':
                 continue
             pim_id = result.get('id')
             if pim_id:
-                obj.pim_id = pim_id
-                updated.append(obj)
-        if updated:
-            type(updated[0]).objects.bulk_update(updated, fields=['pim_id'])
-        total_linked += len(updated)
+                linked.append((obj, pim_id))
+        total_linked += link_fn(linked)
     return total_linked
+
+
+def _link_supplier_products(linked: list) -> int:
+    """Persist pushed ids onto SupplierProduct.pim_id (still a plain CharField)."""
+    objects = []
+    for supplier_product, pim_id in linked:
+        supplier_product.pim_id = pim_id
+        objects.append(supplier_product)
+    if objects:
+        SupplierProduct.objects.bulk_update(objects, fields=['pim_id'])
+    return len(objects)
+
+
+def _link_main_products(linked: list) -> int:
+    """Persist pushed ids as MainProduct.product links.
+
+    ВНИМАНИЕ / known mismatch, carried over unchanged from the pim_id version:
+    the id upsertAsync returns here is a **PriceManagerProduct** id, while
+    every read path (get_pim_data, _search_pim_id_result) addresses the PIM
+    `Product` entity — PriceManagerProduct.productId is the Product id, and
+    PriceManagerProduct.id is not. Under the old CharField that mismatch sat
+    inert as a string that simply never resolved; under the FK it additionally
+    materialises a placeholder product.Product row per push. Preserved as-is so
+    the existing "already pushed, do not push again" suppression keeps working
+    — changing what gets stored is a separate decision. See the note in the PR.
+    """
+    objects = []
+    for main_product, pim_id in linked:
+        row = _pim_product_row(pim_id)
+        if row is None:
+            continue
+        main_product.product = row
+        objects.append(main_product)
+    if objects:
+        MainProduct.objects.bulk_update(objects, fields=['product'])
+    return len(objects)
 
 
 def push_supplier_products_to_pim(supplier_products, batch_size: int = 1000, delay: float = 0.5) -> int:
@@ -646,6 +734,7 @@ def push_supplier_products_to_pim(supplier_products, batch_size: int = 1000, del
             sp.description,
             (sp.main_product.sku if sp.main_product else None) or compute_supplier_sku(sp.article, sp.supplier),
         ),
+        _link_supplier_products,
         batch_size=batch_size,
         delay=delay,
     )
@@ -655,7 +744,7 @@ def push_missing_pim_products(products, batch_size: int = 1000, delay: float = 0
     """Bulk-create MainProducts with no PIM match as PriceManagerProduct records.
 
     Callers must pass only products already confirmed absent from PIM —
-    pim_id is None and _search_pim_id_result just came back _SEARCH_ABSENT.
+    product is None and _search_pim_id_result just came back _SEARCH_ABSENT.
     This doesn't re-check, so every other empty outcome (a failed request, an
     ambiguous match, a product with no sku to search by) must be filtered out
     by the caller: PIM cannot confirm an absence it was never asked about, and
@@ -664,6 +753,7 @@ def push_missing_pim_products(products, batch_size: int = 1000, delay: float = 0
     return _push_pim_products(
         list(products),
         lambda mp: _pim_product_payload(mp.name, mp.description, mp.sku),
+        _link_main_products,
         batch_size=batch_size,
         delay=delay,
     )
@@ -680,7 +770,7 @@ def create_pim_links(delay: float = 0.5, batch_size: int = 1000) -> tuple[int, i
     # sku is ever added back.
     products = list(
         MainProduct.objects
-        .filter(pim_id__isnull=True)
+        .filter(product__isnull=True)
         .exclude(sku__isnull=True)
         .exclude(sku='')[:1000]
     )
@@ -691,8 +781,10 @@ def create_pim_links(delay: float = 0.5, batch_size: int = 1000) -> tuple[int, i
     for product in products:
         pim_id, outcome = _search_pim_id_result(product)
         if pim_id:
-            product.pim_id = pim_id
-            result.append(product)
+            row = _pim_product_row(pim_id)
+            if row is not None:
+                product.product = row
+                result.append(product)
         elif outcome == _SEARCH_ABSENT:
             # Only a confirmed absence may be pushed as a new PIM record; an
             # error or an ambiguous match leaves the product for a later run.
@@ -706,11 +798,11 @@ def create_pim_links(delay: float = 0.5, batch_size: int = 1000) -> tuple[int, i
     # Runs with no transaction held (create_pim_links_task passes atomic=False),
     # so each write below commits on its own rather than idling a transaction
     # open across the PIM calls above. Safe to resume after a partial run: this
-    # only ever fills pim_id__isnull=True, so committed rows are simply skipped
+    # only ever fills product__isnull=True, so committed rows are simply skipped
     # next time, and a row skipped over a PIM error is retried once its
     # _PIM_SEARCH_ERROR_TTL backoff expires.
     if result:
-        MainProduct.objects.bulk_update(result, fields=['pim_id'])
+        MainProduct.objects.bulk_update(result, fields=['product'])
     created += push_missing_pim_products(missing, batch_size=batch_size, delay=delay)
     if unanswered:
         # Raised after the writes, so the progress above stays committed. The
@@ -737,7 +829,7 @@ def iter_pim_id_pk_batches(batch_size: int = 1000, skip_non_empty: bool = False)
     """
     products = MainProduct.objects.order_by('pk')
     if skip_non_empty:
-        products = products.filter(pim_id__isnull=True)
+        products = products.filter(product__isnull=True)
     pks = list(products.values_list('pk', flat=True))
     for i in range(0, len(pks), batch_size):
         yield pks[i:i + batch_size]
@@ -746,7 +838,7 @@ def iter_pim_id_pk_batches(batch_size: int = 1000, skip_non_empty: bool = False)
 def reindex_pim_ids_batch(pks: list[int], delay: float = 0.5, batch_size: int = 1000) -> tuple[int, int]:
     """Re-resolve pim_id for one batch of MainProducts, including ones already linked.
 
-    Unlike create_pim_links (which only fills pim_id__isnull=True), this
+    Unlike create_pim_links (which only fills product__isnull=True), this
     re-searches PIM for every product in the batch so relinked/re-merged
     records pick up their new pim_id. Only writes products whose resolved
     pim_id changed. Products that were never linked and still aren't found
@@ -756,17 +848,19 @@ def reindex_pim_ids_batch(pks: list[int], delay: float = 0.5, batch_size: int = 
     chunk produced by iter_pim_id_pk_batches, so many batches process in
     parallel across Celery workers instead of one product at a time.
     """
-    products = MainProduct.objects.filter(pk__in=pks).order_by('pk')
+    products = MainProduct.objects.filter(pk__in=pks).select_related('product').order_by('pk')
     result = []
     missing = []
     unanswered = 0
     for product in products:
         pim_id, outcome = _search_pim_id_result(product)
         if pim_id:
-            if pim_id != product.pim_id:
-                product.pim_id = pim_id
-                result.append(product)
-        elif outcome == _SEARCH_ABSENT and product.pim_id is None:
+            if pim_id != _pim_id_of(product):
+                row = _pim_product_row(pim_id)
+                if row is not None:
+                    product.product = row
+                    result.append(product)
+        elif outcome == _SEARCH_ABSENT and product.product_id is None:
             # As in create_pim_links: only a confirmed absence gets pushed.
             missing.append(product)
         elif outcome == _SEARCH_ERROR:
@@ -779,7 +873,7 @@ def reindex_pim_ids_batch(pks: list[int], delay: float = 0.5, batch_size: int = 
     # back, and a row skipped over a PIM error is retried once its
     # _PIM_SEARCH_ERROR_TTL backoff expires.
     if result:
-        MainProduct.objects.bulk_update(result, fields=['pim_id'])
+        MainProduct.objects.bulk_update(result, fields=['product'])
     created = push_missing_pim_products(missing, batch_size=batch_size, delay=delay)
     if unanswered:
         # See create_pim_links: raised after the writes so committed progress

--- a/price_manager/main_product_manager/utils.py
+++ b/price_manager/main_product_manager/utils.py
@@ -548,7 +548,10 @@ def load_user_columns(user):
 
 def recalculate_search_vectors(mps):
     if not mps: return None
-    mps = mps.select_related('supplier', 'manufacturer')
+    # 'product' обязателен: _build_searchvector зовёт _pim_id_of, а тот ходит
+    # по FK. Без него каждый уже привязанный товар — лишний запрос; раньше
+    # pim_id лежал в самой строке и доставался даром.
+    mps = mps.select_related('supplier', 'manufacturer', 'product')
     def build_searchvector(mp):
       mp.search_vector = mp._build_searchvector()
       return mp

--- a/price_manager/main_product_manager/utils.py
+++ b/price_manager/main_product_manager/utils.py
@@ -771,6 +771,10 @@ def create_pim_links(delay: float = 0.5, batch_size: int = 1000) -> tuple[int, i
     # here so it doesn't hold a slot — and a delay — against products the scan
     # can still resolve. Drop the exclusion if a search that works without an
     # sku is ever added back.
+    # Без select_related('product') намеренно, в отличие от
+    # reindex_pim_ids_batch: выборка — ровно непривязанные товары, и цикл ниже
+    # связь только пишет, ни разу не зовя _pim_id_of. Если сюда добавится
+    # чтение текущей связи — select_related станет обязателен.
     products = list(
         MainProduct.objects
         .filter(product__isnull=True)

--- a/price_manager/main_product_manager/views.py
+++ b/price_manager/main_product_manager/views.py
@@ -189,7 +189,7 @@ class MainProductTableView(SingleTableView):
     # GROUP BY подзапроса счёта.
     limit = settings.MAINPRODUCT_GROUPING_ROW_LIMIT
     if filtered.order_by()[:limit + 1].count() > limit:
-      return filtered.prefetch_related('categories').annotate(**subqueries)
+      return filtered.select_related('product').prefetch_related('categories').annotate(**subqueries)
 
     # Порядок слоёв здесь жёсткий: дедупликация → Subquery → оконные аннотации.
     # categories — M2M, и её join дублирует строки (categories_method не зря
@@ -201,7 +201,7 @@ class MainProductTableView(SingleTableView):
     # поиске — на пустом всё выглядело бы правильным.
     qs = MainProduct.objects.filter(
       pk__in=filtered.order_by().values('pk')
-    ).prefetch_related('categories').annotate(**subqueries)
+    ).select_related('product').prefetch_related('categories').annotate(**subqueries)
 
     # rank не переживает пересборку queryset, а групповая сортировка по
     # релевантности его требует — навешиваем заново тем же выражением.


### PR DESCRIPTION
## Что изменилось

`MainProduct.pim_id` (строковая колонка) заменён на `MainProduct.product` — FK на `product.Product`, привязка идёт к записи зеркала с тем же `pim_id`.

Зеркало PIM уже живёт в `product.Product`, и хранить рядом с ним ещё и голый id значило держать две несвязанные копии одной связи. Заодно это тот самый «reconnected to the legacy stack», про который написано в `CLAUDE.md`: до этого ни одно живое приложение не импортировало `product`, теперь `main_product_manager` импортирует.

### Миграция `0011_mainproduct_product_fk`

Три шага: `AddField` → `RunPython` → `RemoveField`. Обратима.

Засеять зеркало в ней пришлось, и это главное, что стоит проверить глазами: `product.0005` создал по `Product` на каждый `MainProduct.pim_id`, который существовал **на тот момент**, а `_resolve_pim_id`, `create_pim_links`, `reindex_pim_ids_batch` и импорт PIM-выгрузки писали `pim_id` и после него — для этих строк `Product`-а нет. Поэтому сначала `bulk_create` заготовок (только `pim_id`, `number`/`name` = NULL — та же форма, что кладёт `product.0005` и `sync_product_from_pim`), и только потом один коррелированный `UPDATE` на ~156k строк.

`pim_id` длиннее 64 символов пропускаются: у старой колонки ограничения длины не было, у `product.Product.pim_id` — `max_length=64`. Такие `MainProduct` остаются непривязанными, а не роняют миграцию на `DataError` посреди `bulk_create`.

### Переведено на FK

`_note_pim_404`, `_resolve_pim_id`, `get_pim_data_for_product`, `sync_pim_relations`, `prefetch_pim_data`, `create_pim_links`, `iter_pim_id_pk_batches`, `reindex_pim_ids_batch`, ключ группировки, ресурс импорта выгрузки (`PimProductWidget` — `ForeignKeyWidget`, который `get_or_create`-ит, а не только ищет), шаблон карточки.

`_push_pim_products` получил хук `link_fn` на вызывающего: `SupplierProduct` сохраняет свой `pim_id` (CharField никуда не делся), `MainProduct` пишет FK.

Вместо свойства `pim_id` на модели — функция `_pim_id_of()`. Свойство продолжало бы работать в шаблонах и молча ломалось в `.filter()`/аннотациях, где лукап теперь `product__pim_id`; четыре явных правки дешевле такой двусмысленности.

## Два бага, найденных по дороге

**Коллизия ключа группировки.** `product_id` и `MainProduct.id` — независимые счётчики, поэтому без префикса непривязанный товар с `id = N` попадал в группу товаров, привязанных к `Product` с `id = N`. Со строковым `pim_id` этого случиться не могло — он не похож на маленькое целое, — так что опасность новая. Обе ветки ключа теперь с префиксом, есть регрессионный тест.

**`CONCAT()` в Postgres глотает NULL.** Первая версия префикса была `Coalesce(Concat('pim-', product_id), Concat('mp-', id))` — и это молча сломано: `CONCAT()` считает NULL пустой строкой (в отличие от оператора `||`), поэтому `Concat('pim-', NULL)` даёт `'pim-'`, а не NULL, и `Coalesce` никогда не доходил до второй ветки. **Все** непривязанные товары склеивались в одну фальшивую группу с ключом `'pim-'` — ровно то, от чего ключ и должен защищать. Заменено на `Case/When`.

Поймал это только новый тест по отрендеренному `data-grp-key`. `py_compile`, `manage.py check` и прогон миграции на пустой базе прошли чисто.

Плюс убран N+1: `recalculate_search_vectors` теперь делает `select_related('product')`, потому что `_build_searchvector` ходит по FK там, где раньше читал колонку той же строки. Правка в одной функции, но она общая точка входа для задач `main_product_manager`, задач `supplier_product_manager` и привязки категории.

## Как проверялось

На **отдельном стеке** (`PROJECT_NAME=pm-mpfk`, порты 8010/5442/6389) — общий стек всё это время был занят другой сессией и остался нетронутым.

- `manage.py check` — чисто (только предупреждения, которые были и до этого);
- `manage.py makemigrations --check --dry-run` — **No changes detected**, то есть рукописная 0011 точно соответствует состоянию моделей;
- **158 тестов зелёные**: `main_product_manager`, `product`, `supplier_product_manager`, `core`, `product_price_manager`.

Миграция прогнана в обе стороны на засеянных вручную данных (шесть форм): общий `pim_id` у двух поставщиков даёт одну связь на двоих; существующая строка зеркала переиспользуется и сохраняет свои `number`/`name`, дубля нет; заготовка создаётся только для неизвестного id; NULL, `''` и слишком длинный остаются непривязанными; обратный ход возвращает `pim_id`.

## Что нужно от ревьюера

**1. Открытый вопрос — `_push_pim_products` сохраняет id не той сущности.**

Это расхождение было и раньше, но FK делает его дороже. `_push_pim_products` создаёт в PIM записи `PriceManagerProduct` через `upsertAsync` и сохраняет возвращённый id. Но все пути чтения — `get_pim_data`, `_search_pim_id_result` — адресуют сущность **`Product`**, а по схеме `PriceManagerProduct.productId` — это id товара, и `PriceManagerProduct.id` им не является. Сохранённый id не резолвится.

Под старым CharField это лежало инертной строкой, которая просто никогда не находилась. Под FK `_link_main_products` отдаёт её в `get_or_create`, и каждый push **создаёт заготовку `product.Product`, ключом которой является id PriceManagerProduct**.

Поведение сохранено намеренно — на нём держится подавление повторного push «уже отправляли, не отправлять снова» — и помечено комментарием в `_link_main_products`. Вопрос: не правильнее ли вместо этого оставлять товар непривязанным и давать следующему проходу `create_pim_links` найти настоящий `Product` поиском?

**2. `platformID` в этот PR не вошёл, и вот почему.**

`push_missing_pim_products` запускается только на товарах, **подтверждённо отсутствующих** в PIM, — у них нет связи, а значит нет и `Product.id`, который можно было бы отправить в `platformID`. Отправка требует второго прохода, уже после того как `_link_main_products` создаст строку. Скажите, если нужно — добавлю отдельно.

## Прочее

- `.claude/knowledge/main_product_manager.md` обновлён keeper-агентом: записаны ловушка с `CONCAT()`/NULL, правило префиксов в ключе партиции, N+1 и расхождение с `PriceManagerProduct`. Заодно починены разъехавшиеся на 50–120 строк ссылки `file:line` и два устаревших факта (`maybe_notify_pim_error` больше не под `DEBUG` — #177; `priceManagerId` из UI-копии убран).
- `SupplierProduct.pim_id` **не** тронут — это отдельное живое поле.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
